### PR TITLE
Qualify automatic policy remediation as Business Critical

### DIFF
--- a/content/docs/insights/discovery/connect-cloud-accounts.md
+++ b/content/docs/insights/discovery/connect-cloud-accounts.md
@@ -107,7 +107,7 @@ The wizard shows how many accounts, subscriptions, or projects it discovered and
 
 The access level determines which permissions Pulumi receives in each account:
 
-- **Build & Manage (read and write)**: the default. Enables [Pulumi Neo](/docs/ai/), infrastructure as code, deployments, and policies that remediate issues automatically. Grants `AdministratorAccess` in AWS, **Contributor** in Azure, or **Editor** in Google Cloud.
+- **Build & Manage (read and write)**: the default. Enables [Pulumi Neo](/docs/ai/), infrastructure as code, deployments, and policies that remediate issues automatically (Business Critical edition). Grants `AdministratorAccess` in AWS, **Contributor** in Azure, or **Editor** in Google Cloud.
 - **Discovery & Policy (read-only)**: limited to discovery scanning and inventory. Pulumi can't modify your infrastructure. Grants `ReadOnlyAccess` in AWS, **Reader** in Azure, or **Viewer** in Google Cloud.
 
 Select **Change access level** to switch the default, or set a different level for individual accounts under **Per account access**. If your security review requires it, start with read-only access; you can raise access for specific accounts later.


### PR DESCRIPTION
## Why

The Connect cloud accounts wizard docs (#20135) describe the Build & Manage access level as enabling "policies that remediate issues automatically" without a plan qualifier. Per the pricing page, the Remediation enforcement mode is Business Critical only — Team and Enterprise get Advisory & Mandatory (`content/pricing/_index.md`, Enforcement Modes row). The launch blog post (#20204) already carries the qualifier; this aligns the docs page with pricing and the post.

## What

- One line: add "(Business Critical edition)" to the remediation clause in the Build & Manage bullet on `/docs/insights/discovery/connect-cloud-accounts/`.

## Testing

- `make lint` passes (Markdown lint: 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)