### PR TITLE
Add daily blog review and known-issues indexing process

### DIFF
--- a/.claude/commands/blog-review-index/SKILL.md
+++ b/.claude/commands/blog-review-index/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: blog-review-index
+description: Review one existing blog post selected by the daily blog-review workflow and record its known issues into the S3 index. Flag-only — never edits content, never opens PRs. Invoked by the blog-review-index workflow; not user-invocable.
+user-invocable: false
+---
+
+# Blog Review Index
+
+You are reviewing one existing blog post — not a PR diff — to build the
+blog's **known-issues index**. The selection script has already chosen
+today's posts; your job is to run the docs-review machinery over the whole
+file and record every defensible issue you find as structured findings.
+
+This process is **FLAG-ONLY**. You make **zero edits** to the working tree:
+
+- Do NOT edit the post or any other content file.
+- Do NOT run `git commit`, `git push`, or `gh pr create`, and do not create
+  branches.
+- Your ONLY output is `.blog-review-findings.json` at the repo root.
+
+The workflow's record job asserts the tree is clean after you finish; a
+dirty tree invalidates the whole run (recorded `incomplete`, retried later),
+so a "quick fix while you're in there" destroys the run's value. Blog fixes
+happen elsewhere; this process only *knows things*.
+
+The index's eventual consumer is a decision process that marks rotted,
+low-value posts `block_external_search_index: true` (the site's per-page
+noindex knob). Your findings and the advisory `noindex_signal` are evidence
+for that decision — made later, with traffic thresholds you can't see — not
+the decision itself.
+
+## Input
+
+Read `.blog-review-queue.json` from the repo root (written by
+`scripts/blog-review/select-posts.py`; the workflow slices it to one post per
+run). Shape:
+
+```json
+{
+  "generated": "2026-07-15T14:30:00+00:00",
+  "count": 1,
+  "halted": null,
+  "traffic": { "available": true, "period": "2026-06", "pages_matched": 640 },
+  "reader_signals": { "available": false, "gsc": { "available": false } },
+  "posts": [
+    { "path": "content/blog/my-post/index.md",
+      "url": "/blog/my-post/",
+      "slug": "my-post",
+      "lane": "priority",
+      "post_date": "2021-03-04",
+      "monthly_visits": 842,
+      "signals": null,
+      "last_reviewed": null,
+      "attempts": 0,
+      "score": 812.5 }
+  ]
+}
+```
+
+- `lane` — `priority` (scored pick) or `manual` (workflow_dispatch override).
+- `post_date` — the post's publish date. Calibrate expectations to it: a
+  2019 post naming then-current versions is normal; the question is whether
+  the content **misleads a reader today**, not whether it aged.
+- `signals` / `monthly_visits` — selection facts, not review instructions;
+  `null` on a signal-blind run (it never fabricates).
+- If `posts` is empty or `halted` is set, write nothing and stop (the
+  workflow won't invoke you in that case, but be defensive).
+
+## Pre-computed artifacts
+
+The workflow has ALREADY run the deterministic docs-review pre-computation
+over the post (synthetic whole-file diff → claim extraction + verification,
+Vale, frontmatter, editorial balance, readthrough). Read these from the repo
+root; do NOT regenerate them:
+
+- `.verified-claims.json` — claim verdicts (the fact-check backbone)
+- `.candidate-claims.json`, `.fetched-urls.json` — claim provenance
+- `.vale-findings.json` — prose-lint findings
+- `.frontmatter-validation.json` — frontmatter checks
+- `.readthrough-findings.json` — whole-post coherence findings
+
+(The PR-bound editorial-balance detector can't run here; apply the
+`docs-review:references:blog` editorial-balance criteria yourself from the
+whole-file read when the post is a comparison, listicle, or FAQ.)
+
+If one is missing or carries an `errors` field, note it in your findings
+file's issue evidence where relevant and continue with what you have.
+
+## Review procedure
+
+1. Read the whole post (`path` from the queue). Whole-file read is
+   mandatory — this is the same posture as
+   `docs-review:references:blog`: fact-check-first, heightened scrutiny.
+2. Triage the pre-computed artifacts and investigate with the
+   `docs-review:references:blog` criteria (fact-check, code correctness,
+   product accuracy, editorial balance, category fit, SEO/AEO, links,
+   publishing blockers). Verify anything you record: check links you cite as
+   dead (WebFetch), check product claims against current docs
+   (`content/docs/`), check code against current SDK idioms.
+3. Classify every defensible issue into the CLOSED taxonomy in
+   `references/issue-taxonomy.md` and assign severity per its rubric. The
+   record job validates categories and severities against that closed set —
+   an invented category invalidates the run.
+4. **Evidence is required per issue.** Each issue must carry concrete,
+   checkable evidence (the URL that 404s and what it returns; the claim and
+   the authoritative source contradicting it; the deprecated feature and
+   where its deprecation is documented). An issue you cannot evidence is an
+   opinion — leave it out.
+5. Assess the advisory `noindex_signal` per `references/noindex-rubric.md`.
+6. Write `.blog-review-findings.json` at the repo root — your ONLY output.
+   Shape (JSON Schema in `references/findings-schema.json`):
+
+```json
+{
+  "schema_version": 1,
+  "path": "content/blog/my-post/index.md",
+  "slug": "my-post",
+  "issues": [
+    {
+      "id": "dead-link-01",
+      "category": "dead-link",
+      "severity": "major",
+      "summary": "Link to the Kubernetes ingress tutorial 404s",
+      "evidence": "https://example.com/tutorial returns HTTP 404 (fetched during this review); no redirect target exists",
+      "location": "## Setting up ingress, paragraph 2"
+    }
+  ],
+  "clean": false,
+  "noindex_signal": {
+    "assessment": "keep",
+    "rationale": "Content is dated but accurate; the post still answers its title question correctly."
+  }
+}
+```
+
+- `path`/`slug` must match the queue entry exactly.
+- `issues` empty ⇔ `clean: true`. A genuinely clean post is a valid,
+  valuable outcome — it advances the staleness clock and records positive
+  evidence for keeping the post indexed. Do not pad findings to look
+  productive.
+- `id` — unique within the file, `<category>-<nn>`.
+- `location` — a heading, line range, or section pointer a human can find.
+
+## What NOT to do
+
+- No edits, commits, branches, or PRs (see above).
+- No re-running the pre-compute pipeline (`extract-claims*`, `verify-claims`,
+  `readthrough`, Vale) — read the artifacts.
+- No `make build` and no `make lint` — nothing you do changes the tree, so
+  there is nothing to lint.
+- No ledger, index, or summary writes — `record-findings.py` owns every S3
+  object; you own exactly one local JSON file.
+- No style nitpicks as issues: Vale nags, prose taste, and heading-case
+  preferences are not index material. The index exists to answer "is this
+  post misleading, broken, or worthless to a searcher?" — not "could this
+  post be nicer?".

--- a/.claude/commands/blog-review-index/references/findings-schema.json
+++ b/.claude/commands/blog-review-index/references/findings-schema.json
@@ -1,0 +1,71 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Blog review findings sentinel (.blog-review-findings.json)",
+    "description": "The review model's only structured output. Enforced deterministically by scripts/blog-review/validate-findings.py; this document is the human/model-readable statement of the same contract. Category and severity sets must stay in sync with references/issue-taxonomy.md.",
+    "type": "object",
+    "required": ["schema_version", "path", "slug", "issues", "clean", "noindex_signal"],
+    "additionalProperties": false,
+    "properties": {
+        "schema_version": { "const": 1 },
+        "path": {
+            "type": "string",
+            "pattern": "^content/blog/.+/index\\.md$",
+            "description": "Must match the queue entry exactly."
+        },
+        "slug": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Must match the queue entry exactly."
+        },
+        "issues": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["id", "category", "severity", "summary", "evidence", "location"],
+                "additionalProperties": false,
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Unique within the file; convention <category>-<nn>."
+                    },
+                    "category": {
+                        "enum": ["factual-rot", "dead-link", "broken-code", "deprecated-product", "seo-thin", "ai-positioning", "frontmatter", "rendering"]
+                    },
+                    "severity": { "enum": ["blocker", "major", "minor"] },
+                    "summary": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "One sentence stating the defect."
+                    },
+                    "evidence": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Concrete, checkable evidence: the URL and its response, the claim and the contradicting source. Required — unevidenced issues are rejected."
+                    },
+                    "location": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "A heading, line range, or section pointer a human can find."
+                    }
+                }
+            }
+        },
+        "clean": {
+            "type": "boolean",
+            "description": "true iff issues is empty; the gate enforces the biconditional."
+        },
+        "noindex_signal": {
+            "type": "object",
+            "required": ["assessment", "rationale"],
+            "additionalProperties": false,
+            "properties": {
+                "assessment": {
+                    "enum": ["keep", "candidate", "strong-candidate"],
+                    "description": "Advisory only (see references/noindex-rubric.md). strong-candidate requires at least one recorded issue."
+                },
+                "rationale": { "type": "string", "minLength": 1 }
+            }
+        }
+    }
+}

--- a/.claude/commands/blog-review-index/references/issue-taxonomy.md
+++ b/.claude/commands/blog-review-index/references/issue-taxonomy.md
@@ -1,0 +1,40 @@
+---
+user-invocable: false
+description: The closed issue taxonomy and severity rubric for the blog known-issues index. record-findings.py validates every finding against this set.
+---
+
+# Blog Review — Issue Taxonomy
+
+The taxonomy is **closed**: every issue in `.blog-review-findings.json` must
+use one of the categories below, verbatim. The deterministic gate
+(`scripts/blog-review/validate-findings.py` — keep its `CATEGORIES` set in
+sync with this file) rejects anything else and the run is recorded
+`incomplete`. If a real defect genuinely fits no category, record the
+nearest one and say so in the evidence; propose a taxonomy change in a PR to
+this file, never by inventing a value inline.
+
+## Categories
+
+| Category | What it covers |
+|----------|----------------|
+| `factual-rot` | A claim that was true at publish time and is now false or materially misleading: stale version-specific behavior presented as current, superseded benchmarks or pricing, "coming soon" for things that shipped (or died), statistics that no longer hold. |
+| `dead-link` | A link that 404s, redirects to an irrelevant target, or points at a product/page that no longer exists. Internal links that miss their alias chain count. |
+| `broken-code` | Code samples that no longer work: removed/renamed APIs, syntax invalid against current SDKs, imports that don't resolve, CLI flags that were dropped. Evidence must name the current API surface, not just suspicion. |
+| `deprecated-product` | The post is about — or materially depends on — a Pulumi or third-party product/feature that has been renamed, deprecated, or retired (e.g. a walkthrough of a UI that no longer exists). |
+| `seo-thin` | The post has little durable value for a searcher: near-duplicate of another post that does the job better, contentless announcement of a long-past event, listicle bloat with no substance. Name the superseding URL when one exists. |
+| `ai-positioning` | The post violates the AGENTS.md "AI and agent positioning" rules: presents Neo as the only way to use AI with Pulumi, frames Neo as either-or against other coding agents, or disparages other agents. |
+| `frontmatter` | Taxonomy/frontmatter defects: missing or invalid `category`, tag near-duplicates against `data/blog_tags.yaml`, series slug misuse, missing `meta_desc`, broken author reference. |
+| `rendering` | The published page renders broken content: shortcode errors visible in output, missing images, malformed tables/code fences, a broken or buried `<!--more-->` break. |
+
+## Severity rubric
+
+| Severity | Bar |
+|----------|-----|
+| `blocker` | The post actively misleads or embarrasses **today**: a wrong claim a reader would act on, code that fails against current SDKs in a post that ranks, a walkthrough of a retired product presented as current. These drive noindex decisions hardest. |
+| `major` | Clearly degrades the post's usefulness but a reader can route around it: a dead link on the main path, factual rot with visible date context, a deprecated product mentioned but not central. |
+| `minor` | Real but low-stakes: a dead link in a footnote, tag hygiene, a stale minor version number in prose that doesn't change the guidance. |
+
+Severity is about **reader harm now**, not about how hard a fix would be.
+When torn between two severities, pick the lower one and let the evidence
+speak — the index is aggregated over time, and inflation is worse than
+understatement.

--- a/.claude/commands/blog-review-index/references/noindex-rubric.md
+++ b/.claude/commands/blog-review-index/references/noindex-rubric.md
@@ -1,0 +1,44 @@
+---
+user-invocable: false
+description: Advisory rubric for the noindex_signal assessment in blog-review findings. The model recommends; the future noindex process decides.
+---
+
+# Blog Review — Noindex Rubric
+
+`noindex_signal.assessment` is **advisory evidence, not a decision**. The
+eventual noindex process combines your content assessment with traffic and
+Search Console thresholds you cannot see, and a human reviews the resulting
+PRs. Your job is the content half: given what this post *says*, would a
+search engine sending readers here serve them well?
+
+## Assessments
+
+- **`keep`** — the default. The post still answers its question truthfully,
+  or has historical/announcement value that reads as such. Dated but honest
+  content is `keep`: a 2020 tutorial that says it's about 2020 tooling and
+  works within that frame harms nobody.
+- **`candidate`** — the post's value to a searcher is questionable on
+  content grounds: substantial unfixable `factual-rot`, a
+  `deprecated-product` core, or `seo-thin` duplication where a better post
+  exists. Reasonable people could disagree; the traffic data should settle it.
+- **`strong-candidate`** — the post actively harms a reader who lands on it
+  today: `blocker`-severity issues at its core, guidance that would break
+  things if followed, or content whose subject no longer exists in any
+  recognizable form. The gate requires at least one recorded issue before it
+  accepts this assessment.
+
+## Rules
+
+1. **Ground the assessment in the issue list.** Every `candidate` /
+   `strong-candidate` rationale must reference the recorded issues; an
+   assessment with no supporting issues is invalid (the gate enforces this
+   for `strong-candidate`).
+2. **Never assess on age or traffic alone.** Old ≠ noindex; low-traffic ≠
+   noindex. You don't have reliable traffic data, and the selection signals
+   in the queue are for provenance, not judgment.
+3. **Superseded ≠ worthless.** If a newer post covers the topic better,
+   that's `seo-thin` evidence toward `candidate` — but only when the old
+   post adds nothing (no unique migration path, no historical context worth
+   ranking).
+4. **The rationale is one or two sentences** a human skimming
+   `_summary.json` can act on: what class of harm, anchored to which issues.

--- a/.github/workflows/blog-review-index.yml
+++ b/.github/workflows/blog-review-index.yml
@@ -1,0 +1,561 @@
+name: "Scheduled jobs: Blog review index"
+
+# Daily (workdays) automated review of EXISTING blog posts, building the
+# blog's known-issues index in S3. This is the blog sibling of the docs
+# existing-content review (review-existing-content.yml), with one structural
+# difference: it is FLAG-ONLY. Runs record findings (dead links, factual
+# rot, deprecated products, thin content) into the index; they never edit
+# posts and never open PRs, so the whole pipeline fits in a single workflow
+# with a job matrix instead of the docs dispatcher/worker pair.
+#
+# The index's eventual consumer is a future decision process that marks
+# rotted, low-value posts `block_external_search_index: true` (the site's
+# per-page noindex knob) — combining these content findings with traffic and
+# Search Console thresholds, behind human-reviewed PRs. This workflow only
+# gathers the evidence.
+#
+# Pipeline: deterministic selection (scripts/blog-review/select-posts.py —
+# the model never chooses) → one UNPRIVILEGED model review per post (matrix;
+# no credentials, tree must stay clean, output is one findings JSON) → one
+# DETERMINISTIC credentialed record job (validates findings against the
+# closed taxonomy, writes ledger + index + run-log objects to S3, rebuilds
+# the index summary).
+#
+# SINGLE SWITCH (default-on) — the BLOG_REVIEW_COUNT repo variable is both
+# the on/off and the cadence knob, same convention as CONTENT_REVIEW_COUNT:
+#   unset -> on, 5 posts/run (the default; ~7 months to sweep ~800 posts)
+#   '0'   -> off: the whole run is skipped (no runner, no spend)
+#   'N'   -> on, N posts/run
+# workflow_dispatch always runs regardless (the testing path; see the
+# dry_run / count / paths inputs).
+
+on:
+  schedule:
+    # Weekdays at 2:30PM UTC — offset from review-existing-content (14:00)
+    # and check-links (15:00) so the scheduled Claude consumers don't contend.
+    - cron: '30 14 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      count:
+        description: 'Number of posts to review'
+        required: false
+        default: '5'
+      dry_run:
+        description: 'Selection only — no Claude, no S3 writes, no spend'
+        type: boolean
+        required: false
+        default: false
+      paths:
+        description: 'Comma-separated content paths (bypasses scoring; for testing)'
+        required: false
+        default: ''
+
+# The review is flag-only: nothing in this workflow writes to the repo.
+permissions:
+  contents: read
+  id-token: write # Required for ESC OIDC auth + AWS OIDC role + claude-code-action
+
+# One run at a time: a manual dispatch during the scheduled run would race
+# the per-slug S3 writes and the summary rebuild.
+concurrency:
+  group: blog-review-index
+  cancel-in-progress: false
+
+jobs:
+  # Skip the scheduled run on company holidays — same fail-open pattern and
+  # script as review-existing-content.yml (see the comments there). Manual
+  # workflow_dispatch ignores this via the `select` gate.
+  holiday-check:
+    name: Company-holiday check
+    runs-on: ubuntu-latest
+    outputs:
+      is_holiday: ${{ steps.check.outputs.is_holiday }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: check
+        env:
+          ICS_URL: ${{ vars.BAMBOOHR_HOLIDAY_ICS_URL }}
+        run: |
+          if [ -z "$ICS_URL" ]; then
+            echo "BAMBOOHR_HOLIDAY_ICS_URL not set; not skipping for holidays"
+            echo "is_holiday=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if ! curl -fsSL --max-time 20 "$ICS_URL" -o holidays.ics; then
+            echo "::warning::holiday feed unavailable; failing open (review will run)"
+            echo "is_holiday=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if python3 scripts/content-review/is-holiday.py --ics holidays.ics --tz America/Chicago; then
+            echo "is_holiday=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_holiday=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Deterministic selection. Credentialed (ESC + AWS via OIDC) because it
+  # reads the S3 ledger and the traffic/GSC snapshots — but the model never
+  # runs here. Every external input degrades gracefully: with no snapshots
+  # and no ledger, selection is a pure oldest-unreviewed-first sweep.
+  select:
+    name: Select posts
+    needs: holiday-check
+    runs-on: ubuntu-latest
+    # PULUMI_STACK_NAME is an environment-scoped variable, so the job must
+    # select the environment to resolve the ledger bucket stack output.
+    environment: production
+    timeout-minutes: 15
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (vars.BLOG_REVIEW_COUNT != '0' && needs.holiday-check.outputs.is_holiday != 'true')
+    outputs:
+      has_posts: ${{ steps.select.outputs.has_posts }}
+      count: ${{ steps.select.outputs.count }}
+      posts: ${{ steps.emit.outputs.posts }}
+      meta: ${{ steps.emit.outputs.meta }}
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v3
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Selection reads git history (staleness clock: newest non-bot
+          # edit per post), so a shallow clone won't do.
+          fetch-depth: 0
+      - name: Install Python deps
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Configure AWS credentials
+        id: aws-creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
+          role-session-name: blog-review-index
+          aws-region: us-west-2
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+
+      # The blog-review state shares the content-review ledger bucket under
+      # its own blog-review/ prefix — resolved from the stack output, never
+      # hardcoded (same pattern as review-existing-content.yml).
+      - name: Resolve state bucket
+        id: state-bucket
+        continue-on-error: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        run: |
+          BUCKET=$(pulumi -C infrastructure stack output contentReviewLedgerBucketName \
+            --stack "${{ vars.PULUMI_STACK_NAME }}" 2>/dev/null || true)
+          if [ -n "$BUCKET" ]; then
+            echo "ledger_uri=s3://$BUCKET/blog-review/ledger/" >> "$GITHUB_OUTPUT"
+          else
+            echo "state bucket output unavailable; selection proceeds on git staleness alone"
+          fi
+
+      # The blog-traffic export (pageviews per /blog/ path) mirrors the docs
+      # one: produced by the data team's Airflow, latest-object URI published
+      # as a stack output. Until that export ships this resolve logs the skip
+      # and selection scores on staleness alone — the consumer side is
+      # inert-but-ready by design, exactly like the docs reader-signals were.
+      - name: Resolve blog-traffic snapshot URI
+        id: traffic-uri
+        continue-on-error: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        run: |
+          URI=$(pulumi stack output blogTrafficPageviewsLatestS3Uri \
+            --stack pulumi/dwh-workflows-orchestrate-airflow/production 2>/dev/null || true)
+          if [ -n "$URI" ]; then
+            echo "resolved blog-traffic export URI: $URI"
+            echo "uri=$URI" >> "$GITHUB_OUTPUT"
+          else
+            echo "blog-traffic export not yet published; selection proceeds on staleness alone"
+          fi
+      - name: Fetch blog-traffic snapshot from S3
+        if: steps.traffic-uri.outputs.uri != ''
+        continue-on-error: true
+        run: |
+          if aws s3 cp "${{ steps.traffic-uri.outputs.uri }}" .blog-traffic-snapshot --quiet; then
+            echo "fetched blog-traffic snapshot: $(wc -c < .blog-traffic-snapshot) bytes"
+          else
+            echo "blog-traffic snapshot unavailable; selection proceeds without it"
+          fi
+
+      # Blog reader-signals (Search Console impressions/CTR per /blog/ URL) —
+      # same inert-but-ready pattern as the traffic snapshot above.
+      - name: Resolve blog reader-signals URI
+        id: signals-uri
+        continue-on-error: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        run: |
+          URI=$(pulumi stack output blogReaderSignalsLatestS3Uri \
+            --stack pulumi/dwh-workflows-orchestrate-airflow/production 2>/dev/null || true)
+          if [ -n "$URI" ]; then
+            echo "resolved blog reader-signals export URI: $URI"
+            echo "uri=$URI" >> "$GITHUB_OUTPUT"
+          else
+            echo "blog reader-signals export not yet published; selection proceeds without it"
+          fi
+      - name: Fetch blog reader-signals snapshot from S3
+        if: steps.signals-uri.outputs.uri != ''
+        continue-on-error: true
+        run: |
+          if aws s3 cp "${{ steps.signals-uri.outputs.uri }}" .blog-reader-signals.json --quiet; then
+            echo "fetched blog reader-signals snapshot: $(wc -c < .blog-reader-signals.json) bytes"
+          fi
+
+      # The review ledger (one JSON object per post, key = slug) lives in S3,
+      # not the repo. Sync it down for select-posts.py's staleness clock.
+      - name: Fetch review ledger from S3
+        if: steps.state-bucket.outputs.ledger_uri != ''
+        continue-on-error: true
+        run: |
+          mkdir -p .ledger-cache
+          aws s3 sync "${{ steps.state-bucket.outputs.ledger_uri }}" .ledger-cache/ --quiet \
+            || echo "review ledger unavailable; selection proceeds on git staleness alone"
+
+      # Deterministic selection: the model never chooses what to review.
+      - name: Select posts
+        id: select
+        run: |
+          # Count precedence: a manual workflow_dispatch input wins; otherwise
+          # the scheduled run uses the BLOG_REVIEW_COUNT repo variable; otherwise 5.
+          ARGS=(--count "${{ github.event.inputs.count || vars.BLOG_REVIEW_COUNT || '5' }}" --out .blog-review-queue.json)
+          if [ -d .ledger-cache ]; then
+            ARGS+=(--ledger-dir .ledger-cache)
+          fi
+          if [ -f .blog-traffic-snapshot ]; then
+            ARGS+=(--traffic-file .blog-traffic-snapshot)
+          fi
+          if [ -f .blog-reader-signals.json ]; then
+            ARGS+=(--signals-file .blog-reader-signals.json)
+          fi
+          if [ -n "${{ github.event.inputs.paths }}" ]; then
+            ARGS+=(--paths "${{ github.event.inputs.paths }}")
+          fi
+          python3 scripts/blog-review/select-posts.py "${ARGS[@]}"
+          echo "--- queue ---"
+          cat .blog-review-queue.json
+
+      # Hand the queue to the matrix as job outputs: `posts` fans out one
+      # review job per entry; `meta` carries the shared selection provenance
+      # (generated timestamp, snapshot availability) so each review job can
+      # reconstruct its exact single-post queue.
+      - name: Emit queue outputs
+        id: emit
+        run: |
+          echo "posts=$(jq -c '.posts' .blog-review-queue.json)" >> "$GITHUB_OUTPUT"
+          echo "meta=$(jq -c '{generated, halted, traffic, reader_signals}' .blog-review-queue.json)" >> "$GITHUB_OUTPUT"
+
+  # One UNPRIVILEGED model review per selected post. Same privilege posture
+  # as the docs per-article worker's review job: `contents: read` to clone,
+  # `id-token: write` because claude-code-action requests an OIDC token at
+  # startup, no ESC, no AWS, persist-credentials off, and a preflight assert.
+  # The model's only deliverable is `.blog-review-findings.json`; the tree
+  # must stay clean (flag-only), and the record job below distrusts anything
+  # that breaks that contract.
+  review:
+    name: "Review: ${{ matrix.post.slug }}"
+    needs: select
+    if: needs.select.outputs.has_posts == 'true' && github.event.inputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      # Bound concurrent API spend; queued matrix jobs wait their turn.
+      max-parallel: 2
+      matrix:
+        post: ${{ fromJSON(needs.select.outputs.posts) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # The claim pipeline diffs against history and the skill reads
+          # sibling docs; keep the full clone, keep the token out of
+          # .git/config (nothing in this job pushes).
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Assert the model environment is credential-free
+        run: |
+          FAIL=0
+          if [ -n "${AWS_ACCESS_KEY_ID:-}${AWS_SECRET_ACCESS_KEY:-}${AWS_SESSION_TOKEN:-}" ]; then
+            echo "::error::AWS credentials are present in the review job; they belong in select/record only"
+            FAIL=1
+          fi
+          if git config --local --get-regexp '^http\..*\.extraheader$' > /dev/null 2>&1; then
+            echo "::error::a git credential extraheader is persisted in .git/config; set persist-credentials: false"
+            FAIL=1
+          fi
+          exit "$FAIL"
+      # Vale (and other mise-pinned tools) for the whole-file prose-lint
+      # pre-step.
+      - name: Install mise-managed tools
+        uses: jdx/mise-action@v4
+        with:
+          cache: true
+      - name: Install Python deps
+        run: python3 -m pip install --quiet pyyaml
+
+      # Reconstruct this post's single-entry queue from the matrix entry +
+      # the shared meta — the same selection facts the dispatcher computed,
+      # so the record job's provenance is deterministic.
+      - name: Build single-post queue
+        env:
+          POST_JSON: ${{ toJSON(matrix.post) }}
+          META_JSON: ${{ needs.select.outputs.meta }}
+        run: |
+          jq -n --argjson post "$POST_JSON" --argjson meta "$META_JSON" \
+            '$meta + {count: 1, posts: [$post]}' > .blog-review-queue.json
+          echo "--- queue ---"
+          cat .blog-review-queue.json
+
+      # Run the docs-review deterministic pre-computation as a REAL workflow
+      # step — not a model instruction (same pipeline the docs worker uses,
+      # minus the docs-only cross-sibling pass; the PR-bound editorial
+      # balance detector can't run here, so the model applies those criteria
+      # from its whole-file read). Each command degrades gracefully (`|| stub`) so
+      # one pre-step failure never blocks the run; the model notes missing
+      # artifacts in its findings evidence.
+      - name: Pre-compute review artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          POST_PATH: ${{ matrix.post.path }}
+        run: |
+          set +e
+          S=.claude/commands/docs-review/scripts
+          git diff --no-index /dev/null "$POST_PATH" > .synthetic.patch || true
+
+          python3 $S/extract-urls-and-fetch.py \
+            --patch-file .synthetic.patch --out .fetched-urls.json \
+            || echo '[]' > .fetched-urls.json
+          python3 $S/extract-claims.py \
+            --patch-file .synthetic.patch --out .candidate-claims-regex.json \
+            || echo '{"schema_version": 1, "claims": [], "renames": [], "errors": ["extract-claims.py failed to start"], "stats": {"claims_count": 0, "files_scanned": 0, "by_type": {}}}' > .candidate-claims-regex.json
+          python3 $S/extract-claims-llm.py \
+            --patch-file .synthetic.patch --changed-files "$POST_PATH" \
+            --pass atomic --scrutiny heightened --out .candidate-claims-llm-1.json \
+            || echo '{"schema_version": 1, "pass": "atomic", "model": "claude-sonnet-5", "claims": [], "errors": ["extract-claims-llm.py failed to start"], "meta": {"files": 0, "scrutiny": "unknown", "input_tokens": 0, "output_tokens": 0, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}}' > .candidate-claims-llm-1.json
+          python3 $S/extract-claims-llm.py \
+            --patch-file .synthetic.patch --changed-files "$POST_PATH" \
+            --pass holistic --scrutiny heightened --out .candidate-claims-llm-2.json \
+            || echo '{"schema_version": 1, "pass": "holistic", "model": "claude-sonnet-5", "claims": [], "errors": ["extract-claims-llm.py failed to start"], "meta": {"files": 0, "scrutiny": "unknown", "input_tokens": 0, "output_tokens": 0, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}}' > .candidate-claims-llm-2.json
+          python3 $S/merge-claims.py \
+            --regex .candidate-claims-regex.json \
+            --llm .candidate-claims-llm-1.json --llm .candidate-claims-llm-2.json \
+            --out .candidate-claims.json \
+            || echo '{"schema_version": 1, "claims": [], "errors": ["merge-claims.py failed to start"], "meta": {"regex_claims": 0, "llm_claims": 0, "merged_claims": 0, "llm_input_tokens": 0, "llm_output_tokens": 0, "llm_cache_read_input_tokens": 0, "llm_cache_creation_input_tokens": 0}}' > .candidate-claims.json
+          python3 $S/verify-claims.py \
+            --in .candidate-claims.json --fetched-urls .fetched-urls.json \
+            --out .verified-claims.json \
+            || echo '{"schema_version": 1, "model": "claude-sonnet-5", "verdicts": [], "errors": ["verify-claims.py failed to start"], "meta": {"n_claims": 0, "n_pass1": 0, "n_pass2": 0, "n_pass3": 0, "input_tokens": 0, "output_tokens": 0, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}}' > .verified-claims.json
+          python3 $S/frontmatter-validate.py \
+            --changed-files "$POST_PATH" --out .frontmatter-validation.json \
+            || echo '{"files": [], "global_identifier_map_size": 0, "global_alias_map_size": 0}' > .frontmatter-validation.json
+          python3 $S/readthrough.py \
+            --patch-file .synthetic.patch --changed-files "$POST_PATH" \
+            --out .readthrough-findings.json \
+            || echo '{"schema_version": 1, "ran": false, "model": "claude-sonnet-5", "findings": [], "errors": ["readthrough.py failed to start"], "meta": {"files": 0, "scrutiny": "unknown", "input_tokens": 0, "output_tokens": 0, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}}' > .readthrough-findings.json
+
+          vale --no-exit --output=JSON "$POST_PATH" > .vale-raw.json 2>/dev/null \
+            || echo '{}' > .vale-raw.json
+          python3 $S/vale-findings-filter.py \
+            --in .vale-raw.json --out .vale-findings.json \
+            || echo '[]' > .vale-findings.json
+
+          echo "--- pre-compute artifacts ---"
+          ls -1 .fetched-urls.json .candidate-claims.json .verified-claims.json \
+            .vale-findings.json .frontmatter-validation.json \
+            .readthrough-findings.json 2>/dev/null || true
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Scheduled runs surface a Bot actor, which claude-code-action@v1
+          # rejects by default — same allowance the docs worker makes.
+          allowed_bots: 'github-actions[bot]'
+          prompt: |
+            The blog-review-index workflow selected one blog post in
+            `.blog-review-queue.json` at the repo root, and has ALREADY run
+            the deterministic pre-computation pipeline over it. The artifacts
+            are at the repo root: `.candidate-claims.json`,
+            `.verified-claims.json`, `.vale-findings.json`,
+            `.frontmatter-validation.json`, `.readthrough-findings.json`,
+            `.fetched-urls.json`. Read them; do NOT regenerate them.
+
+            Follow `.claude/commands/blog-review-index/SKILL.md` exactly.
+            This review is FLAG-ONLY: make NO edits to any file in the
+            repository, run no `git commit`/`git push`/`gh pr create`, create
+            no branches, and do not run `make lint` or `make build`. A
+            workflow step verifies the tree is untouched after you finish —
+            any tracked-file change invalidates this run's findings.
+
+            Review the post per the skill (fact-check-first, using the
+            criteria in `.claude/commands/docs-review/references/blog.md`),
+            classify every defensible issue into the closed taxonomy in
+            `.claude/commands/blog-review-index/references/issue-taxonomy.md`
+            with per-issue evidence, assess the advisory noindex signal per
+            `references/noindex-rubric.md`, and write your ONLY output —
+            `.blog-review-findings.json` at the repo root — matching
+            `references/findings-schema.json`. A deterministic gate validates
+            it; an invalid file (open taxonomy, missing evidence, path
+            mismatch) is discarded and the run is recorded incomplete.
+          # Broad Bash is deliberate — this job holds no push token, no AWS
+          # creds, and no production environment (same rationale as the docs
+          # worker's review job).
+          claude_args: '--model claude-opus-4-8 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash"'
+
+      # Flag-only contract check + run facts for the record job. Tracked-file
+      # changes (staged or unstaged) mark the run dirty; untracked scratch
+      # files are harmless because nothing here ever commits. Restore the
+      # tree either way so nothing model-written can leak beyond the
+      # findings file this step deliberately copies out.
+      - name: Collect run facts
+        if: always()
+        run: |
+          mkdir -p .blog-review-handoff
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "clean" > .blog-review-handoff/tree-status
+          else
+            echo "::warning::the review modified tracked files; findings will be recorded incomplete"
+            git status --porcelain | head -20
+            echo "dirty" > .blog-review-handoff/tree-status
+            git checkout -- . || true
+          fi
+          echo "${{ steps.claude.outcome }}" > .blog-review-handoff/claude-outcome
+          git rev-parse HEAD > .blog-review-handoff/head-sha
+          cp .blog-review-queue.json .blog-review-handoff/queue.json
+          [ -f .blog-review-findings.json ] \
+            && cp .blog-review-findings.json .blog-review-handoff/findings.json \
+            || echo "no findings sentinel produced"
+      - name: Upload findings artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: blog-review-findings-${{ matrix.post.slug }}
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 7
+          path: .blog-review-handoff/
+
+  # DETERMINISTIC record job (no model): validate every findings file
+  # against the closed-taxonomy gate and write the S3 state — ledger (the
+  # staleness clock), index (the known-issues entries), immutable run logs
+  # (warehouse ingestion), and the rebuilt index summary.
+  record:
+    name: Validate and record (deterministic, credentialed)
+    needs: [select, review]
+    # Runs even when review jobs failed — the ledger must record incomplete
+    # outcomes so those posts stay due — but not when the run was cancelled.
+    if: >-
+      always() && needs.select.outputs.has_posts == 'true' &&
+      github.event.inputs.dry_run != 'true' && needs.review.result != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v3
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Install Python deps
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Download findings artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          pattern: blog-review-findings-*
+          path: .findings-artifacts
+
+      - name: Configure AWS credentials
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
+          role-session-name: blog-review-record
+          aws-region: us-west-2
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+      - name: Resolve state bucket
+        id: state-bucket
+        continue-on-error: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        run: |
+          BUCKET=$(pulumi -C infrastructure stack output contentReviewLedgerBucketName \
+            --stack "${{ vars.PULUMI_STACK_NAME }}" 2>/dev/null || true)
+          if [ -n "$BUCKET" ]; then
+            echo "ledger_uri=s3://$BUCKET/blog-review/ledger/" >> "$GITHUB_OUTPUT"
+            echo "index_uri=s3://$BUCKET/blog-review/index/" >> "$GITHUB_OUTPUT"
+            echo "runs_uri=s3://$BUCKET/blog-review/runs/" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::state bucket output unavailable; records will be written locally only"
+          fi
+
+      # One canonical record per selected post, `if: always()` semantics via
+      # the loop: a matrix job that died without an artifact still lands an
+      # incomplete ledger record (rebuilt from the select job's queue), so
+      # the post stays due and is retried under the attempt cap.
+      - name: Record findings
+        env:
+          BLOG_REVIEW_LEDGER_URI: ${{ steps.state-bucket.outputs.ledger_uri }}
+          BLOG_REVIEW_INDEX_URI: ${{ steps.state-bucket.outputs.index_uri }}
+          BLOG_REVIEW_RUNS_URI: ${{ steps.state-bucket.outputs.runs_uri }}
+          POSTS_JSON: ${{ needs.select.outputs.posts }}
+          META_JSON: ${{ needs.select.outputs.meta }}
+        run: |
+          FAILED=0
+          # Process substitution, not a pipe: the loop must run in this
+          # shell so FAILED propagates to the exit below.
+          while read -r post; do
+            SLUG=$(echo "$post" | jq -r '.slug')
+            DIR=".findings-artifacts/blog-review-findings-$SLUG"
+            if [ -f "$DIR/queue.json" ]; then
+              QUEUE="$DIR/queue.json"
+            else
+              echo "::warning::no artifact for $SLUG (review job died before handoff); recording incomplete"
+              QUEUE=".queue-$SLUG.json"
+              jq -n --argjson post "$post" --argjson meta "$META_JSON" \
+                '$meta + {count: 1, posts: [$post]}' > "$QUEUE"
+            fi
+            python3 scripts/blog-review/record-findings.py \
+              --queue "$QUEUE" \
+              --findings "$DIR/findings.json" \
+              --claude-outcome "$(cat "$DIR/claude-outcome" 2>/dev/null || echo unknown)" \
+              --tree-status "$(cat "$DIR/tree-status" 2>/dev/null || echo dirty)" \
+              --head-sha "$(cat "$DIR/head-sha" 2>/dev/null || true)" \
+              || FAILED=1
+          done < <(echo "$POSTS_JSON" | jq -c '.[]')
+          exit "$FAILED"
+
+      # Rebuild the index summary from the full index prefix (all entries,
+      # not just today's) and upload it back. The summary is what the future
+      # noindex process, humans, and the warehouse read first.
+      - name: Rebuild index summary
+        if: steps.state-bucket.outputs.index_uri != ''
+        continue-on-error: true
+        run: |
+          mkdir -p .index-cache
+          aws s3 sync "${{ steps.state-bucket.outputs.index_uri }}" .index-cache/ --quiet \
+            --exclude "_summary.json"
+          python3 scripts/blog-review/build-summary.py \
+            --index-dir .index-cache --out .index-summary.json
+          cat .index-summary.json
+          aws s3 cp .index-summary.json "${{ steps.state-bucket.outputs.index_uri }}_summary.json" --quiet
+
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,10 @@ When you revise an existing blog post, use **`updated: YYYY-MM-DD`** — not `la
 
 **Do not reach for `lastmod`.** It's a Hugo built-in that only feeds the sitemap and schema.org `dateModified`, and the site already sets `enableGitInfo: true` (`config/_default/config.yml`), so Hugo derives `.Lastmod` from the commit date automatically. A hand-stamped `lastmod` is therefore invisible to readers *and* redundant with git. It's easy to default to because `lastmod` is the generic Hugo idiom for "last changed" — but on this site the reader-facing, canonical field is `updated`.
 
+### Blog known-issues index (automated daily review)
+
+A scheduled workflow (`.github/workflows/blog-review-index.yml`) reviews a few existing blog posts per day — selected deterministically by `scripts/blog-review/select-posts.py` (traffic/GSC-weighted staleness; oldest-unreviewed-first until the blog data exports ship) — and records structured findings (dead links, factual rot, deprecated products, thin content) into an S3 known-issues index. It is **flag-only state, not content**: nothing is committed to the repo, no fixes are applied, and no PRs are opened. State lives in the content-review ledger bucket under the `blog-review/` prefix (`ledger/`, `index/`, `runs/`, and `index/_summary.json`); the on/off/cadence switch is the `BLOG_REVIEW_COUNT` repo variable (unset = 5 posts/run, `'0'` = off). The review skill is `.claude/commands/blog-review-index/SKILL.md`; its closed issue taxonomy lives in that skill's `references/issue-taxonomy.md` and is enforced by `scripts/blog-review/validate-findings.py`. The index is evidence for a future, human-reviewed process that marks rotted, low-value posts `block_external_search_index: true` — do not add that frontmatter based on the index without going through that process.
+
 ---
 
 ## Releases changelog entries

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -1443,6 +1443,7 @@ The repository includes 10 additional utility workflows for automation and proje
 - **claude-code-review.yml**: AI-powered code review automation for pull requests
 - **claude-social-review.yml**: AI-powered review of social media post copy generated for blog post PRs
 - **review-existing-content.yml** / **content-review-article.yml**: Daily existing-content review — deterministic selection fans out one per-article worker per page
+- **blog-review-index.yml**: Daily blog known-issues indexing — deterministic selection (`scripts/blog-review/select-posts.py`), one unprivileged model review per post (matrix), one deterministic record job. FLAG-ONLY: findings land in S3 (`blog-review/` prefix in the content-review ledger bucket: `ledger/`, `index/`, `runs/`, `index/_summary.json`); no content edits, no PRs. On/off/cadence via the `BLOG_REVIEW_COUNT` repo variable (unset = 5/run, `'0'` = off). The index is evidence for a future noindex decision process (`block_external_search_index: true` on rotted, low-value posts).
 
 The first two workflows include a permission check step that verifies the triggering user has write access to the repository before running Claude. Users without write access will see the workflow skip Claude execution. The social review workflow runs only on internal PRs from non-bot authors.
 

--- a/scripts/blog-review/build-summary.py
+++ b/scripts/blog-review/build-summary.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Rebuild the blog-review index summary from the per-post index entries.
+
+The record job syncs the S3 `blog-review/index/` prefix to a local directory,
+runs this script over it, and uploads the result back as
+`blog-review/index/_summary.json`. The summary is the artifact the future
+noindex decision process (and humans, and the warehouse) read first: corpus
+totals by issue category and severity, plus the current list of
+`candidate` / `strong-candidate` posts with the signals a threshold-based
+decision needs.
+
+This script is a pure function of the index directory (plus the --today test
+hook); it consults no network and makes no judgment calls — thresholds and
+decisions belong to the consumer.
+
+Usage:
+    build-summary.py --index-dir .index-cache --out _summary.json [--today YYYY-MM-DD]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+
+def load_entries(index_dir: Path) -> list[dict]:
+    entries = []
+    for f in sorted(index_dir.glob("*.json")):
+        if f.name == "_summary.json":
+            continue
+        try:
+            entry = json.loads(f.read_text())
+        except (OSError, json.JSONDecodeError):
+            print(f"build-summary: unreadable index entry {f}", file=sys.stderr)
+            continue
+        if isinstance(entry, dict) and entry.get("slug"):
+            entries.append(entry)
+    return entries
+
+
+def candidate_row(entry: dict) -> dict:
+    """The fields a threshold-based noindex decision needs, nothing more."""
+    return {
+        "slug": entry["slug"],
+        "url": entry.get("url"),
+        "path": entry.get("path"),
+        "post_date": entry.get("post_date"),
+        "reviewed_at": entry.get("reviewed_at"),
+        "assessment": (entry.get("noindex_signal") or {}).get("assessment"),
+        "rationale": (entry.get("noindex_signal") or {}).get("rationale"),
+        "issue_counts": entry.get("issue_counts"),
+        "signals": entry.get("signals"),
+    }
+
+
+def build_summary(entries: list[dict], today: str | None = None) -> dict:
+    by_severity: dict[str, int] = {}
+    by_category: dict[str, int] = {}
+    clean = 0
+    with_issues = 0
+    candidates = []
+    for e in entries:
+        counts = e.get("issue_counts") or {}
+        for k, v in (counts.get("by_severity") or {}).items():
+            by_severity[k] = by_severity.get(k, 0) + int(v)
+        for k, v in (counts.get("by_category") or {}).items():
+            by_category[k] = by_category.get(k, 0) + int(v)
+        if e.get("clean"):
+            clean += 1
+        elif counts.get("total"):
+            with_issues += 1
+        assessment = (e.get("noindex_signal") or {}).get("assessment")
+        if assessment in ("candidate", "strong-candidate"):
+            candidates.append(candidate_row(e))
+
+    candidates.sort(key=lambda r: (r["assessment"] != "strong-candidate", r["slug"]))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated": today or datetime.now(timezone.utc).date().isoformat(),
+        "posts_indexed": len(entries),
+        "posts_clean": clean,
+        "posts_with_issues": with_issues,
+        "issues_by_severity": dict(sorted(by_severity.items())),
+        "issues_by_category": dict(sorted(by_category.items())),
+        "noindex_candidates": candidates,
+    }
+
+
+def self_test() -> int:
+    entries = [
+        {"slug": "a", "url": "/blog/a/", "clean": False,
+         "issue_counts": {"total": 2, "by_severity": {"major": 1, "minor": 1},
+                          "by_category": {"dead-link": 2}},
+         "noindex_signal": {"assessment": "strong-candidate", "rationale": "r"}},
+        {"slug": "b", "url": "/blog/b/", "clean": True,
+         "issue_counts": {"total": 0, "by_severity": {}, "by_category": {}},
+         "noindex_signal": {"assessment": "keep", "rationale": "r"}},
+        {"slug": "c", "url": "/blog/c/", "clean": False,
+         "issue_counts": {"total": 1, "by_severity": {"minor": 1},
+                          "by_category": {"seo-thin": 1}},
+         "noindex_signal": {"assessment": "candidate", "rationale": "r"}},
+    ]
+    s = build_summary(entries, today="2026-07-15")
+    ok = (
+        s["posts_indexed"] == 3
+        and s["posts_clean"] == 1
+        and s["posts_with_issues"] == 2
+        and s["issues_by_severity"] == {"major": 1, "minor": 2}
+        and s["issues_by_category"] == {"dead-link": 2, "seo-thin": 1}
+        and [c["slug"] for c in s["noindex_candidates"]] == ["a", "c"]
+        and s["generated"] == "2026-07-15"
+    )
+    print("all build-summary self-tests passed" if ok else "FAIL", file=sys.stderr)
+    return 0 if ok else 1
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Rebuild the blog-review index summary.")
+    p.add_argument("--index-dir", help="local sync of the S3 index/ prefix")
+    p.add_argument("--out", help="summary JSON output path")
+    p.add_argument("--today", help="Override the generated date YYYY-MM-DD (testing)")
+    p.add_argument("--self-test", action="store_true", help="run built-in smoke checks")
+    args = p.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.index_dir or not args.out:
+        p.error("--index-dir and --out are required")
+
+    summary = build_summary(load_entries(Path(args.index_dir)), today=args.today)
+    Path(args.out).write_text(json.dumps(summary, indent=2) + "\n")
+    print(
+        f"build-summary: {summary['posts_indexed']} post(s), "
+        f"{len(summary['noindex_candidates'])} noindex candidate(s) → {args.out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/blog-review/record-findings.py
+++ b/scripts/blog-review/record-findings.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Record one blog post's review outcome to the S3 known-issues index.
+
+This is the single source of truth for the blog-review record shapes and
+their upload. The record job of `.github/workflows/blog-review-index.yml`
+runs it once per reviewed post (`if: always()` semantics via the workflow
+loop), so every selected post lands exactly one canonical ledger object per
+run — even when the model exits without producing output.
+
+The review is FLAG-ONLY: the model records findings, never edits content, so
+there is no patch, no branch, and no PR. The model's only structured output
+is the findings sentinel (`.blog-review-findings.json`), validated here via
+validate-findings.py (schema shape, closed taxonomy, evidence-required).
+Status is derived from observable state, not self-report:
+
+  * findings valid, issues found        -> status "reviewed"
+  * findings valid, clean: true         -> status "clean"
+  * findings absent/unreadable/invalid  -> status "incomplete" (stays due,
+                                           retried up to the attempt cap)
+  * working tree was dirty after review -> status "incomplete" (the model
+                                           broke the flag-only contract; its
+                                           findings are not trusted)
+
+Three objects are written (locally always; to S3 when the URIs are set):
+
+  ledger  BLOG_REVIEW_LEDGER_URI/<slug>.json  — bookkeeping / staleness clock
+  index   BLOG_REVIEW_INDEX_URI/<slug>.json   — the known-issues index entry
+                                                (reviewed/clean only)
+  run log BLOG_REVIEW_RUNS_URI/<date>/<slug>.json — immutable append-only
+          copy of each run for warehouse ingestion (every outcome, including
+          incomplete)
+
+Every object carries `schema_version` and `reviewed_at` so the warehouse
+ingestion (see the blog-review section of AGENTS.md) can consume increments.
+
+Self-contained — run the smoke checks with `python3 record-findings.py --self-test`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+SCHEMA_VERSION = 1
+
+# Reuse the validation gate from validate-findings.py (single source of
+# truth for the findings contract). Hyphenated filename, so import by path;
+# main() is guarded under __main__, so importing has no side effects.
+_spec = importlib.util.spec_from_file_location(
+    "validate_findings_mod", HERE / "validate-findings.py"
+)
+_validate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_validate)
+validate_findings = _validate.validate_findings
+
+
+def log(msg: str) -> None:
+    print(f"record-findings: {msg}", file=sys.stderr)
+
+
+def warn(msg: str) -> None:
+    # `::warning::` surfaces in the GitHub Actions run summary.
+    print(f"::warning::record-findings: {msg}", file=sys.stderr)
+
+
+# ---- inputs -----------------------------------------------------------------
+
+
+def _maybe_int(v):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def load_queue_post(queue_path: Path) -> dict:
+    """Return the single post from the worker queue, with its selection signal.
+
+    Beyond the bookkeeping fields (path/slug/lane/attempts), this carries the
+    selection facts the post was chosen on — score, monthly visits, GSC
+    figures, and whether each snapshot was available that run. They're
+    persisted onto the ledger and index records so the S3 state is a
+    complete, self-contained metrics source (outcome AND why-it-was-picked).
+    """
+    data = json.loads(queue_path.read_text())
+    posts = data.get("posts") or []
+    if not posts:
+        raise SystemExit(f"record-findings: no posts in {queue_path}")
+    p = posts[0]
+    traffic = data.get("traffic") or {}
+    return {
+        "path": p["path"],
+        "slug": p["slug"],
+        "url": p.get("url"),
+        "lane": p.get("lane") or "priority",
+        "post_date": p.get("post_date"),
+        # Prior incomplete-retry count, carried from the ledger by the selector.
+        "attempts": int(p.get("attempts") or 0),
+        "score": p.get("score"),
+        "monthly_visits": _maybe_int(p.get("monthly_visits")),
+        "traffic_available": bool(traffic.get("available")),
+        "signals": p.get("signals"),
+        "signals_available": bool((data.get("reader_signals") or {}).get("available")),
+    }
+
+
+def load_findings(findings_path: Path | None) -> dict | None:
+    """Return the model's findings sentinel, or None if absent/unparseable."""
+    if not findings_path or not findings_path.is_file():
+        return None
+    try:
+        return json.loads(findings_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        warn(f"findings sentinel unreadable ({e}); treating as incomplete")
+        return None
+
+
+# ---- derivation -------------------------------------------------------------
+
+
+def issue_counts(issues: list[dict]) -> dict:
+    by_severity: dict[str, int] = {}
+    by_category: dict[str, int] = {}
+    for i in issues:
+        by_severity[i["severity"]] = by_severity.get(i["severity"], 0) + 1
+        by_category[i["category"]] = by_category.get(i["category"], 0) + 1
+    return {"total": len(issues), "by_severity": by_severity, "by_category": by_category}
+
+
+def build_records(
+    post: dict,
+    findings: dict | None,
+    claude_succeeded: bool,
+    tree_dirty: bool,
+    head_sha: str = "",
+    today: str | None = None,
+) -> tuple[dict, dict | None, dict]:
+    """Build (ledger, index-or-None, run-log) records.
+
+    `attempts` accrues the consecutive `incomplete` retries: it starts from
+    the prior count the selector carried in (`post["attempts"]`), is
+    incremented by one on another incomplete outcome, and is reset to 0 the
+    moment the post reaches any completed status. The selector backs a post
+    off once it hits ATTEMPT_CAP, so this counter is the loop guard.
+    """
+    reviewed_at = today or datetime.now(timezone.utc).date().isoformat()
+    prior_attempts = int(post.get("attempts") or 0)
+
+    errors: list[str] = []
+    if findings is None:
+        errors = ["findings sentinel absent or unreadable"]
+    else:
+        errors = validate_findings(findings, post)
+    if tree_dirty:
+        errors.append("working tree was dirty after the review (flag-only contract broken)")
+    if not claude_succeeded:
+        errors.append("review run did not succeed")
+
+    valid = not errors
+    issues = list(findings.get("issues") or []) if valid else []
+    clean = bool(findings.get("clean")) if valid else False
+
+    if valid:
+        status = "clean" if clean else "reviewed"
+        attempts = 0
+        note = None
+    else:
+        status = "incomplete"
+        attempts = prior_attempts + 1
+        note = "; ".join(errors)
+        if findings is not None and note != "findings sentinel absent or unreadable":
+            warn(f"findings rejected for {post['slug']}: {note}")
+
+    ledger = {
+        "schema_version": SCHEMA_VERSION,
+        "path": post["path"],
+        "slug": post["slug"],
+        "lane": post["lane"],
+        "status": status,
+        "issues": len(issues),
+        "note": note,
+        "attempts": attempts,
+        # Selection signal (carried from the queue) — persisted so the ledger
+        # captures why the post was picked, not just the outcome.
+        "score": post.get("score"),
+        "monthly_visits": post.get("monthly_visits"),
+        "traffic_available": bool(post.get("traffic_available")),
+        "signals": post.get("signals"),
+        "signals_available": bool(post.get("signals_available")),
+        "post_date": post.get("post_date"),
+        "head_sha": head_sha,
+        "reviewed_at": reviewed_at,
+    }
+
+    index = None
+    if valid:
+        index = {
+            "schema_version": SCHEMA_VERSION,
+            "path": post["path"],
+            "slug": post["slug"],
+            "url": post.get("url"),
+            "post_date": post.get("post_date"),
+            "head_sha": head_sha,
+            "reviewed_at": reviewed_at,
+            "status": status,
+            "clean": clean,
+            "issues": issues,
+            "issue_counts": issue_counts(issues),
+            "noindex_signal": findings.get("noindex_signal"),
+            "signals": {
+                "monthly_visits": post.get("monthly_visits"),
+                "traffic_available": bool(post.get("traffic_available")),
+                "gsc": (post.get("signals") or {}).get("gsc"),
+            },
+        }
+
+    # The run log records every outcome — including incomplete — so the
+    # warehouse sees retries and breakage, not just successes.
+    run_log = dict(index) if index else {
+        "schema_version": SCHEMA_VERSION,
+        "path": post["path"],
+        "slug": post["slug"],
+        "url": post.get("url"),
+        "post_date": post.get("post_date"),
+        "head_sha": head_sha,
+        "reviewed_at": reviewed_at,
+        "status": status,
+        "clean": False,
+        "issues": [],
+        "issue_counts": issue_counts([]),
+        "noindex_signal": None,
+        "signals": {
+            "monthly_visits": post.get("monthly_visits"),
+            "traffic_available": bool(post.get("traffic_available")),
+            "gsc": (post.get("signals") or {}).get("gsc"),
+        },
+    }
+    run_log = {**run_log, "note": note}
+
+    return ledger, index, run_log
+
+
+# ---- output -----------------------------------------------------------------
+
+
+def upload(record: dict, key: str) -> None:
+    """Upload the record to the S3 key via the aws CLI (stdin)."""
+    try:
+        subprocess.run(
+            ["aws", "s3", "cp", "-", key],
+            input=json.dumps(record, indent=2) + "\n",
+            text=True, check=True,
+        )
+        log(f"uploaded {key}")
+    except FileNotFoundError:
+        warn("aws CLI not available; record not uploaded")
+    except subprocess.CalledProcessError as e:
+        warn(f"upload failed for {key} ({e})")
+
+
+def s3_key(uri: str, *parts: str) -> str:
+    return "/".join([uri.rstrip("/"), *parts])
+
+
+# ---- main -------------------------------------------------------------------
+
+
+def run(args) -> int:
+    post = load_queue_post(Path(args.queue))
+    slug = post["slug"]
+    findings = load_findings(Path(args.findings) if args.findings else None)
+    claude_succeeded = (args.claude_outcome or "").strip().lower() == "success"
+    tree_dirty = (args.tree_status or "").strip().lower() == "dirty"
+
+    ledger, index, run_log = build_records(
+        post, findings, claude_succeeded, tree_dirty,
+        head_sha=args.head_sha or "", today=args.today,
+    )
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / f"ledger-{slug}.json").write_text(json.dumps(ledger, indent=2) + "\n")
+    if index:
+        (out_dir / f"index-{slug}.json").write_text(json.dumps(index, indent=2) + "\n")
+    (out_dir / f"run-{slug}.json").write_text(json.dumps(run_log, indent=2) + "\n")
+    log(f"status={ledger['status']} slug={slug} issues={ledger['issues']} -> {out_dir}")
+
+    ledger_uri = os.environ.get("BLOG_REVIEW_LEDGER_URI", "").strip()
+    index_uri = os.environ.get("BLOG_REVIEW_INDEX_URI", "").strip()
+    runs_uri = os.environ.get("BLOG_REVIEW_RUNS_URI", "").strip()
+    if ledger_uri:
+        upload(ledger, s3_key(ledger_uri, f"{slug}.json"))
+    else:
+        warn("BLOG_REVIEW_LEDGER_URI unset; ledger record written locally only")
+    if index and index_uri:
+        upload(index, s3_key(index_uri, f"{slug}.json"))
+    if runs_uri:
+        upload(run_log, s3_key(runs_uri, ledger["reviewed_at"], f"{slug}.json"))
+
+    return 0
+
+
+def self_test() -> int:
+    import tempfile
+
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+            print(f"FAIL: {name}", file=sys.stderr)
+        else:
+            print(f"ok: {name}")
+
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        queue = d / "queue.json"
+        gsc_block = {"gsc": {"impressions": 15234, "ctr": 0.0205,
+                             "opportunity": 0.41, "multiplier": 1.1025}}
+        queue.write_text(json.dumps({
+            "traffic": {"available": True},
+            "reader_signals": {"available": True},
+            "posts": [{
+                "path": "content/blog/my-post/index.md",
+                "slug": "my-post",
+                "url": "/blog/my-post/",
+                "lane": "priority",
+                "post_date": "2021-03-04",
+                "attempts": 0,
+                "score": 812.5,
+                "monthly_visits": 842,
+                "signals": gsc_block,
+            }]
+        }))
+        post = load_queue_post(queue)
+        check("queue post carries the selection signal",
+              post["score"] == 812.5 and post["monthly_visits"] == 842
+              and post["traffic_available"] is True and post["signals"] == gsc_block)
+
+        good_findings = {
+            "schema_version": 1,
+            "path": "content/blog/my-post/index.md",
+            "slug": "my-post",
+            "issues": [
+                {"id": "dead-link-01", "category": "dead-link", "severity": "major",
+                 "summary": "s", "evidence": "e", "location": "l"},
+                {"id": "rot-01", "category": "factual-rot", "severity": "minor",
+                 "summary": "s", "evidence": "e", "location": "l"},
+            ],
+            "clean": False,
+            "noindex_signal": {"assessment": "candidate", "rationale": "r"},
+        }
+
+        ledger, index, run_log = build_records(
+            post, good_findings, claude_succeeded=True, tree_dirty=False,
+            head_sha="abc123", today="2026-07-15")
+        check("valid findings -> reviewed", ledger["status"] == "reviewed")
+        check("reviewed resets attempts", ledger["attempts"] == 0)
+        check("ledger counts issues", ledger["issues"] == 2)
+        check("index entry exists", index is not None)
+        check("index carries the issues verbatim", index["issues"] == good_findings["issues"])
+        check("index counts by severity",
+              index["issue_counts"]["by_severity"] == {"major": 1, "minor": 1})
+        check("index counts by category",
+              index["issue_counts"]["by_category"] == {"dead-link": 1, "factual-rot": 1})
+        check("index carries noindex_signal",
+              index["noindex_signal"]["assessment"] == "candidate")
+        check("index carries selection signals",
+              index["signals"]["monthly_visits"] == 842
+              and index["signals"]["gsc"] == gsc_block["gsc"])
+        check("schema_version + reviewed_at on every object",
+              all(o.get("schema_version") == 1 and o.get("reviewed_at") == "2026-07-15"
+                  for o in (ledger, index, run_log)))
+        check("run log mirrors the index on success",
+              run_log["issues"] == index["issues"] and run_log["status"] == "reviewed")
+
+        clean_findings = {**good_findings, "issues": [], "clean": True,
+                          "noindex_signal": {"assessment": "keep", "rationale": "r"}}
+        ledger, index, run_log = build_records(
+            post, clean_findings, claude_succeeded=True, tree_dirty=False)
+        check("clean findings -> clean", ledger["status"] == "clean")
+        check("clean still writes an index entry",
+              index is not None and index["clean"] is True and index["issues"] == [])
+
+        # Absent sentinel -> incomplete; attempts accrue; no index entry.
+        retried = {**post, "attempts": 2}
+        ledger, index, run_log = build_records(
+            retried, None, claude_succeeded=True, tree_dirty=False)
+        check("absent findings -> incomplete", ledger["status"] == "incomplete")
+        check("incomplete accrues prior attempts (2 -> 3)", ledger["attempts"] == 3)
+        check("incomplete writes no index entry", index is None)
+        check("incomplete still writes a run log",
+              run_log["status"] == "incomplete" and run_log["note"])
+
+        # Invalid findings (open taxonomy) -> incomplete.
+        bad = {**good_findings,
+               "issues": [{**good_findings["issues"][0], "category": "vibes"}]}
+        ledger, index, _ = build_records(post, bad, claude_succeeded=True, tree_dirty=False)
+        check("invalid findings -> incomplete", ledger["status"] == "incomplete")
+        check("invalid findings never reach the index", index is None)
+
+        # A dirty tree invalidates even valid findings: flag-only is a hard contract.
+        ledger, index, _ = build_records(
+            post, good_findings, claude_succeeded=True, tree_dirty=True)
+        check("dirty tree -> incomplete despite valid findings",
+              ledger["status"] == "incomplete" and index is None)
+        check("dirty tree noted", "flag-only" in (ledger["note"] or ""))
+
+        # A failed run -> incomplete even with a plausible sentinel.
+        ledger, index, _ = build_records(
+            post, good_findings, claude_succeeded=False, tree_dirty=False)
+        check("failed run -> incomplete", ledger["status"] == "incomplete")
+
+    if failures:
+        print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nall record-findings self-tests passed")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Record a blog-review outcome to the S3 index.")
+    p.add_argument("--queue", help="single-post queue JSON (.blog-review-queue.json)")
+    p.add_argument("--findings", help="model findings sentinel (.blog-review-findings.json)")
+    p.add_argument("--claude-outcome",
+                   help="GitHub step outcome of the review run (success/failure/cancelled)")
+    p.add_argument("--tree-status", choices=["clean", "dirty"], default="clean",
+                   help="working-tree state after the review (dirty => incomplete)")
+    p.add_argument("--head-sha", help="commit the review ran on")
+    p.add_argument("--today", help="Override reviewed_at YYYY-MM-DD (testing)")
+    p.add_argument("--out-dir", default=".blog-review-records",
+                   help="local record artifact directory")
+    p.add_argument("--self-test", action="store_true", help="run built-in smoke checks")
+    args = p.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.queue:
+        p.error("--queue is required")
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/blog-review/select-posts.py
+++ b/scripts/blog-review/select-posts.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""Select existing blog posts for the daily known-issues review.
+
+Deterministic pre-step for the blog-review-index workflow
+(`.github/workflows/blog-review-index.yml`): given the S3-fetched traffic
+snapshot, the optional reader-signals (Search Console) snapshot, and the
+per-post review ledger, emit the day's review queue as JSON. The model never
+chooses what to review — this script does, so the selection is auditable and
+reproducible from its inputs.
+
+This is the blog sibling of `scripts/content-review/select-articles.py`, and
+it keeps that script's proven mechanics (single-pass git history read,
+median-imputed log-normalized traffic, boost-only GSC multiplier,
+path-ascending tie-break). The differences are deliberate:
+
+  * The corpus is `content/blog/*/index.md` only (one bundle per post).
+  * No strategic tiers (blogs aren't tiered) and no feedback-widget term
+    (the widget is docs-only).
+  * Posts published fewer than MIN_AGE_DAYS ago are excluded — fresh posts
+    just went through the PR-time docs review; content rot needs time.
+  * The never-reviewed staleness fallback is the post's frontmatter `date`
+    (its publish date), not the git creation date: with no traffic snapshot
+    the selection degrades to an oldest-unreviewed-first sweep.
+  * No open-PR dedup and no MAX_OPEN_PRS halt: the review is flag-only
+    (findings land in the S3 index; no PRs are opened), so there is nothing
+    to guard. The `halted` output key is kept for shape parity with the docs
+    queue, but is always null.
+
+Selection algorithm (weighted fair queuing by staleness):
+
+    score      = importance * staleness
+    importance = (0.5 + 0.5 * traffic_n) * gsc_m     with a traffic snapshot
+               = gsc_m                                without one
+    traffic_n  = log1p(visits) / log1p(max_visits); posts missing from the
+                 snapshot impute the median
+    gsc_m      = 1 + 0.25 * impressions_n * ctr_gap, in [1.0, 1.25]: the
+                 Search Console "opportunity" boost — only posts searchers
+                 see a lot (high impressions) but rarely click (CTR below
+                 the corpus median) boost. Boost-only with a floor of
+                 exactly 1.0: a post absent from the export scores exactly
+                 what it would have scored before the term existed.
+    staleness  = (today - effective_last_review).days, floored at 0
+    effective_last_review = max(completed bot review, newest non-bot commit)
+                 where an `incomplete` review never advances the clock.
+                 Never-reviewed posts fall back to their publish date.
+
+    Ties break on path ascending, so runs are reproducible.
+
+Hard filters: `draft: true`; posts younger than MIN_AGE_DAYS; posts whose
+`incomplete` review already burned ATTEMPT_CAP retries (they back off and
+are surfaced for a human instead of looping forever).
+
+Usage:
+    select-posts.py --count 5 --out .blog-review-queue.json
+        [--traffic-file .blog-traffic-snapshot]
+        [--signals-file .blog-reader-signals.json]
+        [--ledger-dir .ledger-cache]
+        [--paths content/blog/a/index.md,content/blog/b/index.md]
+        [--today YYYY-MM-DD] [--dry-run]
+    select-posts.py --stats   # ledger outcome report
+    select-posts.py --prune   # GC ledger entries whose posts are gone
+
+`--paths` bypasses scoring entirely (workflow_dispatch testing). `--today`
+exists for tests. When `$GITHUB_OUTPUT` is set, the script appends
+`has_posts=`, `halted=`, and `count=` for workflow gating.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_LEDGER_DIR = REPO_ROOT / "scripts/blog-review/ledger"
+CONTENT_DIR = "content/blog"
+
+# An `incomplete` review (worker exited before recording valid findings)
+# never advances the staleness clock, so the post stays due and is retried
+# next sweep. This caps the retries: once a post has burned ATTEMPT_CAP
+# incomplete runs it backs off (is excluded and surfaced) instead of looping
+# forever on whatever keeps breaking it.
+ATTEMPT_CAP = 3
+
+# Posts younger than this never enter the queue: they were just reviewed at
+# PR time by the pre-merge docs review, and the rot this process hunts for
+# (dead links, deprecated products, stale facts) needs time to accumulate.
+MIN_AGE_DAYS = 90
+
+# Search Console boost tuning — same shape and rationale as the docs
+# selector: the multiplier floors at exactly 1.0 (absent posts score exactly
+# as if the export never existed) and caps well under the traffic spread, so
+# it reorders comparably stale peers without overriding staleness.
+GSC_MIN_IMPRESSIONS = 200  # below this, CTR is noise -> neutral
+GSC_BOOST_MAX = 0.25  # gsc multiplier in [1.0, 1.25]
+
+# Statuses a ledger entry can carry (set by record-findings.py). Any status
+# other than "incomplete" is a completed review whose date advances the clock.
+INCOMPLETE_STATUS = "incomplete"
+
+# "Pulumi Bot" (display name) is how the SDK-regen tooling authors its
+# commits; "pulumi-bot" is how the review workflows configure git. Both are
+# the same bot and neither resets a post's staleness clock.
+BOT_AUTHORS = {"pulumi-bot", "Pulumi Bot", "dependabot[bot]", "github-actions[bot]"}
+
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+
+
+# ---- Path helpers -----------------------------------------------------------
+
+
+def slugify(content_path: str) -> str:
+    """content/blog/my-post/index.md -> my-post"""
+    p = content_path
+    if p.startswith(f"{CONTENT_DIR}/"):
+        p = p[len(f"{CONTENT_DIR}/") :]
+    if p.endswith("/index.md"):
+        p = p[: -len("/index.md")]
+    return p.replace("/", "-")
+
+
+def url_for(content_path: str) -> str:
+    """content/blog/my-post/index.md -> /blog/my-post/"""
+    p = content_path
+    if p.startswith("content/"):
+        p = p[len("content/") :]
+    if p.endswith("/index.md"):
+        p = p[: -len("/index.md")]
+    return f"/{p}/"
+
+
+def content_path_for_url(url_path: str, known_paths: set[str]) -> str | None:
+    """Map a live /blog/... URL path back to its content bundle, if it exists."""
+    p = url_path.split("#", 1)[0].split("?", 1)[0].strip()
+    if p.startswith("https://"):
+        p = re.sub(r"^https://[^/]+", "", p)
+    p = "/" + p.strip("/")
+    candidate = f"content{p}/index.md"
+    if candidate in known_paths:
+        return candidate
+    return None
+
+
+# ---- Input loading ----------------------------------------------------------
+
+
+def load_traffic(traffic_file: Path | None, known_paths: set[str]) -> tuple[dict[str, int], dict]:
+    """Parse the S3 traffic snapshot (JSON or CSV) into {content_path: visits}.
+
+    Returns ({}, meta) when the file is missing/unreadable — selection then
+    drops the traffic term entirely (graceful degradation).
+    """
+    meta = {"source": None, "period": None, "pages_matched": 0}
+    if traffic_file is None or not traffic_file.is_file():
+        return {}, meta
+    raw = traffic_file.read_text(errors="replace").strip()
+    if not raw:
+        return {}, meta
+
+    pages: dict[str, int] = {}
+
+    def record(url_path: str, views) -> None:
+        try:
+            views = int(float(views))
+        except (TypeError, ValueError):
+            return
+        cp = content_path_for_url(str(url_path), known_paths)
+        if cp:
+            # A URL and its aliases may both appear; credit the same post once
+            # with the larger figure rather than double-counting.
+            pages[cp] = max(pages.get(cp, 0), views)
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        data = None
+
+    if isinstance(data, dict):
+        meta["source"] = data.get("source")
+        meta["period"] = data.get("period") or data.get("generated")
+        body = data.get("pages", data)
+        if isinstance(body, dict):
+            for url_path, views in body.items():
+                record(url_path, views)
+    elif data is None:
+        # CSV: `path,views` with an optional header row.
+        reader = csv.reader(io.StringIO(raw))
+        for row in reader:
+            if len(row) < 2:
+                continue
+            record(row[0], row[1])
+
+    meta["pages_matched"] = len(pages)
+    return pages, meta
+
+
+def load_reader_signals(
+    signals_file: Path | None, known_paths: set[str]
+) -> tuple[dict[str, dict], dict]:
+    """Parse the reader-signals snapshot into a per-post GSC map.
+
+    Same contract as the docs selector's export (independently optional
+    sections under `signals`), but blogs consume only the `gsc` section —
+    there is no feedback widget on blog pages.
+
+    Returns (gsc, meta). A missing/unreadable/malformed file degrades the
+    signal to unavailable: selection then scores exactly as if the export
+    never existed.
+    """
+    meta = {
+        "gsc": {"available": False, "source": None, "period": None,
+                "pages_matched": 0, "median_ctr": None, "max_impressions": None},
+    }
+    gsc: dict[str, dict] = {}
+    if signals_file is None or not signals_file.is_file():
+        return gsc, meta
+    try:
+        data = json.loads(signals_file.read_text(errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        return gsc, meta
+    if not isinstance(data, dict):
+        return gsc, meta
+    sections = data.get("signals")
+    if not isinstance(sections, dict):
+        return gsc, meta
+
+    def _int(v) -> int:
+        try:
+            return max(int(float(v)), 0)
+        except (TypeError, ValueError):
+            return 0
+
+    gsc_section = sections.get("gsc")
+    if isinstance(gsc_section, dict) and isinstance(gsc_section.get("pages"), dict):
+        for url_path, row in gsc_section["pages"].items():
+            if not isinstance(row, dict):
+                continue
+            cp = content_path_for_url(str(url_path), known_paths)
+            if not cp:
+                continue
+            impressions = _int(row.get("impressions"))
+            clicks = _int(row.get("clicks"))
+            entry = {
+                "impressions": impressions,
+                "clicks": clicks,
+                "ctr": round(clicks / impressions, 6) if impressions else 0.0,
+                "position": row.get("position"),
+            }
+            # A URL and its aliases may both appear; keep the row with the
+            # larger figure rather than double-counting.
+            prev = gsc.get(cp)
+            if prev is None or entry["impressions"] > prev["impressions"]:
+                gsc[cp] = entry
+        if gsc:
+            # Corpus stats over pages with meaningful volume only, so the
+            # long tail of near-zero-impression rows can't drag the median.
+            eligible = [e for e in gsc.values() if e["impressions"] >= GSC_MIN_IMPRESSIONS]
+            ctrs = sorted(e["ctr"] for e in eligible)
+            meta["gsc"] = {
+                "available": True,
+                "source": gsc_section.get("source"),
+                "period": gsc_section.get("period"),
+                "pages_matched": len(gsc),
+                "median_ctr": ctrs[len(ctrs) // 2] if ctrs else None,
+                "max_impressions": max((e["impressions"] for e in eligible), default=None),
+            }
+
+    return gsc, meta
+
+
+def load_ledger(ledger_dir: Path) -> dict[str, dict]:
+    """Return {content_path: ledger entry} from one-file-per-post JSON."""
+    entries: dict[str, dict] = {}
+    if not ledger_dir.is_dir():
+        return entries
+    for f in sorted(ledger_dir.glob("*.json")):
+        try:
+            entry = json.loads(f.read_text())
+        except (OSError, json.JSONDecodeError):
+            print(f"select-posts: unreadable ledger file {f}", file=sys.stderr)
+            continue
+        path = entry.get("path")
+        if path:
+            entry["_file"] = str(f)
+            entries[path] = entry
+    return entries
+
+
+# ---- Frontmatter ------------------------------------------------------------
+
+
+def read_frontmatter(file_path: Path) -> dict:
+    try:
+        head = file_path.read_text(errors="replace")[:8192]
+    except OSError:
+        return {}
+    m = FRONTMATTER_RE.match(head)
+    if not m:
+        return {}
+    try:
+        fm = yaml.safe_load(m.group(1))
+    except yaml.YAMLError:
+        return {}
+    return fm if isinstance(fm, dict) else {}
+
+
+def is_draft(fm: dict) -> bool:
+    return bool(fm.get("draft"))
+
+
+def publish_date(fm: dict) -> date | None:
+    d = fm.get("date")
+    if isinstance(d, datetime):
+        return d.date()
+    if isinstance(d, date):
+        return d
+    return parse_day(str(d)) if d else None
+
+
+# ---- Git signals (single-pass, no per-file subprocess fan-out) ---------------
+
+
+def git_history_signals(repo: Path) -> tuple[dict[str, int], dict[str, int]]:
+    """Per-path git timestamps for content/blog, from one history pass.
+
+    Walks history newest-first and returns two maps of unix commit times:
+
+      newest_non_bot : the most recent commit by a *non-bot* author that
+                       touched the path (a human edit — resets the staleness
+                       clock). Absent for posts only ever touched by bots.
+      created        : the oldest commit that touched the path, the fallback
+                       clock when a post's frontmatter carries no usable date.
+    """
+    out = run_git(repo, ["log", "--name-only", "--format=%x01%ct%x01%an", "--", CONTENT_DIR])
+    newest_non_bot: dict[str, int] = {}
+    created: dict[str, int] = {}
+    current_ct = 0
+    author_is_bot = True
+    for line in out.splitlines():
+        if line.startswith("\x01"):
+            # Header line is "\x01<commit-time>\x01<author-name>".
+            parts = line.split("\x01")
+            ct = parts[1] if len(parts) > 1 else ""
+            an = parts[2] if len(parts) > 2 else ""
+            try:
+                current_ct = int(ct.strip())
+            except ValueError:
+                current_ct = 0
+            author_is_bot = an.strip() in BOT_AUTHORS
+        elif line.strip():
+            path = line.strip()
+            created[path] = current_ct  # last write wins -> oldest commit
+            if not author_is_bot and path not in newest_non_bot:
+                newest_non_bot[path] = current_ct
+    return newest_non_bot, created
+
+
+def run_git(repo: Path, args: list[str]) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=False
+    )
+    return proc.stdout
+
+
+# ---- Scoring -----------------------------------------------------------------
+
+
+def parse_day(s: str | None) -> date | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(str(s).replace("Z", "+00:00")).date()
+    except ValueError:
+        try:
+            return datetime.strptime(str(s), "%Y-%m-%d").date()
+        except ValueError:
+            return None
+
+
+def _ts_to_day(ts: int | None) -> date | None:
+    if not ts:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).date()
+
+
+def effective_last_review(
+    path: str,
+    entry: dict | None,
+    newest_non_bot: dict[str, int],
+    published: date | None,
+    created: dict[str, int],
+) -> date | None:
+    """The date the staleness clock is measured from.
+
+    max(completed bot review, newest human edit); an `incomplete` review does
+    not count, so the post stays due. Never-reviewed posts fall back to their
+    publish date (frontmatter `date`), then to the git creation date. None
+    only when the post has no usable date at all.
+    """
+    cands: list[date] = []
+    if entry:
+        reviewed = parse_day(entry.get("reviewed_at"))
+        if reviewed and entry.get("status") != INCOMPLETE_STATUS:
+            cands.append(reviewed)
+    human = _ts_to_day(newest_non_bot.get(path))
+    if human:
+        cands.append(human)
+    if cands:
+        return max(cands)
+    return published or _ts_to_day(created.get(path))
+
+
+def gsc_multiplier(
+    entry: dict | None, max_impressions: int | None, median_ctr: float | None
+) -> tuple[float, float]:
+    """(multiplier in [1, 1+GSC_BOOST_MAX], opportunity in [0, 1]).
+
+    Opportunity is impressions_n * ctr_gap: only the high-impressions AND
+    below-median-CTR quadrant boosts. Posts absent from the export or under
+    GSC_MIN_IMPRESSIONS are neutral.
+    """
+    if (
+        not entry
+        or entry["impressions"] < GSC_MIN_IMPRESSIONS
+        or not max_impressions
+        or not median_ctr
+    ):
+        return 1.0, 0.0
+    impressions_n = math.log1p(entry["impressions"]) / math.log1p(max_impressions)
+    ctr_gap = min(max(median_ctr - entry["ctr"], 0.0) / median_ctr, 1.0)
+    opportunity = min(impressions_n * ctr_gap, 1.0)
+    return 1.0 + GSC_BOOST_MAX * opportunity, round(opportunity, 4)
+
+
+def importance(
+    visits: int | None,
+    max_visits: int,
+    median_visits: int,
+    have_traffic: bool,
+    gsc_m: float = 1.0,
+) -> float:
+    """Traffic weight when a snapshot is available; neutral 1.0 otherwise."""
+    if have_traffic and max_visits > 0:
+        v = visits if visits is not None else median_visits
+        traffic_n = math.log1p(v) / math.log1p(max_visits)
+        return (0.5 + 0.5 * traffic_n) * gsc_m
+    return gsc_m
+
+
+def score_post(
+    visits: int | None,
+    max_visits: int,
+    median_visits: int,
+    last_review: date | None,
+    today: date,
+    have_traffic: bool,
+    gsc_m: float = 1.0,
+) -> float:
+    staleness = max((today - last_review).days, 0) if last_review else 0
+    return round(
+        importance(visits, max_visits, median_visits, have_traffic, gsc_m) * staleness,
+        4,
+    )
+
+
+# ---- Subcommands ---------------------------------------------------------------
+
+
+def cmd_stats(ledger_dir: Path) -> int:
+    entries = load_ledger(ledger_dir)
+    counts = {"reviewed": 0, "clean": 0, "skipped": 0,
+              "incomplete": 0, "capped": 0, "other": 0}
+    with_issues = 0
+    for path, entry in sorted(entries.items()):
+        status = entry.get("status")
+        if status == INCOMPLETE_STATUS:
+            counts["incomplete"] += 1
+            if int(entry.get("attempts", 0)) >= ATTEMPT_CAP:
+                counts["capped"] += 1
+            continue
+        if status in counts:
+            counts[status] += 1
+        else:
+            counts["other"] += 1
+        if int(entry.get("issues", 0)) > 0:
+            with_issues += 1
+    print(json.dumps({"entries": len(entries), "outcomes": counts,
+                      "posts_with_issues": with_issues}, indent=2))
+    return 0
+
+
+def cmd_prune(ledger_dir: Path, repo: Path, dry_run: bool) -> int:
+    pruned = []
+    for path, entry in load_ledger(ledger_dir).items():
+        if not (repo / path).is_file():
+            pruned.append(entry["_file"])
+            if not dry_run:
+                Path(entry["_file"]).unlink()
+    verb = "would prune" if dry_run else "pruned"
+    print(f"select-posts: {verb} {len(pruned)} orphaned ledger file(s)")
+    for f in pruned:
+        print(f"  {f}")
+    return 0
+
+
+# ---- Main ----------------------------------------------------------------------
+
+
+def write_github_output(queue: dict) -> None:
+    gh_out = os.environ.get("GITHUB_OUTPUT")
+    if not gh_out:
+        return
+    with open(gh_out, "a") as fh:
+        fh.write(f"has_posts={'true' if queue['posts'] else 'false'}\n")
+        fh.write(f"halted={queue.get('halted') or ''}\n")
+        fh.write(f"count={len(queue['posts'])}\n")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--count", type=int, default=5)
+    p.add_argument("--out", help="Queue JSON output path")
+    p.add_argument("--traffic-file", help="S3-fetched traffic snapshot (CSV or JSON)")
+    p.add_argument("--signals-file", help="S3-fetched reader-signals snapshot (JSON)")
+    p.add_argument("--ledger-dir", default=str(DEFAULT_LEDGER_DIR))
+    p.add_argument("--repo-root", default=str(REPO_ROOT), help=argparse.SUPPRESS)
+    p.add_argument("--paths", help="Comma-separated content paths; bypasses scoring (testing)")
+    p.add_argument("--lane", help="Override lane for --paths entries (default manual)")
+    p.add_argument("--today", help="Override today's date YYYY-MM-DD (testing)")
+    p.add_argument("--dry-run", action="store_true", help="Print queue, write nothing")
+    p.add_argument("--stats", action="store_true", help="Report ledger outcomes and exit")
+    p.add_argument("--prune", action="store_true", help="GC ledger entries for deleted posts")
+    args = p.parse_args()
+
+    repo = Path(args.repo_root)
+    ledger_dir = Path(args.ledger_dir)
+
+    if args.stats:
+        return cmd_stats(ledger_dir)
+    if args.prune:
+        return cmd_prune(ledger_dir, repo, args.dry_run)
+    if not args.out and not args.dry_run:
+        p.error("--out is required (or use --dry-run/--stats/--prune)")
+
+    today = parse_day(args.today) or datetime.now(timezone.utc).date()
+    ledger = load_ledger(ledger_dir)
+
+    all_paths = sorted(
+        str(f.relative_to(repo)) for f in (repo / CONTENT_DIR).glob("*/index.md")
+    )
+    known = set(all_paths)
+    frontmatter = {path: read_frontmatter(repo / path) for path in all_paths}
+
+    traffic, traffic_meta = load_traffic(
+        Path(args.traffic_file) if args.traffic_file else None, known
+    )
+    have_traffic = bool(traffic)
+    visits_known = sorted(traffic.values())
+    max_visits = visits_known[-1] if visits_known else 0
+    median_visits = visits_known[len(visits_known) // 2] if visits_known else 0
+
+    gsc, signals_meta = load_reader_signals(
+        Path(args.signals_file) if args.signals_file else None, known
+    )
+    signals_available = signals_meta["gsc"]["available"]
+
+    queue: dict = {
+        "generated": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "count": 0,
+        "halted": None,
+        "traffic": {**traffic_meta, "available": have_traffic},
+        "reader_signals": {"available": signals_available, **signals_meta},
+        "posts": [],
+    }
+
+    def signal_terms(path: str) -> tuple[float, dict | None]:
+        """(gsc_m, per-post signals block) — one source for both scoring and
+        the queue entry, so they can't diverge."""
+        if not signals_available:
+            return 1.0, None
+        gsc_entry = gsc.get(path)
+        gsc_m, opportunity = gsc_multiplier(
+            gsc_entry, signals_meta["gsc"]["max_impressions"], signals_meta["gsc"]["median_ctr"]
+        )
+        return gsc_m, {
+            "gsc": {
+                "impressions": gsc_entry["impressions"],
+                "ctr": gsc_entry["ctr"],
+                "opportunity": opportunity,
+                "multiplier": round(gsc_m, 4),
+            } if gsc_entry else None,
+        }
+
+    def post(path: str, lane: str, score: float | None) -> dict:
+        entry = ledger.get(path, {})
+        pub = publish_date(frontmatter.get(path, {}))
+        return {
+            "path": path,
+            "url": url_for(path),
+            "slug": slugify(path),
+            "lane": lane,
+            "post_date": pub.isoformat() if pub else None,
+            "monthly_visits": traffic.get(path),
+            "signals": signal_terms(path)[1],
+            "last_reviewed": entry.get("reviewed_at"),
+            "attempts": int(entry.get("attempts", 0)),
+            "score": score,
+        }
+
+    # --paths: explicit override, no scoring, no filters (testing path).
+    if args.paths:
+        lane = args.lane or "manual"
+        for raw in args.paths.split(","):
+            path = raw.strip()
+            if not path:
+                continue
+            if path not in known:
+                print(f"select-posts: --paths entry not found: {path}", file=sys.stderr)
+                return 1
+            queue["posts"].append(post(path, lane, None))
+        return finish(queue, args)
+
+    newest_non_bot, created = git_history_signals(repo)
+
+    candidates: list[str] = []
+    capped: list[str] = []
+    for path in all_paths:
+        fm = frontmatter.get(path, {})
+        if is_draft(fm):
+            continue
+        pub = publish_date(fm)
+        if pub and (today - pub).days < MIN_AGE_DAYS:
+            continue
+        entry = ledger.get(path)
+        if entry and entry.get("status") == INCOMPLETE_STATUS \
+                and int(entry.get("attempts", 0)) >= ATTEMPT_CAP:
+            capped.append(path)
+            continue
+        candidates.append(path)
+
+    if capped:
+        print(
+            f"select-posts: {len(capped)} post(s) backed off at the "
+            f"{ATTEMPT_CAP}-attempt cap (need a human): " + ", ".join(sorted(capped)[:10])
+            + (" ..." if len(capped) > 10 else ""),
+            file=sys.stderr,
+        )
+
+    def scored_entry(path: str) -> tuple[float, str]:
+        gsc_m, _ = signal_terms(path)
+        return (
+            score_post(
+                traffic.get(path),
+                max_visits,
+                median_visits,
+                effective_last_review(
+                    path, ledger.get(path), newest_non_bot,
+                    publish_date(frontmatter.get(path, {})), created,
+                ),
+                today,
+                have_traffic,
+                gsc_m=gsc_m,
+            ),
+            path,
+        )
+
+    scored = sorted(
+        (scored_entry(path) for path in candidates),
+        key=lambda t: (-t[0], t[1]),
+    )
+
+    for score, path in scored[: max(args.count, 0)]:
+        queue["posts"].append(post(path, "priority", score))
+
+    return finish(queue, args)
+
+
+def finish(queue: dict, args) -> int:
+    queue["count"] = len(queue["posts"])
+    body = json.dumps(queue, indent=2)
+    if args.dry_run or not args.out:
+        print(body)
+    else:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(body + "\n")
+        print(
+            f"select-posts: {queue['count']} post(s)"
+            + (f" (halted: {queue['halted']})" if queue["halted"] else "")
+            + f" → {out}",
+            file=sys.stderr,
+        )
+    write_github_output(queue)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/blog-review/test_select_posts.py
+++ b/scripts/blog-review/test_select_posts.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Tests for select-posts.py.
+
+Self-contained — run with `python3 test_select_posts.py` (no pytest dep).
+Builds a throwaway git repo with a miniature content/blog tree committed at
+controlled dates by human and bot authors, plus fixture ledger/traffic/signals
+files, and shells out to the script with `--today` (frozen clock), asserting
+on the queue JSON.
+
+The selector scores every post by `importance * staleness` and takes the top
+N. `staleness` is measured from `effective_last_review = max(completed bot
+review, newest non-bot commit)`, falling back to the post's frontmatter
+publish date — so with no traffic snapshot the queue is an
+oldest-unreviewed-first sweep. Fixture posts are dated deliberately:
+
+  published 2019-01-01  -> ~7.4 years stale at the 2026-06-12 clock
+  published 2022-01-01  -> ~4.4 years stale
+  published 2024-01-01  -> ~2.4 years stale
+  published 2026-05-01  -> 42 days old: excluded by the 90-day minimum age
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE / "select-posts.py"
+
+TODAY = "2026-06-12"
+
+_failures: list[str] = []
+_passes = 0
+
+
+def check(cond: bool, msg: str) -> None:
+    global _passes
+    if cond:
+        _passes += 1
+    else:
+        _failures.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def post_body(date: str, draft: bool = False) -> str:
+    fm = f"---\ntitle: T\ndate: {date}\n"
+    if draft:
+        fm += "draft: true\n"
+    fm += "---\n\nBody.\n"
+    return fm
+
+
+# slug -> publish date. All committed in one initial commit, so git history
+# is identical across them and ordering is driven by the frontmatter dates.
+BASE_POSTS = {
+    "ancient-post": "2019-01-01",
+    "old-post": "2022-01-01",
+    "middling-post": "2024-01-01",
+    "recent-post": "2026-05-01",  # < 90 days old at TODAY -> excluded
+}
+
+
+def git(repo: Path, *args: str, date: str | None = None,
+        name: str = "Human Author", email: str = "human@example.com") -> None:
+    env = {**os.environ, "GIT_AUTHOR_NAME": name, "GIT_AUTHOR_EMAIL": email,
+           "GIT_COMMITTER_NAME": name, "GIT_COMMITTER_EMAIL": email}
+    if date:
+        env["GIT_AUTHOR_DATE"] = date
+        env["GIT_COMMITTER_DATE"] = date
+    subprocess.run(["git", "-C", str(repo), *args], check=True, env=env,
+                   capture_output=True)
+
+
+def make_repo(tmp: Path) -> Path:
+    repo = tmp / "repo"
+    repo.mkdir(parents=True)
+    git(repo, "init", "-q")
+    git(repo, "config", "commit.gpgsign", "false")
+
+    for slug, date in BASE_POSTS.items():
+        f = repo / "content/blog" / slug / "index.md"
+        f.parent.mkdir(parents=True)
+        f.write_text(post_body(date))
+    # A draft post — never selectable.
+    d = repo / "content/blog/draft-post/index.md"
+    d.parent.mkdir(parents=True)
+    d.write_text(post_body("2020-01-01", draft=True))
+    # Seed commit is bot-authored so no post starts with a human edit: the
+    # staleness clock falls back to each post's frontmatter publish date,
+    # which is exactly the degraded age-based mode under test.
+    git(repo, "add", "-A", date="2026-01-01T00:00:00Z")
+    git(repo, "commit", "-q", "-m", "seed", date="2026-01-01T00:00:00Z",
+        name="pulumi-bot", email="bot@pulumi.com")
+
+    # A human edit to middling-post two days before TODAY: resets its clock,
+    # so its staleness drops from ~2.4 years to ~2 days.
+    f = repo / "content/blog/middling-post/index.md"
+    f.write_text(post_body("2024-01-01") + "\nHuman touch.\n")
+    git(repo, "add", "-A", date="2026-06-10T00:00:00Z")
+    git(repo, "commit", "-q", "-m", "human edit", date="2026-06-10T00:00:00Z")
+
+    # A bot edit to old-post at the same time: does NOT reset the clock.
+    f = repo / "content/blog/old-post/index.md"
+    f.write_text(post_body("2022-01-01") + "\nBot touch.\n")
+    git(repo, "add", "-A", date="2026-06-10T00:00:00Z")
+    git(repo, "commit", "-q", "-m", "bot edit", date="2026-06-10T00:00:00Z",
+        name="pulumi-bot", email="bot@pulumi.com")
+
+    return repo
+
+
+def run_select(repo: Path, *extra: str, ledger: Path | None = None,
+               gh_output: Path | None = None) -> dict:
+    out = repo / ".queue.json"
+    args = [sys.executable, str(SCRIPT), "--repo-root", str(repo),
+            "--today", TODAY, "--out", str(out)]
+    if ledger:
+        args += ["--ledger-dir", str(ledger)]
+    args += list(extra)
+    env = dict(os.environ)
+    env.pop("GITHUB_OUTPUT", None)
+    if gh_output:
+        env["GITHUB_OUTPUT"] = str(gh_output)
+    proc = subprocess.run(args, capture_output=True, text=True, env=env)
+    if proc.returncode != 0:
+        raise AssertionError(f"select-posts failed:\n{proc.stderr}")
+    return json.loads(out.read_text())
+
+
+def paths(queue: dict) -> list[str]:
+    return [p["path"] for p in queue["posts"]]
+
+
+def write_ledger(tmp: Path, entries: list[dict]) -> Path:
+    d = tmp / "ledger"
+    d.mkdir(parents=True, exist_ok=True)
+    for e in entries:
+        (d / f"{e['slug']}.json").write_text(json.dumps(e))
+    return d
+
+
+def test_age_based_sweep(tmp: Path) -> None:
+    print("test: degraded (no traffic) selection is an oldest-first sweep")
+    repo = make_repo(tmp / "t1")
+    q = run_select(repo, "--count", "10")
+    got = paths(q)
+    check(got[0] == "content/blog/ancient-post/index.md",
+          f"oldest post first, got {got}")
+    check(got[1] == "content/blog/old-post/index.md",
+          "bot edit does not reset the staleness clock")
+    check("content/blog/recent-post/index.md" not in got,
+          "posts younger than 90 days are excluded")
+    check("content/blog/draft-post/index.md" not in got,
+          "draft posts are excluded")
+    check(got[-1] == "content/blog/middling-post/index.md",
+          "a human edit resets the clock (sorts to the back)")
+    check(q["halted"] is None, "halted is null")
+    check(q["traffic"]["available"] is False, "traffic marked unavailable")
+    check(all(p["score"] is not None for p in q["posts"]), "scored entries carry scores")
+    check(q["posts"][0]["post_date"] == "2019-01-01", "post_date carried on the entry")
+
+
+def test_ledger_clock(tmp: Path) -> None:
+    print("test: ledger review advances the clock; incomplete does not; cap excludes")
+    repo = make_repo(tmp / "t2")
+    ledger = write_ledger(tmp / "t2", [
+        # Completed review of ancient-post yesterday -> drops to the back.
+        {"slug": "ancient-post", "path": "content/blog/ancient-post/index.md",
+         "status": "reviewed", "reviewed_at": "2026-06-11", "attempts": 0},
+        # Incomplete review of old-post -> clock NOT advanced, stays in front.
+        {"slug": "old-post", "path": "content/blog/old-post/index.md",
+         "status": "incomplete", "reviewed_at": "2026-06-11", "attempts": 1},
+    ])
+    q = run_select(repo, "--count", "10", ledger=ledger)
+    got = paths(q)
+    check(got[0] == "content/blog/old-post/index.md",
+          f"incomplete review leaves the post due, got {got}")
+    check(got[-1] == "content/blog/ancient-post/index.md",
+          "completed review resets the clock")
+    check(q["posts"][0]["attempts"] == 1, "attempts carried onto the queue entry")
+
+    ledger = write_ledger(tmp / "t2b", [
+        {"slug": "old-post", "path": "content/blog/old-post/index.md",
+         "status": "incomplete", "reviewed_at": "2026-06-11", "attempts": 3},
+    ])
+    q = run_select(repo, "--count", "10", ledger=ledger)
+    check("content/blog/old-post/index.md" not in paths(q),
+          "attempt-capped post is excluded")
+
+
+def test_traffic_and_gsc(tmp: Path) -> None:
+    print("test: traffic weights equally stale posts; GSC boost is boost-only")
+    repo = make_repo(tmp / "t3")
+    # Give every post the same publish date so staleness ties and importance
+    # decides. Rewrite dates, amend history in one commit.
+    for slug in BASE_POSTS:
+        (repo / "content/blog" / slug / "index.md").write_text(post_body("2020-01-01"))
+    git(repo, "add", "-A", date="2026-01-02T00:00:00Z")
+    git(repo, "commit", "-q", "-m", "level dates", date="2026-01-02T00:00:00Z",
+        name="pulumi-bot", email="bot@pulumi.com")
+
+    traffic = repo / ".traffic.json"
+    traffic.write_text(json.dumps({"pages": {
+        "/blog/old-post/": 50000,
+        "/blog/middling-post/": 500,
+        "/blog/recent-post/": 40,
+        # ancient-post absent -> imputes the median (500), never zero
+    }}))
+    q = run_select(repo, "--count", "10", "--traffic-file", str(traffic))
+    got = paths(q)
+    check(q["traffic"]["available"] is True, "traffic marked available")
+    check(got[0] == "content/blog/old-post/index.md",
+          f"high-traffic post ranks first among equally stale posts, got {got}")
+    entry = {p["slug"]: p for p in q["posts"]}
+    check(entry["old-post"]["monthly_visits"] == 50000, "visits carried on the entry")
+    check(entry["ancient-post"]["monthly_visits"] is None,
+          "absent post carries null visits (median imputed in scoring only)")
+    check(entry["ancient-post"]["score"] > entry["recent-post"]["score"],
+          "median imputation outranks a known-tiny-traffic equally stale post")
+
+    signals = repo / ".signals.json"
+    signals.write_text(json.dumps({"version": 1, "signals": {"gsc": {"pages": {
+        # High impressions, terrible CTR -> boosted.
+        "/blog/middling-post/": {"impressions": 30000, "clicks": 30},
+        # High impressions, great CTR -> neutral (never suppressed).
+        "/blog/old-post/": {"impressions": 30000, "clicks": 6000},
+        # Below the noise floor -> neutral.
+        "/blog/ancient-post/": {"impressions": 50, "clicks": 0},
+    }}}}))
+    q2 = run_select(repo, "--count", "10", "--traffic-file", str(traffic),
+                    "--signals-file", str(signals))
+    e2 = {p["slug"]: p for p in q2["posts"]}
+    check(q2["reader_signals"]["available"] is True, "signals marked available")
+    check(e2["middling-post"]["signals"]["gsc"]["multiplier"] > 1.0,
+          "high-impressions low-CTR post gets a boost")
+    check(e2["middling-post"]["score"] > entry["middling-post"]["score"],
+          "the boost raises the score vs the signal-blind run")
+    check(e2["old-post"]["score"] == entry["old-post"]["score"],
+          "good CTR is neutral, never a suppression")
+    check(e2["ancient-post"]["score"] == entry["ancient-post"]["score"],
+          "sub-noise-floor impressions are neutral")
+
+
+def test_paths_override_and_output(tmp: Path) -> None:
+    print("test: --paths bypasses scoring/filters; GITHUB_OUTPUT contract")
+    repo = make_repo(tmp / "t4")
+    gh_out = tmp / "t4" / "gh_output"
+    q = run_select(repo, "--paths", "content/blog/recent-post/index.md",
+                   gh_output=gh_out)
+    check(paths(q) == ["content/blog/recent-post/index.md"],
+          "--paths selects the named post even under the age filter")
+    check(q["posts"][0]["lane"] == "manual", "--paths entries default to manual lane")
+    check(q["posts"][0]["score"] is None, "--paths entries carry no score")
+    check(q["posts"][0]["slug"] == "recent-post", "slug is the bundle dir name")
+    check(q["posts"][0]["url"] == "/blog/recent-post/", "url derived from the bundle")
+    out = gh_out.read_text()
+    check("has_posts=true" in out and "count=1" in out and "halted=\n" in out,
+          f"GITHUB_OUTPUT contract, got: {out!r}")
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(repo), "--today", TODAY,
+         "--out", str(repo / ".q.json"), "--paths", "content/blog/nope/index.md"],
+        capture_output=True, text=True)
+    check(proc.returncode == 1, "unknown --paths entry fails loudly")
+
+
+def test_determinism(tmp: Path) -> None:
+    print("test: repeated runs produce identical ordering")
+    repo = make_repo(tmp / "t5")
+    a = paths(run_select(repo, "--count", "10"))
+    b = paths(run_select(repo, "--count", "10"))
+    check(a == b, "two identical runs, identical queues")
+    q = run_select(repo, "--count", "2")
+    check(len(q["posts"]) == 2 and q["count"] == 2, "--count truncates the queue")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        test_age_based_sweep(tmp)
+        test_ledger_clock(tmp)
+        test_traffic_and_gsc(tmp)
+        test_paths_override_and_output(tmp)
+        test_determinism(tmp)
+
+    if _failures:
+        print(f"\n{len(_failures)} failure(s), {_passes} passed", file=sys.stderr)
+        return 1
+    print(f"\nall select-posts tests passed ({_passes} checks)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/blog-review/validate-findings.py
+++ b/scripts/blog-review/validate-findings.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Validate a blog-review findings sentinel against the index contract.
+
+The review model's ONLY structured output is `.blog-review-findings.json`
+(shape documented in `.claude/commands/blog-review-index/SKILL.md` and
+`references/findings-schema.json`). This script is the deterministic gate
+between that model-written file and the S3 index: schema shape, the CLOSED
+issue taxonomy, evidence-required-per-issue, and agreement with the trusted
+queue entry. Invalid findings never reach the index — record-findings.py
+records the post `incomplete` instead (burning an attempt), so a model that
+free-styles the schema is retried rather than trusted.
+
+Importable (validate_findings) and runnable:
+
+    validate-findings.py --findings .blog-review-findings.json \
+        --queue .blog-review-queue.json
+
+Exit 0 when valid; exit 1 with one error per line on stderr otherwise.
+Run the built-in smoke checks with --self-test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+# The closed issue taxonomy. Definitions and the severity rubric live in
+# `.claude/commands/blog-review-index/references/issue-taxonomy.md`; the two
+# files must stay in sync — the reference documents what the model may emit,
+# this set is what the gate accepts.
+CATEGORIES = {
+    "factual-rot",
+    "dead-link",
+    "broken-code",
+    "deprecated-product",
+    "seo-thin",
+    "ai-positioning",
+    "frontmatter",
+    "rendering",
+}
+
+SEVERITIES = {"blocker", "major", "minor"}
+
+# Advisory noindex assessments (see references/noindex-rubric.md). The model
+# recommends; the future noindex process — with traffic thresholds a model
+# can't see — decides.
+ASSESSMENTS = {"keep", "candidate", "strong-candidate"}
+
+
+def _nonempty_str(v) -> bool:
+    return isinstance(v, str) and bool(v.strip())
+
+
+def validate_findings(findings, queue_post: dict) -> list[str]:
+    """Return a list of validation errors (empty when the findings are valid)."""
+    errors: list[str] = []
+    if not isinstance(findings, dict):
+        return ["findings must be a JSON object"]
+
+    if findings.get("schema_version") != SCHEMA_VERSION:
+        errors.append(
+            f"schema_version must be {SCHEMA_VERSION}, got {findings.get('schema_version')!r}"
+        )
+
+    # The path/slug must agree with the trusted queue entry — a findings file
+    # about a different post than the one selected is a broken run.
+    for key in ("path", "slug"):
+        if findings.get(key) != queue_post.get(key):
+            errors.append(
+                f"{key} mismatch: findings say {findings.get(key)!r}, "
+                f"queue says {queue_post.get(key)!r}"
+            )
+
+    issues = findings.get("issues")
+    if not isinstance(issues, list):
+        errors.append("issues must be a list")
+        issues = []
+
+    seen_ids: set[str] = set()
+    for i, issue in enumerate(issues):
+        where = f"issues[{i}]"
+        if not isinstance(issue, dict):
+            errors.append(f"{where} must be an object")
+            continue
+        iid = issue.get("id")
+        if not _nonempty_str(iid):
+            errors.append(f"{where}.id must be a non-empty string")
+        elif iid in seen_ids:
+            errors.append(f"{where}.id {iid!r} is duplicated")
+        else:
+            seen_ids.add(iid)
+        if issue.get("category") not in CATEGORIES:
+            errors.append(
+                f"{where}.category {issue.get('category')!r} is not in the "
+                f"closed taxonomy ({', '.join(sorted(CATEGORIES))})"
+            )
+        if issue.get("severity") not in SEVERITIES:
+            errors.append(
+                f"{where}.severity {issue.get('severity')!r} must be one of "
+                f"{', '.join(sorted(SEVERITIES))}"
+            )
+        if not _nonempty_str(issue.get("summary")):
+            errors.append(f"{where}.summary must be a non-empty string")
+        # Evidence is REQUIRED: an issue the model can't evidence is an
+        # opinion, and opinions don't get to drive noindex decisions.
+        if not _nonempty_str(issue.get("evidence")):
+            errors.append(f"{where}.evidence must be a non-empty string")
+        if not _nonempty_str(issue.get("location")):
+            errors.append(f"{where}.location must be a non-empty string")
+
+    clean = findings.get("clean")
+    if not isinstance(clean, bool):
+        errors.append("clean must be a boolean")
+    elif clean and issues:
+        errors.append("clean is true but issues is non-empty")
+    elif clean is False and not issues:
+        errors.append("clean is false but issues is empty")
+
+    signal = findings.get("noindex_signal")
+    if not isinstance(signal, dict):
+        errors.append("noindex_signal must be an object")
+    else:
+        if signal.get("assessment") not in ASSESSMENTS:
+            errors.append(
+                f"noindex_signal.assessment {signal.get('assessment')!r} must be "
+                f"one of {', '.join(sorted(ASSESSMENTS))}"
+            )
+        if not _nonempty_str(signal.get("rationale")):
+            errors.append("noindex_signal.rationale must be a non-empty string")
+        # A keep-worthy post shouldn't need a stronger-than-keep assessment
+        # with zero recorded issues: the assessment must be grounded in the
+        # issue list, not free-floating vibes.
+        if signal.get("assessment") == "strong-candidate" and not issues:
+            errors.append("noindex_signal.assessment strong-candidate requires issues")
+
+    return errors
+
+
+def load_queue_post(queue_path: Path) -> dict:
+    data = json.loads(queue_path.read_text())
+    posts = data.get("posts") or []
+    if not posts:
+        raise SystemExit(f"validate-findings: no posts in {queue_path}")
+    return posts[0]
+
+
+def self_test() -> int:
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+            print(f"FAIL: {name}", file=sys.stderr)
+        else:
+            print(f"ok: {name}")
+
+    post = {"path": "content/blog/p/index.md", "slug": "p"}
+    good = {
+        "schema_version": 1,
+        "path": "content/blog/p/index.md",
+        "slug": "p",
+        "issues": [{
+            "id": "dead-link-01", "category": "dead-link", "severity": "major",
+            "summary": "Link to example.com/docs 404s",
+            "evidence": "curl returns HTTP 404 as of the review run",
+            "location": "## Getting started, line 42",
+        }],
+        "clean": False,
+        "noindex_signal": {"assessment": "keep", "rationale": "content still current"},
+    }
+    check("valid findings pass", validate_findings(good, post) == [])
+
+    clean = {**good, "issues": [], "clean": True}
+    check("clean findings pass", validate_findings(clean, post) == [])
+
+    check("non-dict rejected", validate_findings([], post) != [])
+    check("schema_version enforced",
+          any("schema_version" in e for e in validate_findings({**good, "schema_version": 2}, post)))
+    check("path mismatch rejected",
+          any("path mismatch" in e for e in validate_findings({**good, "path": "content/blog/x/index.md"}, post)))
+    bad_cat = {**good, "issues": [{**good["issues"][0], "category": "vibes"}]}
+    check("open taxonomy rejected",
+          any("closed taxonomy" in e for e in validate_findings(bad_cat, post)))
+    bad_sev = {**good, "issues": [{**good["issues"][0], "severity": "catastrophic"}]}
+    check("unknown severity rejected",
+          any("severity" in e for e in validate_findings(bad_sev, post)))
+    no_evidence = {**good, "issues": [{**good["issues"][0], "evidence": "  "}]}
+    check("evidence required",
+          any("evidence" in e for e in validate_findings(no_evidence, post)))
+    dup = {**good, "issues": [good["issues"][0], good["issues"][0]]}
+    check("duplicate ids rejected",
+          any("duplicated" in e for e in validate_findings(dup, post)))
+    check("clean/issues consistency (clean+issues)",
+          any("clean is true" in e for e in validate_findings({**good, "clean": True}, post)))
+    check("clean/issues consistency (dirty+empty)",
+          any("clean is false" in e for e in validate_findings({**good, "issues": [], "clean": False}, post)))
+    check("noindex assessment enforced",
+          any("assessment" in e for e in validate_findings(
+              {**good, "noindex_signal": {"assessment": "nuke", "rationale": "r"}}, post)))
+    check("strong-candidate requires issues",
+          any("strong-candidate requires issues" in e for e in validate_findings(
+              {**clean, "noindex_signal": {"assessment": "strong-candidate", "rationale": "r"}}, post)))
+
+    if failures:
+        print(f"\n{len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nall validate-findings self-tests passed")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Validate a blog-review findings sentinel.")
+    p.add_argument("--findings", help="model findings sentinel (.blog-review-findings.json)")
+    p.add_argument("--queue", help="single-post queue JSON (.blog-review-queue.json)")
+    p.add_argument("--self-test", action="store_true", help="run built-in smoke checks")
+    args = p.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.findings or not args.queue:
+        p.error("--findings and --queue are required")
+
+    try:
+        findings = json.loads(Path(args.findings).read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"validate-findings: unreadable findings file: {e}", file=sys.stderr)
+        return 1
+    errors = validate_findings(findings, load_queue_post(Path(args.queue)))
+    for e in errors:
+        print(f"validate-findings: {e}", file=sys.stderr)
+    if errors:
+        return 1
+    print("validate-findings: findings are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Proposed changes

Introduces **blog-review-index** — the blog sibling of the daily existing-content review. A scheduled workflow reviews a few existing blog posts per weekday, selected deterministically by signal-weighted staleness, and records structured findings into an S3 **known-issues index**. The process is **flag-only**: no content edits, no per-post PRs. The index is evidence for a future, human-reviewed process that will mark rotted, low-value posts `block_external_search_index: true` (the site's existing per-page noindex knob) so search engines stop indexing them.

**Architecture** (mirrors the docs review's privilege split, in one workflow):

- `select` (credentialed, deterministic) — `scripts/blog-review/select-posts.py` scores `content/blog/*/index.md` by `importance × staleness`. With no blog traffic export yet, it degrades to an oldest-unreviewed-first sweep; it automatically picks up the `blogTrafficPageviewsLatestS3Uri` / `blogReaderSignalsLatestS3Uri` stack outputs when the data team ships them (both sources verified present in the warehouse: `fct_pageviews`, `fct_google_search_console_metrics`). Posts younger than 90 days are excluded; incomplete runs retry under a 3-attempt cap.
- `review` (unprivileged model, one matrix job per post, `max-parallel: 2`) — no ESC/AWS, `persist-credentials: false`, credential-free preflight. Pre-computes the docs-review claim pipeline (synthetic whole-file diff → claim extraction/verification, Vale, frontmatter, readthrough) as real workflow steps, then runs the new `.claude/commands/blog-review-index/SKILL.md`. The model's only output is `.blog-review-findings.json`; a tracked-file change marks the run dirty and invalidates it.
- `record` (credentialed, deterministic, no model) — `validate-findings.py` gates every findings file (schema, **closed issue taxonomy** of `factual-rot` / `dead-link` / `broken-code` / `deprecated-product` / `seo-thin` / `ai-positioning` / `frontmatter` / `rendering`, evidence required per issue); `record-findings.py` writes ledger + index + immutable run-log objects under the `blog-review/` prefix of the existing content-review bucket; `build-summary.py` rebuilds `index/_summary.json` (corpus totals + the current noindex-candidate list).

**Controls**: `BLOG_REVIEW_COUNT` repo variable (unset = 5 posts/run ≈ 7-month sweep of ~800 posts, `'0'` = off), `workflow_dispatch` with `count` / `dry_run` / `paths`, holiday-check fail-open, cron offset (14:30 UTC) from the docs review and check-links.

**Testing**: `test_select_posts.py` (32 checks: age-based sweep, human-vs-bot clock resets, ledger/attempt-cap behavior, traffic + GSC boost-only scoring, `--paths`, `GITHUB_OUTPUT` contract, determinism) plus `--self-test` suites in `validate-findings.py`, `record-findings.py`, and `build-summary.py`; all pass, `make lint` markdown + prettier clean.

**Follow-ups (not in this PR)**:

1. File the data-team request in `pulumi/data` (sibling of pulumi/data#873): blog slices of the pageviews/GSC exports **and** warehouse ingestion of the `blog-review/` prefix (run logs are date-partitioned, `schema_version`-stamped for that purpose).
1. A degradation-health lane (signal-health-style Slack alerting) once the exports exist to degrade.
1. The noindex decision process itself, consuming `index/_summary.json`.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Follows the architecture of `review-existing-content.yml` / `content-review-article.yml`. Warehouse-ingestion precedent: pulumi/data#873.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4m5VLFgGFbpvx9R2pF8eP

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4m5VLFgGFbpvx9R2pF8eP)_