### PR TITLE
Fix outdated left-nav path to the Accounts page

### DIFF
--- a/content/blog/connect-your-cloud-accounts-to-pulumi-in-minutes/index.md
+++ b/content/blog/connect-your-cloud-accounts-to-pulumi-in-minutes/index.md
@@ -49,7 +49,7 @@ The wizard handles the entire onboarding lifecycle for AWS, Microsoft Azure, and
 
 ## How it works
 
-The wizard walks you through five steps: choose a provider, authenticate, select accounts, configure discovery and policy, and review the results. You can open it from **Insights** > **Accounts** in the Pulumi Cloud console, or from the **Get to know Pulumi** card on the home dashboard.
+The wizard walks you through five steps: choose a provider, authenticate, select accounts, configure discovery and policy, and review the results. You can open it from **Management** > **Accounts** in the Pulumi Cloud console, or from the **Get to know Pulumi** card on the home dashboard.
 
 Authentication uses each provider's native federation mechanism: IAM Identity Center (SSO) for AWS, Microsoft Entra ID workload identity federation for Azure, and Workload Identity Federation for Google Cloud. After you sign in, the wizard discovers the accounts in your organization and pre-selects everything that isn't already connected. You can search, select all, or toggle individual accounts.
 
@@ -78,7 +78,7 @@ For security reviewers, the docs include a full accounting of [what the wizard c
 
 The Connect cloud accounts wizard is available now for all Pulumi Cloud organizations. To connect your first accounts:
 
-1. Navigate to [**Insights** > **Accounts**](https://app.pulumi.com/) in the Pulumi Cloud console and select **Connect cloud accounts**.
+1. Navigate to [**Management** > **Accounts**](https://app.pulumi.com/) in the Pulumi Cloud console and select **Connect cloud accounts**.
 1. Follow the guided flow for AWS, Azure, or Google Cloud.
 1. Explore your [discovered resources](/docs/insights/discovery/search/) and [policy findings](/docs/insights/policy/policy-findings/).
 

--- a/content/docs/insights/discovery/accounts.md
+++ b/content/docs/insights/discovery/accounts.md
@@ -26,7 +26,7 @@ To onboard many AWS, Azure, or Google Cloud accounts at once, use the [Connect c
 
 ## Account creation
 
-1. After logging into the Pulumi Cloud Console, navigate to **Insights** > **Accounts**.  
+1. After logging into the Pulumi Cloud Console, navigate to **Management** > **Accounts**.  
 1. On this page, select the **Connect cloud accounts** button to open the connection wizard.  
 1. Select your provider.
 {{< notes type="info" >}}  

--- a/content/docs/insights/discovery/connect-cloud-accounts.md
+++ b/content/docs/insights/discovery/connect-cloud-accounts.md
@@ -27,7 +27,7 @@ Resource scans and policy evaluations consume workflow minutes and can incur cha
 
 You can open the wizard from two places in the Pulumi Cloud console:
 
-- Navigate to **Insights** > **Accounts** and select **Connect cloud accounts**.
+- Navigate to **Management** > **Accounts** and select **Connect cloud accounts**.
 - On the home dashboard, select the **Connect cloud accounts** task on the **Get to know Pulumi** card.
 
 The wizard opens as a panel and walks you through the onboarding steps.

--- a/content/docs/insights/discovery/get-started/create-accounts.md
+++ b/content/docs/insights/discovery/get-started/create-accounts.md
@@ -22,7 +22,7 @@ Currently while in public preview, Pulumi Insights Account discovery supports AW
 
 ## Create an Insights account
 
-1. Navigate to **Insights** > **Accounts** in the Pulumi Cloud console. You will be directed to the Accounts landing page where you'll be able to create and manage all your Insights accounts and view scan statuses.
+1. Navigate to **Management** > **Accounts** in the Pulumi Cloud console. You will be directed to the Accounts landing page where you'll be able to create and manage all your Insights accounts and view scan statuses.
 
 1. Select **Connect cloud accounts** and choose your cloud provider. For this example, choose **AWS**.
 


### PR DESCRIPTION
The Accounts page moved in the Pulumi Cloud console left nav: it's now **Management** > **Accounts**, not **Insights** > **Accounts**. This updates the five remaining references to the old path.

## Changes
- `content/docs/insights/discovery/connect-cloud-accounts.md` — wizard prerequisites nav step
- `content/docs/insights/discovery/accounts.md` — account creation nav step
- `content/docs/insights/discovery/get-started/create-accounts.md` — get-started nav step
- `content/blog/connect-your-cloud-accounts-to-pulumi-in-minutes/index.md` — launch blog (two references)

The correct path already appears in `content/docs/insights/self-hosted.md`, which was used as the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)