### PR TITLE
claim pre-step: resolve scrutiny per file; pin small edits to changed-lines scope

### DIFF
--- a/.claude/commands/docs-review/references/blog.md
+++ b/.claude/commands/docs-review/references/blog.md
@@ -5,7 +5,7 @@ description: Review criteria for blog posts and customer stories. Fact-check-fir
 
 # Review — Blog
 
-Applied to blog posts (`content/blog/`) and customer stories (`content/case-studies/`). These are usually drafted whole-file (often with AI assistance) rather than edited incrementally, so scrutiny is `heightened` by default and the whole file is in scope. On this whole-file path, a pre-computed `readthrough` coherence pass (`docs-review:references:readthrough`) reads the post end to end and surfaces anchored structural defects as `🚩 flagged` findings in your buckets — triage each with the standard two-question test.
+Applied to blog posts (`content/blog/`) and customer stories (`content/case-studies/`). These are usually drafted whole-file (often with AI assistance) rather than edited incrementally, so scrutiny is `heightened` by default and the whole file is in scope. (Small incremental edits to an already-published post are the exception: the claim pre-step extracts from the changed lines only -- see `docs-review:references:fact-check` §Scope.) On this whole-file path, a pre-computed `readthrough` coherence pass (`docs-review:references:readthrough`) reads the post end to end and surfaces anchored structural defects as `🚩 flagged` findings in your buckets — triage each with the standard two-question test.
 
 > **Fact-check-first treatment.** Fact-check is the headline finding bucket. Get it right before commenting on AI-writing patterns or structure.
 

--- a/.claude/commands/docs-review/references/fact-check.md
+++ b/.claude/commands/docs-review/references/fact-check.md
@@ -81,6 +81,8 @@ Workflow pre-step: `extract-claims.py` (a deterministic regex floor — numbers,
 - Default (`scrutiny=standard`): extract claims from the diff only -- lines added or modified
 - `scrutiny=heightened`: extract claims from the **full file**, not just the diff. AI hallucinates surrounding prose, not just changed lines.
 
+The Layer-B pre-step (`extract-claims-llm.py`) resolves scrutiny **per file**: blog files and brand-new files bump to `heightened`; high-similarity renames and small edits to existing files (≤30 added lines and ≤20% of the body) pin back to `standard` -- the added lines still get extracted, the already-published unchanged body doesn't. Each pin is surfaced as a note in the artifact's `errors[]`.
+
 ### Frontmatter sweep
 
 Hugo posts duplicate the same load-bearing phrasing across the body, `meta_desc`, and `social:` sub-keys (`twitter`, `linkedin`, `bluesky`). When extracting a claim from any of these locations, scan the rest of the file -- body plus every prose-bearing frontmatter key -- for the same factual phrasing or a near-paraphrase, and treat all occurrences as one claim with multiple cited locations. A single finding then renders one suggestion-block per location, so a verified-false claim is fixed everywhere in one pass.

--- a/.claude/commands/docs-review/scripts/extract-claims-llm.py
+++ b/.claude/commands/docs-review/scripts/extract-claims-llm.py
@@ -110,6 +110,18 @@ RENAME_TO_RE = re.compile(r"^rename to (.+)$")
 # correctly demote to `not-a-claim — unchanged`.
 RENAME_BODY_SKIP_THRESHOLD = 95
 
+# Blog prose defaults to full-file (heightened) extraction — posts are usually
+# drafted whole-file, often with AI assistance, and AI hallucinates surrounding
+# prose, not just changed lines. That rationale doesn't hold for a small edit
+# to an already-published post: the unchanged body was reviewed at publish
+# time, and full-file extraction re-litigates it at ~dozens of claims per
+# file. (PR #20224: a 3-line CTA insert into 75 posts → 1,080 verified claims
+# → the 25-minute job timeout.) Pin such edits to `standard` (changed-lines)
+# scope when BOTH bounds hold — the added prose itself still gets extracted.
+SMALL_EDIT_MAX_ADDED_LINES = 30    # demote when added lines ≤ this ...
+SMALL_EDIT_MAX_ADDED_RATIO = 0.20  # ... AND added / file body lines ≤ this
+BLOG_PREFIX = "content/blog/"
+
 # Claim types the schema allows — kept in sync with references/claim-extraction.md.
 CLAIM_TYPES = [
     "numerical", "version", "temporal", "feature", "behavior", "api-surface",
@@ -344,6 +356,11 @@ def changed_line_ranges(patch: str, target: str) -> list[str]:
     return [f"L{a}" if a == b else f"L{a}-{b}" for a, b in ranges]
 
 
+def added_line_count(patch: str, target: str) -> int:
+    """Number of added (`+`) lines in this file's hunks."""
+    return sum(1 for raw in _file_patch_lines(patch, target) if raw.startswith("+"))
+
+
 def numbered_hunks(patch: str, target: str) -> str:
     """The file's diff hunks with new-file line numbers prefixed on +/context lines.
 
@@ -412,11 +429,19 @@ def number_lines(text: str) -> str:
 
 
 def build_user_message(repo_root: Path, patch: str, path: str, scrutiny: str) -> tuple[str, str | None]:
-    """Return (user_message_text, note) for one file. `note` is a non-fatal warning, if any."""
+    """Return (user_message_text, note) for one file. `note` is a non-fatal warning, if any.
+
+    Scrutiny is resolved per file: the `--scrutiny` flag is the global default
+    (`heightened` acts as a force-override for testing/manual runs), and the
+    guards below bump or pin each file's effective scope from there.
+    """
     effective = scrutiny
     note = None
-    if scrutiny == "standard" and is_new_file(patch, path):
+    new_file = is_new_file(patch, path)
+    if scrutiny == "standard" and new_file:
         effective = "heightened"  # a brand-new file: extract from the whole thing
+    if scrutiny == "standard" and path.startswith(BLOG_PREFIX):
+        effective = "heightened"  # blog prose: full-file by default (see small-edit guard below)
 
     # Pure-rename guard: a high-similarity rename's body carries no *new* claims —
     # only the diff hunks (frontmatter changes etc.) do. Pin scope to the hunks
@@ -428,9 +453,23 @@ def build_user_message(repo_root: Path, patch: str, path: str, scrutiny: str) ->
         effective = "standard"
 
     file_path = repo_root / path
+    file_text = file_path.read_text(encoding="utf-8", errors="replace") if file_path.is_file() else None
+
+    # Small-edit guard: a per-file `heightened` bump on an *existing* file whose
+    # diff adds only a few lines pins back to `standard` — the added prose still
+    # gets extracted, the long-since-reviewed unchanged body doesn't. Never
+    # applies to new files or under a global `--scrutiny heightened` override.
+    if scrutiny == "standard" and effective == "heightened" and not new_file and file_text is not None:
+        added = added_line_count(patch, path)
+        body_lines = len(file_text.splitlines()) or 1
+        if 0 < added <= SMALL_EDIT_MAX_ADDED_LINES and added / body_lines <= SMALL_EDIT_MAX_ADDED_RATIO:
+            note = (f"{path} is a small edit ({added} added line(s), {body_lines}-line file) — "
+                    f"extracting from the diff hunks only (unchanged body skipped)")
+            effective = "standard"
+
     if effective == "heightened":
-        if file_path.is_file():
-            numbered = number_lines(file_path.read_text(encoding="utf-8", errors="replace"))
+        if file_text is not None:
+            numbered = number_lines(file_text)
             changed = changed_line_ranges(patch, path)
             changed_note = (
                 f"This PR added/modified these line ranges: {', '.join(changed)}."
@@ -646,7 +685,9 @@ def main() -> int:
     p.add_argument("--changed-files", help="Comma-separated content/**/*.md paths (testing; overrides PR-derived list)")
     p.add_argument("--repo-root", default=".", help="Repo root (default: cwd)")
     p.add_argument("--pass", dest="pass_name", required=True, choices=["atomic", "holistic"])
-    p.add_argument("--scrutiny", default="standard", choices=["standard", "heightened"])
+    p.add_argument("--scrutiny", default="standard", choices=["standard", "heightened"],
+                   help="Global default; per-file guards bump blog/new files to heightened and pin "
+                        "renames/small edits back to standard. `heightened` forces full-file everywhere.")
     p.add_argument("--model", default=DEFAULT_MODEL)
     p.add_argument("--out", required=True, help="Output JSON path")
     p.add_argument("--dry-run", action="store_true", help="Don't call the API; emit placeholder claims (testing)")
@@ -687,6 +728,10 @@ def main() -> int:
 
     skipped_over_cap: list[str] = []
     if len(files) > FILE_CAP:
+        # Spend the cap on the biggest edits first (stable sort keeps the
+        # original order for ties), so a bulk PR's one substantive rewrite
+        # isn't crowded out of Layer B by dozens of small mechanical edits.
+        files.sort(key=lambda f: -added_line_count(patch, f))
         skipped_over_cap = files[FILE_CAP:]
         files = files[:FILE_CAP]
 

--- a/.claude/commands/docs-review/scripts/test_extract_claims.py
+++ b/.claude/commands/docs-review/scripts/test_extract_claims.py
@@ -7,13 +7,15 @@ JSON they emit. Fixtures in `testdata/` are committed deterministic diffs of
 real merged pulumi/docs PRs (#18771, #18743, #18541) — corpus-drawn cases of
 the run-to-run-fragile claim shapes the regex floor must guarantee.
 
-(extract-claims-llm.py isn't tested here — it needs ANTHROPIC_API_KEY and is
-spike-tested in CI; merge-claims.py is tested against hand-crafted Layer-B
-inputs below.)
+(extract-claims-llm.py's API paths need ANTHROPIC_API_KEY and are spike-tested
+in CI; its per-file scrutiny resolution and file-cap ordering ARE tested here,
+via module import and --dry-run. merge-claims.py is tested against
+hand-crafted Layer-B inputs below.)
 """
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
@@ -22,6 +24,7 @@ from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 EXTRACT = HERE / "extract-claims.py"
+EXTRACT_LLM = HERE / "extract-claims-llm.py"
 MERGE = HERE / "merge-claims.py"
 TESTDATA = HERE / "testdata"
 
@@ -367,6 +370,101 @@ def test_merge_missing_and_error_inputs() -> None:
               f"merge: llm-only should yield the 1 llm claim; got {m['claims']}")
 
 
+# ---- extract-claims-llm.py: per-file scrutiny + file-cap ordering -------------
+
+def _llm_mod():
+    spec = importlib.util.spec_from_file_location("extract_claims_llm", EXTRACT_LLM)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_llm_scrutiny_per_file() -> None:
+    print("test_llm_scrutiny_per_file (blog bump, small-edit pin, ratio bound, override, new file)")
+    m = _llm_mod()
+    blog = "content/blog/some-post/index.md"
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        f = root / blog
+        f.parent.mkdir(parents=True)
+        f.write_text("\n".join(f"body line {i}" for i in range(1, 101)) + "\n")
+
+        # A 3-line insert into a 100-line published post: bumped for being blog,
+        # then pinned back to standard by the small-edit guard.
+        small = _mk_patch(blog, ["{{< blog/cta-card >}}", "Two lines of new prose.", "{{< /blog/cta-card >}}"])
+        msg, note = m.build_user_message(root, small, blog, "standard")
+        check("scope: standard" in msg, "llm-scrutiny: small blog edit pins to standard scope")
+        check(note is not None and "small edit" in note, f"llm-scrutiny: small-edit pin surfaces a note; got {note!r}")
+
+        # 40 added lines: over the absolute bound — stays heightened.
+        big = _mk_patch(blog, [f"New prose line {i}." for i in range(40)])
+        msg, _ = m.build_user_message(root, big, blog, "standard")
+        check("WHOLE file" in msg, "llm-scrutiny: 40-line blog edit stays heightened")
+
+        # 25 added lines: under the absolute bound but >20% of a 100-line file — stays heightened.
+        mid = _mk_patch(blog, [f"New prose line {i}." for i in range(25)])
+        msg, _ = m.build_user_message(root, mid, blog, "standard")
+        check("WHOLE file" in msg, "llm-scrutiny: 25 added lines in a 100-line file (>20%) stays heightened")
+
+        # Global --scrutiny heightened is a force-override: no small-edit pin.
+        msg, _ = m.build_user_message(root, small, blog, "heightened")
+        check("WHOLE file" in msg, "llm-scrutiny: global heightened override defeats the small-edit pin")
+
+    # A docs file's small edit under standard scrutiny: no blog bump, standard scope.
+    docs = "content/docs/x/page.md"
+    with tempfile.TemporaryDirectory() as td:
+        msg, note = m.build_user_message(Path(td), _mk_patch(docs, ["One new line."]), docs, "standard")
+        check("scope: standard" in msg and note is None,
+              f"llm-scrutiny: docs small edit is standard scope with no note; got note={note!r}")
+
+    # A brand-new blog file: heightened even though tiny (small-edit pin skips new files).
+    new_blog = "content/blog/new-post/index.md"
+    new_patch = (
+        f"diff --git a/{new_blog} b/{new_blog}\n"
+        "new file mode 100644\n"
+        "--- /dev/null\n"
+        f"+++ b/{new_blog}\n"
+        "@@ -0,0 +1,3 @@\n"
+        "+---\n"
+        "+title: New post\n"
+        "+---\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        nf = root / new_blog
+        nf.parent.mkdir(parents=True)
+        nf.write_text("---\ntitle: New post\n---\n")
+        msg, _ = m.build_user_message(root, new_patch, new_blog, "standard")
+        check("WHOLE file" in msg, "llm-scrutiny: brand-new blog file stays heightened despite being tiny")
+
+
+def test_llm_file_cap_prefers_biggest_edits() -> None:
+    print("test_llm_file_cap_prefers_biggest_edits")
+    files = [f"content/docs/x/f{i:02}.md" for i in range(20)] + ["content/docs/x/big.md"]
+    patch = "".join(_mk_patch(f, ["One added line."]) for f in files[:20])
+    patch += _mk_patch("content/docs/x/big.md", [f"Added line {i}." for i in range(10)])
+    with tempfile.TemporaryDirectory() as td:
+        pf = Path(td) / "p.patch"
+        pf.write_text(patch)
+        out = Path(td) / "out.json"
+        # The script loads its system prompt from the repo root before the
+        # dry-run short-circuit; give the tmp root a stub copy.
+        ref = Path(td) / ".claude/commands/docs-review/references/claim-extraction.md"
+        ref.parent.mkdir(parents=True)
+        ref.write_text("stub system prompt\n")
+        r = subprocess.run([sys.executable, str(EXTRACT_LLM), "--patch-file", str(pf),
+                            "--changed-files", ",".join(files), "--repo-root", td,
+                            "--pass", "atomic", "--dry-run", "--out", str(out)],
+                           capture_output=True, text=True)
+        check(r.returncode == 0, f"llm cap: exits 0 (stderr: {r.stderr.strip()[:200]})")
+        doc = json.loads(out.read_text())
+        kept = {c["file"] for c in doc["claims"]}
+        check("content/docs/x/big.md" in kept, "llm cap: the biggest edit survives the file cap")
+        check(len(kept) == 20, f"llm cap: exactly FILE_CAP files processed; got {len(kept)}")
+        check(any("over file cap" in e for e in doc["errors"]),
+              f"llm cap: over-cap skip is surfaced in errors[]; got {doc['errors'][:2]}")
+
+
 # ---- main ---------------------------------------------------------------------
 
 def main() -> int:
@@ -390,6 +488,8 @@ def main() -> int:
         test_merge_dedup_and_provenance,
         test_merge_line_anchor_clamps_out_of_bounds,
         test_merge_missing_and_error_inputs,
+        test_llm_scrutiny_per_file,
+        test_llm_file_cap_prefers_biggest_edits,
     ]
     for t in tests:
         try:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -592,23 +592,6 @@ jobs:
       # All steps continue-on-error with schema-matching `||` stubs; the scripts'
       # safe_main() surfaces failures *inside* the artifact (`errors: [...]`),
       # not via file-presence heuristics.
-      - name: Pre-compute claim scrutiny scope
-        if: steps.pr-context.outputs.skip_reason == ''
-        id: claim-scrutiny
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.pr-context.outputs.pr_number }}
-        run: |
-          # `heightened` (full-file extraction) when any blog file changed —
-          # AI hallucinates surrounding prose, not just changed lines. Per-file
-          # new-file bumping happens inside extract-claims-llm.py.
-          BLOG=$(gh pr diff "$PR" --name-only | grep -E '^content/blog/.*\.md$' || true)
-          if [ -n "$BLOG" ]; then
-            echo "value=heightened" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=standard" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Extract candidate claims (Layer A — regex floor)
         if: steps.pr-context.outputs.skip_reason == ''
         id: extract-claims-regex
@@ -629,7 +612,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PR: ${{ steps.pr-context.outputs.pr_number }}
-          SCRUTINY: ${{ steps.claim-scrutiny.outputs.value }}
         run: |
           # Run the two Sonnet extraction passes concurrently — wall-clock
           # collapses from sum(atomic + holistic) to max(atomic, holistic).
@@ -637,13 +619,15 @@ jobs:
           # independently. Per pre-step fallback discipline, failure is
           # surfaced INSIDE the artifact (errors: [...]), not via a
           # missing-file or silent-empty heuristic.
+          # Scrutiny is resolved per file inside the script (blog/new files
+          # bump to heightened; renames and small edits pin to standard).
           set +e
           python3 .claude/commands/docs-review/scripts/extract-claims-llm.py \
-            --pr "$PR" --pass atomic --scrutiny "${SCRUTINY:-standard}" \
+            --pr "$PR" --pass atomic --scrutiny standard \
             --out .candidate-claims-llm-1.json &
           ATOMIC_PID=$!
           python3 .claude/commands/docs-review/scripts/extract-claims-llm.py \
-            --pr "$PR" --pass holistic --scrutiny "${SCRUTINY:-standard}" \
+            --pr "$PR" --pass holistic --scrutiny standard \
             --out .candidate-claims-llm-2.json &
           HOLISTIC_PID=$!
           wait "$ATOMIC_PID";   ATOMIC_RC=$?


### PR DESCRIPTION
## What

The Layer-B claim-extraction pre-step used a PR-global scrutiny flag: one changed blog file put **every** file in the PR on heightened (full-file) claim extraction. On bulk mechanical PRs this is pathological — #20224 (a 3-line CTA insert into ~75 published posts) extracted 1,902 LLM claims, verified 1,080, and drove the `claude-review` job into its 25-minute timeout on every attempt, so it cycles `review:in-progress` → `review:error` and never publishes a pinned review.

This PR resolves scrutiny **per file** inside `extract-claims-llm.py`, following the existing per-file guard pattern (new-file bump, pure-rename pin):

- `content/blog/` files still bump to heightened, but a **small edit to an existing file** (≤30 added lines AND ≤20% of the body) pins back to `standard` scope. The added lines still get extracted and verified; the already-published unchanged body doesn't get re-litigated. New files and the global `--scrutiny heightened` override are exempt from the pin, and each pin is surfaced as a note in the artifact's `errors[]`.
- The workflow's PR-global scrutiny grep is removed. Side effect fixed: one blog file no longer drags co-changed docs files into full-file extraction.
- When a PR exceeds the 20-file Layer-B cap, the cap is now spent on the **biggest edits first** (stable sort by added-line count) instead of file-list order, so a bulk PR's one substantive rewrite isn't crowded out by dozens of mechanical edits.

`references/fact-check.md` §Scope and `references/blog.md` document the new per-file resolution.

## Validation

- `test_extract_claims.py`: 62 checks pass, including new coverage for the blog bump, the small-edit pin (both bounds), the heightened force-override, the new-file exemption, and cap ordering.
- Dry-run against the real #20224 diff: all 20 capped files pin to standard scope with a note in `errors[]`.

## Notes

Deliberate behavior change: a blog post whose diff is a small incremental edit is no longer full-file fact-checked — extraction covers the changed lines only. The heightened rationale ("posts are drafted whole-file, often with AI assistance") doesn't apply to a small edit of an already-reviewed post.

This fixes the bulk-mechanical class of review timeouts (#20224). The generated-corpus class (#20274, ~100K generated lines overwhelming the main review step itself) is a separate triage-lane change and not addressed here.