### PR TITLE
Event meta-image skill: opt-in buttons, unattended mode, eval + author guide

### DIFF
--- a/.claude/commands/event-meta-image/SKILL.md
+++ b/.claude/commands/event-meta-image/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: event-meta-image
-description: "Generate on-brand social cards for a Pulumi event/workshop in five sizes (1200x628 OG, 1200x675, 628x628, 1080x1080, 540x960) using the shared Satori events renderer. Enriches the build-time default with people not in frontmatter (external co-presenters + their photos) and company/partner logos (Pulumi + e.g. Microsoft). Runs event-bound (writes into a content/events/<slug>/ bundle + sets meta_image / meta_image_square) or standalone (just emit the five PNGs to a folder). Use when the user types /event-meta-image or asks to create, generate, regenerate, or enrich an event's meta image, social card, OpenGraph image, or speaker/workshop card."
+description: "Generate on-brand social cards for a Pulumi event/workshop in five sizes (1200x628 OG, 1200x675, 628x628, 1080x1080, 540x960) using the shared Satori events renderer. Enriches the build-time default with people not in frontmatter (external co-presenters + their photos) and company/partner logos (Pulumi + e.g. Microsoft). Runs event-bound (writes into a content/events/<slug>/ bundle + sets meta_image / meta_image_square) or standalone (just emit the five PNGs to a folder). Use when the user types /event-meta-image or asks to create, generate, regenerate, or enrich an event's meta image, social card, OpenGraph image, or speaker/workshop card. Pass -y / --yes / --non-interactive (or 'no questions') to run end-to-end with sensible defaults and no prompts. A Register button is never added unless explicitly requested."
 ---
 
 # `/event-meta-image` — Generate event / workshop social cards
@@ -10,7 +10,7 @@ You generate the branded event card (the Figma "Workshop / event images" compone
 **Skill directory**: `.claude/commands/event-meta-image/` — paths below are relative to the **repo root** unless noted.
 **Renderer CLI**: `scripts/meta-images/render-event.mjs` (shared with the build). One JSON config → one PNG per size.
 
-> **You do not need a custom card for most events.** Every event already gets an on-brand landscape + square card automatically at build time from its frontmatter (`scripts/generate-meta-images.mjs`). Use this skill only to (a) enrich a card with people/logos not in frontmatter, (b) override the auto default, or (c) grab the extra social sizes (square-large, portrait, tall) for manual use.
+> **You do not need a custom card for most events.** Every event already gets an on-brand landscape + square card automatically at build time from its frontmatter (`scripts/generate-meta-images.mjs`). Use this skill only to (a) enrich a card with people/logos not in frontmatter, (b) override the auto default, or (c) grab the extra social sizes (square-large, portrait, tall) for manual use. (For a plain default with no enrichment, `scripts/meta-images/render-event-cards.mjs <slug>` renders all five sizes from frontmatter without a config.)
 
 ---
 
@@ -20,6 +20,17 @@ You generate the branded event card (the Figma "Workshop / event images" compone
 - **Standalone** — the user just wants images ("generate event images for …", no event attached). Collect inputs directly (Steps 3–5), skip frontmatter, and write the PNGs to an output dir (default `.context/event-images/<slug>/`, or a path the user gives). **No** frontmatter or bundle writes.
 
 Everything below applies to both modes **except** the bundle/frontmatter writes in Step 6 (event-bound only).
+
+## Interaction mode — when to ask questions
+
+Orthogonal to event-bound/standalone, pick how much to prompt. **Default to searching, not asking:** in both modes you still auto-resolve people and logos via the ladders in Steps 3–4 (including `WebSearch`/`WebFetch`). The modes differ only in what happens when something can't be resolved or is genuinely ambiguous.
+
+- **Unattended — never ask.** Trigger when `$ARGUMENTS` contains `-y`, `--yes`, `--non-interactive`, `--no-input`, `no questions`, or "just do it" (and automatically whenever you're running non-interactively, e.g. under `claude -p` or the eval, where `AskUserQuestion` can't be answered). Skip **every** `AskUserQuestion`. Derive all inputs automatically:
+  - **overline** = `event_type`; **title** = frontmatter `title`; **speakers** = frontmatter `presenters[].photo`; **additionalText** = the derived "With …" line.
+  - **people** = frontmatter presenters **plus** any external co-presenter named in the title/body.
+  - **logos** = `["pulumi"]` **plus** any partner company named in the title/body.
+  - Auto-resolve each derived photo/logo via the Step 3 / Step 4 ladders. **On a resolution miss, skip that one asset with a warning and keep going — never block.** No button, no secondary title.
+- **Default — ask only when needed.** Same automatic derivation and search as unattended mode, but fall back to a single targeted `AskUserQuestion` **only** when an asset can't be resolved, or an input is genuinely ambiguous (multiple candidate events, missing `title`, a partner named but not identifiable). Do **not** ask to confirm things already known from frontmatter or `$ARGUMENTS`.
 
 ## [Step 1/6] Locate the event (event-bound)
 
@@ -41,7 +52,7 @@ The build default already uses exactly these. If the user only wants the default
 
 ## [Step 3/6] Add people not in frontmatter (external co-presenters)
 
-Ask (with `AskUserQuestion`) whether to add anyone beyond the `presenters:` list — e.g. a partner-company co-host. For each added person collect **name** + **role/company**, then resolve a **color photo** via this ladder (stop at the first hit):
+Add anyone beyond the `presenters:` list — e.g. a partner-company co-host. **Derive these from the event first** (the title/body and `$ARGUMENTS`); only fall back to `AskUserQuestion` per the interaction mode (default: ask when a person is named but you can't identify or resolve them; unattended: skip an unresolvable person with a warning, never ask). For each added person collect **name** + **role/company**, then resolve a **color photo** via this ladder (stop at the first hit):
 
 1. An existing `presenters[].photo` (already have it).
 2. `static/images/team/<kebab-name>.{jpg,jpeg,png}`.
@@ -55,7 +66,7 @@ Save any fetched/provided external photo to a real file (e.g. `.context/event-im
 
 Pulumi is **always** included (`"pulumi"` → the bundled brand mark — never re-color or restyle it). The renderer lays the logos out in a row joined by a muted **`+`** (Pulumi `+` Microsoft `+` …), so each entry should read as a company on its own.
 
-Ask whether to add partner/company logos (e.g. Microsoft, GitHub, Google Cloud, NVIDIA). Three hard rules when sourcing each one:
+Add partner/company logos (e.g. Microsoft, GitHub, Google Cloud, NVIDIA) for any partner named in the event's title/body or `$ARGUMENTS`. **Derive them from the event first** — only fall back to `AskUserQuestion` per the interaction mode (default: ask when a partner is named but you can't source a compliant logo; unattended: skip an unresolvable logo with a warning, never ask). Three hard rules when sourcing each one:
 
 - **Default to the WORDMARK** — the lockup that includes the **company name** (e.g. the Microsoft squares *plus* "Microsoft"), not the bare glyph. A mark-only icon next to "Pulumi" reads as unfinished. Only fall back to a glyph if no wordmark exists or the glyph IS the brand (rare).
 - **Prefer the HORIZONTAL variant.** The renderer scales every logo to a fixed row *height*, so a vertical/**stacked** lockup (mark stacked above the name) renders its text tiny and unbalanced next to Pulumi. Choose the horizontal lockup (mark beside the name, or the wordmark alone). Rule of thumb: check the SVG `viewBox` / PNG dimensions and prefer an **aspect ratio ≳ 3:1**; reject stacked or roughly-square lockups (aspect ≲ 2) even when they're technically a wordmark, and keep looking (a company's brand/press page usually offers both a "horizontal" and a "stacked" variant — take the horizontal one).
@@ -72,12 +83,13 @@ Resolve each via this ladder, stopping at the first hit that satisfies both rule
 
 ## [Step 5/6] Options
 
-Confirm with `AskUserQuestion` (skip anything `$ARGUMENTS` already answered):
+Default every option and move on. Only reach for `AskUserQuestion` per the interaction mode (and never in unattended mode); never re-confirm what `$ARGUMENTS` or frontmatter already answered.
 
-- **overline** — default `event_type` (e.g. `WORKSHOP`, `WEBINAR`, `PANEL`). Allow an override.
-- **secondary title** — hidden by default; offer to set a small line above the title.
-- **show "Register" button?** — default **no**.
+- **overline** — default `event_type` (e.g. `WORKSHOP`, `WEBINAR`, `PANEL`); honor an override if `$ARGUMENTS` gives one.
+- **secondary title** — hidden. Set it only if the user explicitly asks for a small line above the title.
 - **which people / logos to include and their order** — when there are more than 5 people, pick the 5 to show; order logos Pulumi-first.
+
+**Never add a button.** `showButton` stays `false` unless the user's prompt *explicitly* asks for one (e.g. "with a Register button", "add a CTA", "include a sign-up button"). Do not offer it, do not ask about it, and never enable it in unattended mode. Only when explicitly requested, set `showButton: true` and `buttonText` accordingly.
 
 ## [Step 6/6] Render the five sizes
 
@@ -92,13 +104,14 @@ Write **one** config JSON (e.g. `.context/event-images/<slug>/config.json`), the
   "secondaryTitle": "",
   "additionalText": "With Jane Doe - Staff Engineer, Acme and John Roe",
   "showButton": false,
-  "buttonText": "Register",
+  "buttonText": "Register",         // opt-in only — see below; leave showButton false unless explicitly requested
   "speakers": ["/images/people/jane.jpg", ".context/event-images/<slug>/john-roe.jpg"],
   "logos": ["pulumi", ".claude/commands/event-meta-image/assets/logos/microsoft.svg"]
 }
 ```
 
 - `additionalText` is the literal "With …" line. Compose it yourself: one presenter → `With {name} - {role}`; many → names only, Oxford comma (`With A, B, and C`). (Omit to let the CLI derive it from a `presenters: [{name, role}]` array instead.)
+- `showButton` is **off unless the user explicitly asked for a button** (see Step 5). Omit it or leave `false` in every default and unattended run.
 - `speakers` / `logos` resolve as: `data:` URI → path relative to the config file → repo path (`/images/…`, `static/`, `assets/fingerprinted/`, `static/logos/**`) → absolute path. Unresolved entries are skipped with a warning.
 
 **Render loop** — same config, five sizes:

--- a/.claude/commands/event-meta-image/eval/README.md
+++ b/.claude/commands/event-meta-image/eval/README.md
@@ -1,0 +1,74 @@
+# `/event-meta-image` eval
+
+A headless LLM eval for the `/event-meta-image` skill. It runs the skill non-interactively
+(`claude -p`) across a set of fixtures on one or more models, then asserts on the **artifacts the
+model produced** — the `config.json` it wrote and the five PNGs it rendered — never on prose. This
+catches a model that ignores the skill's defaults (adding a button it shouldn't, dropping a speaker,
+producing wrong sizes) and tells you the cheapest model that runs the skill correctly.
+
+## Run it
+
+```bash
+# Core fixtures on the default target model (opus):
+node .claude/commands/event-meta-image/eval/run.mjs
+
+# Full cost spread — prints a cheapest-passing table:
+node .claude/commands/event-meta-image/eval/run.mjs --models haiku,sonnet,opus,fable
+
+# One fixture, deterministic core only, keep outputs to eyeball:
+node .claude/commands/event-meta-image/eval/run.mjs --fixture button-requested --keep
+```
+
+Flags: `--models <csv>` (aliases `haiku,sonnet,opus,fable`), `--fixture <id>`, `--no-web` (skip
+live-web fixtures), `--web-strict` (let web fixtures gate the exit code), `--keep` (leave the
+`.context/event-images/eval/<id>/` output dirs in place). Override the CLI binary with
+`CLAUDE_BIN`. Runs are sequential; each takes ~1–5 min per fixture depending on the model and
+whether it hits the web.
+
+Exit code is non-zero if any **core** fixture fails for any tested model — suitable for CI.
+
+## Fixtures (`fixtures.json`)
+
+All fixtures run in **standalone** mode with an explicit output dir, so the eval never mutates
+`content/events/`.
+
+- **Core** (`web:false`) — resolve entirely from local files / the bundled logo cache, so they're
+  deterministic and gate pass/fail: basic card (button off, Pulumi only), two local presenters,
+  an explicitly-requested Register button (button on), and a cached-partner logo (Microsoft).
+- **Web** (`web:true`) — exercise live `WebSearch`/`WebFetch` sourcing. They run and report
+  separately and gate only under `--web-strict`, because search results and headshot availability
+  shift over time. `partner-logo-web` (NVIDIA) forces a real logo fetch — `forceMissLogo` deletes
+  the cache entry before **and** after the run so it always fetches fresh and leaves the committed
+  cache clean. `external-presenter-web` (a headshot search) is `soft:true` — auth-gated headshots
+  are inherently flaky, so it only checks the byline name and never gates.
+
+## What each run asserts
+
+Per fixture, against the model-written `config.json` + rendered PNGs:
+
+- `config.json` was written to the output dir and parses.
+- `showButton` matches the expectation (this is the button-regression guard).
+- `speakers.length` matches; `logos` contain the expected substrings; the byline contains the
+  expected names.
+- **Five card PNGs**, one per expected size — verified by reading each PNG's `IHDR` width/height,
+  so it's filename-agnostic (`1200x628`, `628x628`, `1200x675`, `1080x1080`, `540x960`). Only
+  card-sized PNGs are counted; a fetched source photo the skill saves into the same folder (e.g. a
+  downloaded headshot) is a non-card size and is ignored, not counted as a sixth card.
+- The config **re-renders with no unresolved assets** — the harness runs
+  `scripts/meta-images/render-event.mjs` once on the model's config and fails on any
+  `could not resolve` warning.
+- **The partner logo is actually visible** — for any fixture with a non-Pulumi logo, the harness
+  decodes that re-render and counts "ink" pixels in the partner-logo band of the card. A logo that
+  *resolves* can still be *invisible* (a white / dark-mode asset on the near-white `#f5f5ff` card);
+  resolution alone isn't enough. Calibrated on real runs: visible logos land ~3,100–5,600 ink,
+  an invisible one lands 0; the threshold is 400. This is the check that catches a cheap model
+  fetching an off-brand dark-mode logo.
+
+## Reading the cost table
+
+The summary sorts models with all core fixtures passing first, then by measured run cost (the real
+`total_cost_usd` from each `claude -p` run), and names the cheapest passing model. Output pricing
+(the driver of cost) is `haiku $5 < sonnet $15 < opus $25 < fable $50` per 1M tokens — so "lowest
+cost that works" is a direct read-off. (Fable is the most capable *and* most expensive model, not a
+cheap one; the reported failure that motivated this eval was Fable ignoring a default, which is
+exactly what these assertions catch.)

--- a/.claude/commands/event-meta-image/eval/fixtures.json
+++ b/.claude/commands/event-meta-image/eval/fixtures.json
@@ -1,0 +1,50 @@
+{
+    "_comment": "Eval fixtures for the /event-meta-image skill. Each runs the skill headless via claude -p (see run.mjs). All use STANDALONE mode + an explicit output dir so they never mutate content/events/. CORE fixtures (web:false) resolve entirely from local files / the bundled logo cache, so they are deterministic and gate a model's pass/fail. WEB fixtures (web:true) exercise live WebSearch/WebFetch sourcing; they run and report separately and only gate under --web-strict, because search results and headshot availability shift over time. `expect.logosInclude` / `expect.additionalTextIncludes` are case-insensitive substring matches; `expect.speakers` is config.speakers.length. `forceMissLogo` names a cache basename run.mjs deletes before AND after the run so the fixture always forces a real web fetch and leaves the committed cache clean. `soft:true` marks a fixture whose failures are always WARN (never gate), for inherently flaky resolution like auth-gated headshots.",
+    "outBase": ".context/event-images/eval",
+    "fixtures": [
+        {
+            "id": "standalone-basic",
+            "web": false,
+            "prompt": "Standalone mode, no questions. Do not touch content/events. Write config.json and all five PNGs into OUTDIR. Title: \"Eval Basic Card One\". Overline: WEBINAR. No presenters, no partners.",
+            "expect": { "showButton": false, "speakers": 0, "logosInclude": ["pulumi"] }
+        },
+        {
+            "id": "with-presenters",
+            "web": false,
+            "prompt": "Standalone mode, no questions. Do not touch content/events. Write config.json and all five PNGs into OUTDIR. Title: \"Eval Presenters Card Two\". Overline: WORKSHOP. Two presenters: Piers Karsenbarg - Senior Solutions Engineer, Pulumi (photo /images/team/piers-karsenbarg.jpg) and Torian Crane - Senior Technical Content Engineer, Pulumi (photo /images/team/torian-crane.jpg). No partner logos.",
+            "expect": { "showButton": false, "speakers": 2, "logosInclude": ["pulumi"] }
+        },
+        {
+            "id": "button-requested",
+            "web": false,
+            "prompt": "Standalone mode, no questions. Do not touch content/events. Write config.json and all five PNGs into OUTDIR. Title: \"Eval Button Card Three\". Overline: WEBINAR. Include a Register button on the card.",
+            "expect": { "showButton": true, "speakers": 0, "logosInclude": ["pulumi"] }
+        },
+        {
+            "id": "partner-logo-cached",
+            "web": false,
+            "prompt": "Standalone mode, no questions. Do not touch content/events. Write config.json and all five PNGs into OUTDIR. Title: \"Eval Partner Card Four\". Overline: WORKSHOP. This workshop is co-hosted with Microsoft — include the Microsoft logo alongside Pulumi.",
+            "expect": { "showButton": false, "speakers": 0, "logosInclude": ["pulumi", "microsoft"] }
+        },
+        {
+            "id": "unattended",
+            "web": false,
+            "prompt": "--yes standalone. Do not touch content/events. Write config.json and all five PNGs into OUTDIR. Title: \"Eval Unattended Card Five\". Overline: PANEL. Run end to end with sensible defaults and ask me nothing.",
+            "expect": { "showButton": false, "speakers": 0, "logosInclude": ["pulumi"] }
+        },
+        {
+            "id": "partner-logo-web",
+            "web": true,
+            "forceMissLogo": "nvidia",
+            "prompt": "Standalone mode, no questions. Do not touch content/events. Write config.json and all five PNGs into OUTDIR. Title: \"Eval Web Logo Card\". Overline: WORKSHOP. This workshop is co-hosted with NVIDIA — source the NVIDIA logo from the web (a transparent, horizontal wordmark) and include it alongside Pulumi.",
+            "expect": { "showButton": false, "speakers": 0, "logosInclude": ["pulumi", "nvidia"] }
+        },
+        {
+            "id": "external-presenter-web",
+            "web": true,
+            "soft": true,
+            "prompt": "Standalone mode, no questions. Do not touch content/events. Write config.json and all five PNGs into OUTDIR. Title: \"Eval Web Speaker Card\". Overline: WEBINAR. Co-presented with Kelsey Hightower (independent). Search the web for a headshot; if you cannot find one, still list him in the byline.",
+            "expect": { "showButton": false, "additionalTextIncludes": ["Kelsey Hightower"], "logosInclude": ["pulumi"] }
+        }
+    ]
+}

--- a/.claude/commands/event-meta-image/eval/run.mjs
+++ b/.claude/commands/event-meta-image/eval/run.mjs
@@ -19,96 +19,137 @@
 // Exit code is non-zero if any *core* assertion failed for any tested model
 // (web fixtures gate only under --web-strict; `soft` fixtures never gate).
 
-import { readFileSync, existsSync, rmSync, readdirSync, mkdirSync } from "fs"
-import zlib from "zlib"
-import { spawnSync } from "child_process"
-import { dirname, join, resolve } from "path"
-import { fileURLToPath } from "url"
+import { readFileSync, existsSync, rmSync, readdirSync, mkdirSync } from "fs";
+import zlib from "zlib";
+import { spawnSync } from "child_process";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
 
-const HERE = dirname(fileURLToPath(import.meta.url))
-const REPO_ROOT = resolve(HERE, "../../../..")
-const RENDERER = "scripts/meta-images/render-event.mjs"
-const CLAUDE_BIN = process.env.CLAUDE_BIN || "claude"
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "../../../..");
+const RENDERER = "scripts/meta-images/render-event.mjs";
+const CLAUDE_BIN = process.env.CLAUDE_BIN || "claude";
 
 // alias -> { id, in$/1M, out$/1M }. Output price dominates a generation task and
 // drives the cost ranking; input price is shown for completeness.
 const MODELS = {
-  haiku:  { id: "claude-haiku-4-5-20251001", in: 1,  out: 5  },
-  sonnet: { id: "claude-sonnet-5",           in: 3,  out: 15 },
-  opus:   { id: "claude-opus-4-8",           in: 5,  out: 25 },
-  fable:  { id: "claude-fable-5",            in: 10, out: 50 },
-}
+    haiku: { id: "claude-haiku-4-5-20251001", in: 1, out: 5 },
+    sonnet: { id: "claude-sonnet-5", in: 3, out: 15 },
+    opus: { id: "claude-opus-4-8", in: 5, out: 25 },
+    fable: { id: "claude-fable-5", in: 10, out: 50 },
+};
 
-const EXPECTED_SIZES = ["1200x628", "628x628", "1200x675", "1080x1080", "540x960"].sort()
+const EXPECTED_SIZES = ["1200x628", "628x628", "1200x675", "1080x1080", "540x960"].sort();
 
 // ---- args -------------------------------------------------------------------
-const argv = process.argv.slice(2)
+const argv = process.argv.slice(2);
 const getOpt = (name, def) => {
-  const i = argv.indexOf(name)
-  return i >= 0 && argv[i + 1] ? argv[i + 1] : def
+    const i = argv.indexOf(name);
+    return i >= 0 && argv[i + 1] ? argv[i + 1] : def;
+};
+const hasFlag = name => argv.includes(name);
+const models = getOpt("--models", "opus")
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean);
+const fixtureFilter = getOpt("--fixture", null);
+const noWeb = hasFlag("--no-web");
+const webStrict = hasFlag("--web-strict");
+const keep = hasFlag("--keep");
+
+for (const m of models)
+    if (!MODELS[m]) {
+        console.error(`unknown model alias: ${m} (known: ${Object.keys(MODELS).join(", ")})`);
+        process.exit(2);
+    }
+
+const spec = JSON.parse(readFileSync(join(HERE, "fixtures.json"), "utf-8"));
+let fixtures = spec.fixtures;
+if (fixtureFilter) {
+    const want = new Set(fixtureFilter.split(",").map(s => s.trim()));
+    fixtures = fixtures.filter(f => want.has(f.id));
 }
-const hasFlag = (name) => argv.includes(name)
-const models = getOpt("--models", "opus").split(",").map((s) => s.trim()).filter(Boolean)
-const fixtureFilter = getOpt("--fixture", null)
-const noWeb = hasFlag("--no-web")
-const webStrict = hasFlag("--web-strict")
-const keep = hasFlag("--keep")
-
-for (const m of models) if (!MODELS[m]) { console.error(`unknown model alias: ${m} (known: ${Object.keys(MODELS).join(", ")})`); process.exit(2) }
-
-const spec = JSON.parse(readFileSync(join(HERE, "fixtures.json"), "utf-8"))
-let fixtures = spec.fixtures
-if (fixtureFilter) { const want = new Set(fixtureFilter.split(",").map((s) => s.trim())); fixtures = fixtures.filter((f) => want.has(f.id)) }
-if (noWeb) fixtures = fixtures.filter((f) => !f.web)
-if (!fixtures.length) { console.error("no fixtures selected"); process.exit(2) }
+if (noWeb) fixtures = fixtures.filter(f => !f.web);
+if (!fixtures.length) {
+    console.error("no fixtures selected");
+    process.exit(2);
+}
 
 // ---- helpers ----------------------------------------------------------------
 function pngSize(path) {
-  const buf = readFileSync(path)
-  if (buf.length < 24 || buf.readUInt32BE(0) !== 0x89504e47) return null // not a PNG
-  return `${buf.readUInt32BE(16)}x${buf.readUInt32BE(20)}`
+    const buf = readFileSync(path);
+    if (buf.length < 24 || buf.readUInt32BE(0) !== 0x89504e47) return null; // not a PNG
+    return `${buf.readUInt32BE(16)}x${buf.readUInt32BE(20)}`;
 }
 
 // Minimal PNG decoder (8-bit RGB/RGBA, non-interlaced — what resvg-js emits).
 // Returns { width, height, ch, data } or null if unsupported/undecodable.
 function decodePNG(path) {
-  const buf = readFileSync(path)
-  if (buf.length < 8 || buf.readUInt32BE(0) !== 0x89504e47) return null
-  let pos = 8, width = 0, height = 0, depth = 0, ctype = 0, interlace = 0
-  const idat = []
-  while (pos + 8 <= buf.length) {
-    const len = buf.readUInt32BE(pos), type = buf.toString("ascii", pos + 4, pos + 8)
-    const data = buf.subarray(pos + 8, pos + 8 + len)
-    if (type === "IHDR") { width = data.readUInt32BE(0); height = data.readUInt32BE(4); depth = data[8]; ctype = data[9]; interlace = data[12] }
-    else if (type === "IDAT") idat.push(data)
-    else if (type === "IEND") break
-    pos += 12 + len
-  }
-  if (depth !== 8 || interlace !== 0 || (ctype !== 6 && ctype !== 2)) return null
-  const ch = ctype === 6 ? 4 : 3
-  const raw = zlib.inflateSync(Buffer.concat(idat))
-  const stride = width * ch, out = Buffer.alloc(height * stride)
-  let ri = 0
-  for (let y = 0; y < height; y++) {
-    const f = raw[ri++]
-    for (let x = 0; x < stride; x++) {
-      const rb = raw[ri++]
-      const a = x >= ch ? out[y * stride + x - ch] : 0
-      const b = y > 0 ? out[(y - 1) * stride + x] : 0
-      const c = x >= ch && y > 0 ? out[(y - 1) * stride + x - ch] : 0
-      let v
-      switch (f) {
-        case 0: v = rb; break
-        case 1: v = rb + a; break
-        case 2: v = rb + b; break
-        case 3: v = rb + ((a + b) >> 1); break
-        case 4: { const p = a + b - c, pa = Math.abs(p - a), pb = Math.abs(p - b), pc = Math.abs(p - c); v = rb + (pa <= pb && pa <= pc ? a : pb <= pc ? b : c); break }
-        default: v = rb
-      }
-      out[y * stride + x] = v & 0xff
+    const buf = readFileSync(path);
+    if (buf.length < 8 || buf.readUInt32BE(0) !== 0x89504e47) return null;
+    let pos = 8,
+        width = 0,
+        height = 0,
+        depth = 0,
+        ctype = 0,
+        interlace = 0;
+    const idat = [];
+    while (pos + 8 <= buf.length) {
+        const len = buf.readUInt32BE(pos),
+            type = buf.toString("ascii", pos + 4, pos + 8);
+        const data = buf.subarray(pos + 8, pos + 8 + len);
+        if (type === "IHDR") {
+            width = data.readUInt32BE(0);
+            height = data.readUInt32BE(4);
+            depth = data[8];
+            ctype = data[9];
+            interlace = data[12];
+        } else if (type === "IDAT") idat.push(data);
+        else if (type === "IEND") break;
+        pos += 12 + len;
     }
-  }
-  return { width, height, ch, data: out }
+    if (depth !== 8 || interlace !== 0 || (ctype !== 6 && ctype !== 2)) return null;
+    const ch = ctype === 6 ? 4 : 3;
+    const raw = zlib.inflateSync(Buffer.concat(idat));
+    const stride = width * ch,
+        out = Buffer.alloc(height * stride);
+    let ri = 0;
+    for (let y = 0; y < height; y++) {
+        const f = raw[ri++];
+        for (let x = 0; x < stride; x++) {
+            const rb = raw[ri++];
+            const a = x >= ch ? out[y * stride + x - ch] : 0;
+            const b = y > 0 ? out[(y - 1) * stride + x] : 0;
+            const c = x >= ch && y > 0 ? out[(y - 1) * stride + x - ch] : 0;
+            let v;
+            switch (f) {
+                case 0:
+                    v = rb;
+                    break;
+                case 1:
+                    v = rb + a;
+                    break;
+                case 2:
+                    v = rb + b;
+                    break;
+                case 3:
+                    v = rb + ((a + b) >> 1);
+                    break;
+                case 4: {
+                    const p = a + b - c,
+                        pa = Math.abs(p - a),
+                        pb = Math.abs(p - b),
+                        pc = Math.abs(p - c);
+                    v = rb + (pa <= pb && pa <= pc ? a : pb <= pc ? b : c);
+                    break;
+                }
+                default:
+                    v = rb;
+            }
+            out[y * stride + x] = v & 0xff;
+        }
+    }
+    return { width, height, ch, data: out };
 }
 
 // Count "ink" pixels (meaningfully off the #f5f5ff card background) in the
@@ -116,28 +157,33 @@ function decodePNG(path) {
 // the Pulumi mark + "+" separator, within the bottom logo row. A visible partner
 // logo lands 3k-6k ink here; an invisible (white / dark-mode) logo lands ~0.
 function partnerInk(img) {
-  const { width, height, ch, data } = img
-  const x0 = Math.round(width * 0.24), x1 = Math.round(width * 0.62)
-  const y0 = height - 90, y1 = height - 30
-  let n = 0
-  for (let y = y0; y < y1; y++) for (let x = x0; x < x1; x++) {
-    const i = (y * width + x) * ch
-    if (Math.abs(data[i] - 245) + Math.abs(data[i + 1] - 245) + Math.abs(data[i + 2] - 255) > 60) n++
-  }
-  return n
+    const { width, height, ch, data } = img;
+    const x0 = Math.round(width * 0.24),
+        x1 = Math.round(width * 0.62);
+    const y0 = height - 90,
+        y1 = height - 30;
+    let n = 0;
+    for (let y = y0; y < y1; y++)
+        for (let x = x0; x < x1; x++) {
+            const i = (y * width + x) * ch;
+            if (Math.abs(data[i] - 245) + Math.abs(data[i + 1] - 245) + Math.abs(data[i + 2] - 255) > 60) n++;
+        }
+    return n;
 }
-const LOGO_VISIBLE_MIN = 400 // calibrated: visible logos ~3100-5600 ink, invisible = 0
+const LOGO_VISIBLE_MIN = 400; // calibrated: visible logos ~3100-5600 ink, invisible = 0
 
 function cacheGlob(basename) {
-  const dir = join(HERE, "..", "assets", "logos")
-  if (!existsSync(dir)) return []
-  return readdirSync(dir).filter((f) => f.replace(/\.[^.]+$/, "") === basename).map((f) => join(dir, f))
+    const dir = join(HERE, "..", "assets", "logos");
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir)
+        .filter(f => f.replace(/\.[^.]+$/, "") === basename)
+        .map(f => join(dir, f));
 }
-const rmCacheLogo = (basename) => cacheGlob(basename).forEach((p) => rmSync(p, { force: true }))
+const rmCacheLogo = basename => cacheGlob(basename).forEach(p => rmSync(p, { force: true }));
 
 function includesAll(hay, needles) {
-  const h = (hay || "").toString().toLowerCase()
-  return (needles || []).every((n) => h.includes(n.toLowerCase()))
+    const h = (hay || "").toString().toLowerCase();
+    return (needles || []).every(n => h.includes(n.toLowerCase()));
 }
 
 // Re-run the shared renderer once (1200x628) on the model-written config. This
@@ -145,143 +191,181 @@ function includesAll(hay, needles) {
 // "could not resolve" warnings surface as a failure — and the produced PNG is
 // reused for the logo-visibility check. Caller deletes `tmp`.
 function renderProbe(cfgAbs) {
-  const tmp = join(REPO_ROOT, ".context", "event-images", "eval", "_probe.png")
-  const r = spawnSync("node", [RENDERER, "--config", cfgAbs, "--size", "1200x628", "--out", tmp],
-    { cwd: REPO_ROOT, encoding: "utf-8" })
-  const warned = /could not resolve/i.test((r.stderr || "") + (r.stdout || ""))
-  return { tmp, rendered: r.status === 0, ok: r.status === 0 && !warned, detail: r.status !== 0 ? `renderer exit ${r.status}` : warned ? "could-not-resolve warning" : "" }
+    const tmp = join(REPO_ROOT, ".context", "event-images", "eval", "_probe.png");
+    const r = spawnSync("node", [RENDERER, "--config", cfgAbs, "--size", "1200x628", "--out", tmp], { cwd: REPO_ROOT, encoding: "utf-8" });
+    const warned = /could not resolve/i.test((r.stderr || "") + (r.stdout || ""));
+    return { tmp, rendered: r.status === 0, ok: r.status === 0 && !warned, detail: r.status !== 0 ? `renderer exit ${r.status}` : warned ? "could-not-resolve warning" : "" };
 }
 
 function runSkill(prompt, modelId, outRel) {
-  const full = `/event-meta-image ${prompt.replace(/OUTDIR/g, outRel)}`
-  const r = spawnSync(CLAUDE_BIN, ["-p", full, "--model", modelId, "--output-format", "json", "--dangerously-skip-permissions"],
-    { cwd: REPO_ROOT, encoding: "utf-8", timeout: 15 * 60 * 1000, maxBuffer: 64 * 1024 * 1024 })
-  let cost = null, runErr = null
-  if (r.error) runErr = String(r.error)
-  try {
-    const j = JSON.parse(r.stdout)
-    cost = typeof j.total_cost_usd === "number" ? j.total_cost_usd : null
-    if (j.is_error) runErr = runErr || "claude reported is_error"
-  } catch { runErr = runErr || "could not parse claude --output-format json output" }
-  return { cost, runErr }
+    const full = `/event-meta-image ${prompt.replace(/OUTDIR/g, outRel)}`;
+    const r = spawnSync(CLAUDE_BIN, ["-p", full, "--model", modelId, "--output-format", "json", "--dangerously-skip-permissions"], {
+        cwd: REPO_ROOT,
+        encoding: "utf-8",
+        timeout: 15 * 60 * 1000,
+        maxBuffer: 64 * 1024 * 1024,
+    });
+    let cost = null,
+        runErr = null;
+    if (r.error) runErr = String(r.error);
+    try {
+        const j = JSON.parse(r.stdout);
+        cost = typeof j.total_cost_usd === "number" ? j.total_cost_usd : null;
+        if (j.is_error) runErr = runErr || "claude reported is_error";
+    } catch {
+        runErr = runErr || "could not parse claude --output-format json output";
+    }
+    return { cost, runErr };
 }
 
 // ---- assertions for one fixture run ----------------------------------------
 function assertFixture(fx, outAbs) {
-  const checks = []
-  const add = (name, ok, detail = "") => checks.push({ name, ok, detail })
+    const checks = [];
+    const add = (name, ok, detail = "") => checks.push({ name, ok, detail });
 
-  const cfgPath = join(outAbs, "config.json")
-  if (!existsSync(cfgPath)) { add("config.json written", false, `missing at ${cfgPath}`); return checks }
-  add("config.json written", true)
+    const cfgPath = join(outAbs, "config.json");
+    if (!existsSync(cfgPath)) {
+        add("config.json written", false, `missing at ${cfgPath}`);
+        return checks;
+    }
+    add("config.json written", true);
 
-  let cfg
-  try { cfg = JSON.parse(readFileSync(cfgPath, "utf-8")) } catch (e) { add("config.json parses", false, String(e)); return checks }
-  add("config.json parses", true)
+    let cfg;
+    try {
+        cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    } catch (e) {
+        add("config.json parses", false, String(e));
+        return checks;
+    }
+    add("config.json parses", true);
 
-  const e = fx.expect || {}
-  if (e.showButton !== undefined) add(`showButton == ${e.showButton}`, !!cfg.showButton === e.showButton, `got ${!!cfg.showButton}`)
-  if (e.speakers !== undefined) { const n = (cfg.speakers || []).length; add(`speakers == ${e.speakers}`, n === e.speakers, `got ${n}`) }
-  if (e.logosInclude) for (const needle of e.logosInclude) {
-    const hit = (cfg.logos || []).some((l) => l.toLowerCase().includes(needle.toLowerCase()))
-    add(`logos include "${needle}"`, hit, hit ? "" : `got ${JSON.stringify(cfg.logos || [])}`)
-  }
-  if (e.additionalTextIncludes) for (const needle of e.additionalTextIncludes)
-    add(`byline includes "${needle}"`, includesAll(cfg.additionalText, [needle]), `got ${JSON.stringify(cfg.additionalText || "")}`)
+    const e = fx.expect || {};
+    if (e.showButton !== undefined) add(`showButton == ${e.showButton}`, !!cfg.showButton === e.showButton, `got ${!!cfg.showButton}`);
+    if (e.speakers !== undefined) {
+        const n = (cfg.speakers || []).length;
+        add(`speakers == ${e.speakers}`, n === e.speakers, `got ${n}`);
+    }
+    if (e.logosInclude)
+        for (const needle of e.logosInclude) {
+            const hit = (cfg.logos || []).some(l => l.toLowerCase().includes(needle.toLowerCase()));
+            add(`logos include "${needle}"`, hit, hit ? "" : `got ${JSON.stringify(cfg.logos || [])}`);
+        }
+    if (e.additionalTextIncludes)
+        for (const needle of e.additionalTextIncludes)
+            add(`byline includes "${needle}"`, includesAll(cfg.additionalText, [needle]), `got ${JSON.stringify(cfg.additionalText || "")}`);
 
-  // One card PNG per expected size (filename-agnostic). Ignore stray PNGs whose
-  // size isn't a card size — the skill saves fetched source photos (headshots)
-  // into the same dir per Step 3, and those must not count against the five cards.
-  const pngs = existsSync(outAbs) ? readdirSync(outAbs).filter((f) => f.endsWith(".png")) : []
-  const sizes = pngs.map((f) => pngSize(join(outAbs, f))).filter(Boolean)
-  const counts = {}
-  for (const s of sizes) if (EXPECTED_SIZES.includes(s)) counts[s] = (counts[s] || 0) + 1
-  const allOnce = EXPECTED_SIZES.every((s) => counts[s] === 1)
-  const cardTotal = Object.values(counts).reduce((a, b) => a + b, 0)
-  const nonCard = sizes.length - cardTotal
-  add("five card PNGs at correct sizes", allOnce && cardTotal === 5,
-    `card sizes: ${Object.keys(counts).sort().join(", ") || "none"}${nonCard ? ` (+${nonCard} non-card asset ignored)` : ""}`)
+    // One card PNG per expected size (filename-agnostic). Ignore stray PNGs whose
+    // size isn't a card size — the skill saves fetched source photos (headshots)
+    // into the same dir per Step 3, and those must not count against the five cards.
+    const pngs = existsSync(outAbs) ? readdirSync(outAbs).filter(f => f.endsWith(".png")) : [];
+    const sizes = pngs.map(f => pngSize(join(outAbs, f))).filter(Boolean);
+    const counts = {};
+    for (const s of sizes) if (EXPECTED_SIZES.includes(s)) counts[s] = (counts[s] || 0) + 1;
+    const allOnce = EXPECTED_SIZES.every(s => counts[s] === 1);
+    const cardTotal = Object.values(counts).reduce((a, b) => a + b, 0);
+    const nonCard = sizes.length - cardTotal;
+    add(
+        "five card PNGs at correct sizes",
+        allOnce && cardTotal === 5,
+        `card sizes: ${Object.keys(counts).sort().join(", ") || "none"}${nonCard ? ` (+${nonCard} non-card asset ignored)` : ""}`,
+    );
 
-  const probe = renderProbe(cfgPath)
-  add("renders with no unresolved assets", probe.ok, probe.detail)
+    const probe = renderProbe(cfgPath);
+    add("renders with no unresolved assets", probe.ok, probe.detail);
 
-  // Logo visibility: a resolved logo can still be invisible (a white / dark-mode
-  // asset on the near-white card). If a non-Pulumi partner logo is expected or
-  // present, it must actually paint ink on the card — resolution alone isn't enough.
-  const partnerExpected = (e.logosInclude || []).some((l) => l.toLowerCase() !== "pulumi")
-    || (cfg.logos || []).some((l) => l.toLowerCase() !== "pulumi" && !l.toLowerCase().includes("/pulumi"))
-  if (partnerExpected && probe.rendered) {
-    const img = decodePNG(probe.tmp)
-    if (!img) add("partner logo visible on card", true, "skipped — render not decodable")
-    else { const n = partnerInk(img); add("partner logo visible on card", n >= LOGO_VISIBLE_MIN, `ink=${n} (min ${LOGO_VISIBLE_MIN})`) }
-  }
-  rmSync(probe.tmp, { force: true })
+    // Logo visibility: a resolved logo can still be invisible (a white / dark-mode
+    // asset on the near-white card). If a non-Pulumi partner logo is expected or
+    // present, it must actually paint ink on the card — resolution alone isn't enough.
+    const partnerExpected =
+        (e.logosInclude || []).some(l => l.toLowerCase() !== "pulumi") || (cfg.logos || []).some(l => l.toLowerCase() !== "pulumi" && !l.toLowerCase().includes("/pulumi"));
+    if (partnerExpected && probe.rendered) {
+        const img = decodePNG(probe.tmp);
+        if (!img) add("partner logo visible on card", true, "skipped — render not decodable");
+        else {
+            const n = partnerInk(img);
+            add("partner logo visible on card", n >= LOGO_VISIBLE_MIN, `ink=${n} (min ${LOGO_VISIBLE_MIN})`);
+        }
+    }
+    rmSync(probe.tmp, { force: true });
 
-  return checks
+    return checks;
 }
 
 // ---- run --------------------------------------------------------------------
-console.log(`repo: ${REPO_ROOT}`)
-console.log(`models: ${models.join(", ")}   fixtures: ${fixtures.map((f) => f.id).join(", ")}\n`)
+console.log(`repo: ${REPO_ROOT}`);
+console.log(`models: ${models.join(", ")}   fixtures: ${fixtures.map(f => f.id).join(", ")}\n`);
 
-const results = {} // model -> { rows:[{fx, passed, gating, cost, checks}], cost }
-let hardFail = false
+const results = {}; // model -> { rows:[{fx, passed, gating, cost, checks}], cost }
+let hardFail = false;
 
 for (const alias of models) {
-  const { id } = MODELS[alias]
-  results[alias] = { rows: [], cost: 0 }
-  console.log(`\n===== ${alias} (${id}) =====`)
-  for (const fx of fixtures) {
-    // With --keep, namespace output by model so every model's cards survive
-    // (otherwise later models clobber earlier ones in the shared per-fixture dir).
-    const outRel = keep ? join(spec.outBase, fx.id, alias) : join(spec.outBase, fx.id)
-    const outAbs = join(REPO_ROOT, outRel)
-    rmSync(outAbs, { recursive: true, force: true })
-    mkdirSync(outAbs, { recursive: true })
-    if (fx.web && fx.forceMissLogo) rmCacheLogo(fx.forceMissLogo) // force a real fetch
+    const { id } = MODELS[alias];
+    results[alias] = { rows: [], cost: 0 };
+    console.log(`\n===== ${alias} (${id}) =====`);
+    for (const fx of fixtures) {
+        // With --keep, namespace output by model so every model's cards survive
+        // (otherwise later models clobber earlier ones in the shared per-fixture dir).
+        const outRel = keep ? join(spec.outBase, fx.id, alias) : join(spec.outBase, fx.id);
+        const outAbs = join(REPO_ROOT, outRel);
+        rmSync(outAbs, { recursive: true, force: true });
+        mkdirSync(outAbs, { recursive: true });
+        if (fx.web && fx.forceMissLogo) rmCacheLogo(fx.forceMissLogo); // force a real fetch
 
-    process.stdout.write(`  ${fx.id} ... `)
-    const { cost, runErr } = runSkill(fx.prompt, id, outRel)
-    const checks = runErr ? [{ name: "skill run", ok: false, detail: runErr }] : assertFixture(fx, outAbs)
+        process.stdout.write(`  ${fx.id} ... `);
+        const { cost, runErr } = runSkill(fx.prompt, id, outRel);
+        const checks = runErr ? [{ name: "skill run", ok: false, detail: runErr }] : assertFixture(fx, outAbs);
 
-    if (fx.web && fx.forceMissLogo) rmCacheLogo(fx.forceMissLogo) // keep committed cache clean
-    if (!keep) rmSync(outAbs, { recursive: true, force: true })
+        if (fx.web && fx.forceMissLogo) rmCacheLogo(fx.forceMissLogo); // keep committed cache clean
+        if (!keep) rmSync(outAbs, { recursive: true, force: true });
 
-    const passed = checks.every((c) => c.ok)
-    // A fixture gates the exit code unless it's soft, or it's a web fixture and we're not in --web-strict.
-    const gating = !fx.soft && (!fx.web || webStrict)
-    if (!passed && gating) hardFail = true
-    if (cost != null) results[alias].cost += cost
+        const passed = checks.every(c => c.ok);
+        // A fixture gates the exit code unless it's soft, or it's a web fixture and we're not in --web-strict.
+        const gating = !fx.soft && (!fx.web || webStrict);
+        if (!passed && gating) hardFail = true;
+        if (cost != null) results[alias].cost += cost;
 
-    const tag = fx.web ? "web" : "core"
-    console.log(`${passed ? "PASS" : (gating ? "FAIL" : "warn")} (${tag}${cost != null ? `, $${cost.toFixed(4)}` : ""})`)
-    for (const c of checks) if (!c.ok) console.log(`      ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ""}`)
-    results[alias].rows.push({ fx, passed, gating, cost, checks })
-  }
+        const tag = fx.web ? "web" : "core";
+        console.log(`${passed ? "PASS" : gating ? "FAIL" : "warn"} (${tag}${cost != null ? `, $${cost.toFixed(4)}` : ""})`);
+        for (const c of checks) if (!c.ok) console.log(`      ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ""}`);
+        results[alias].rows.push({ fx, passed, gating, cost, checks });
+    }
 }
 
 // ---- summary + cost ranking -------------------------------------------------
-console.log(`\n\n===== summary =====`)
-const rank = models.map((alias) => {
-  const rows = results[alias].rows
-  const core = rows.filter((r) => !r.fx.web)
-  const web = rows.filter((r) => r.fx.web)
-  const corePass = core.filter((r) => r.passed).length
-  const webPass = web.filter((r) => r.passed).length
-  return {
-    alias, corePass, coreTotal: core.length, webPass, webTotal: web.length,
-    allCore: corePass === core.length, cost: results[alias].cost, out: MODELS[alias].out,
-  }
-}).sort((a, b) => (a.allCore !== b.allCore ? (a.allCore ? -1 : 1) : a.cost - b.cost))
+console.log(`\n\n===== summary =====`);
+const rank = models
+    .map(alias => {
+        const rows = results[alias].rows;
+        const core = rows.filter(r => !r.fx.web);
+        const web = rows.filter(r => r.fx.web);
+        const corePass = core.filter(r => r.passed).length;
+        const webPass = web.filter(r => r.passed).length;
+        return {
+            alias,
+            corePass,
+            coreTotal: core.length,
+            webPass,
+            webTotal: web.length,
+            allCore: corePass === core.length,
+            cost: results[alias].cost,
+            out: MODELS[alias].out,
+        };
+    })
+    .sort((a, b) => (a.allCore !== b.allCore ? (a.allCore ? -1 : 1) : a.cost - b.cost));
 
-const pad = (s, n) => String(s).padEnd(n)
-console.log(`${pad("model", 9)}${pad("core", 8)}${pad("web", 8)}${pad("out $/1M", 10)}${pad("run $", 10)}verdict`)
+const pad = (s, n) => String(s).padEnd(n);
+console.log(`${pad("model", 9)}${pad("core", 8)}${pad("web", 8)}${pad("out $/1M", 10)}${pad("run $", 10)}verdict`);
 for (const r of rank) {
-  const verdict = r.allCore ? "core PASS" : "core FAIL"
-  console.log(`${pad(r.alias, 9)}${pad(`${r.corePass}/${r.coreTotal}`, 8)}${pad(r.webTotal ? `${r.webPass}/${r.webTotal}` : "-", 8)}${pad(`$${r.out}`, 10)}${pad(`$${r.cost.toFixed(4)}`, 10)}${verdict}`)
+    const verdict = r.allCore ? "core PASS" : "core FAIL";
+    console.log(
+        `${pad(r.alias, 9)}${pad(`${r.corePass}/${r.coreTotal}`, 8)}${pad(r.webTotal ? `${r.webPass}/${r.webTotal}` : "-", 8)}${pad(`$${r.out}`, 10)}${pad(
+            `$${r.cost.toFixed(4)}`,
+            10,
+        )}${verdict}`,
+    );
 }
-const cheapest = rank.find((r) => r.allCore)
-if (cheapest) console.log(`\nCheapest model passing all core fixtures: ${cheapest.alias} (out $${cheapest.out}/1M, this run $${cheapest.cost.toFixed(4)})`)
-else console.log(`\nNo tested model passed all core fixtures.`)
+const cheapest = rank.find(r => r.allCore);
+if (cheapest) console.log(`\nCheapest model passing all core fixtures: ${cheapest.alias} (out $${cheapest.out}/1M, this run $${cheapest.cost.toFixed(4)})`);
+else console.log(`\nNo tested model passed all core fixtures.`);
 
-process.exit(hardFail ? 1 : 0)
+process.exit(hardFail ? 1 : 0);

--- a/.claude/commands/event-meta-image/eval/run.mjs
+++ b/.claude/commands/event-meta-image/eval/run.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+// run.mjs — headless LLM eval for the /event-meta-image skill.
+//
+// For each (fixture x model) it runs the skill non-interactively via
+//   claude -p "/event-meta-image <prompt>" --model <id> --output-format json --dangerously-skip-permissions
+// then asserts on the deterministic artifacts the model produced (the config.json
+// it wrote + the five PNGs it rendered), NOT on any prose. This catches a model
+// ignoring the skill's defaults — e.g. adding a button it shouldn't, dropping a
+// speaker, or producing the wrong sizes.
+//
+// Usage:
+//   node .claude/commands/event-meta-image/eval/run.mjs                  # core fixtures, target model (opus)
+//   node .claude/commands/event-meta-image/eval/run.mjs --models haiku,sonnet,opus,fable   # cost spread
+//   node .claude/commands/event-meta-image/eval/run.mjs --fixture button-requested
+//   node .claude/commands/event-meta-image/eval/run.mjs --no-web        # skip live-web fixtures
+//   node .claude/commands/event-meta-image/eval/run.mjs --web-strict    # let web fixtures gate the exit code
+//   node .claude/commands/event-meta-image/eval/run.mjs --keep          # leave output dirs for inspection
+//
+// Exit code is non-zero if any *core* assertion failed for any tested model
+// (web fixtures gate only under --web-strict; `soft` fixtures never gate).
+
+import { readFileSync, existsSync, rmSync, readdirSync, mkdirSync } from "fs"
+import zlib from "zlib"
+import { spawnSync } from "child_process"
+import { dirname, join, resolve } from "path"
+import { fileURLToPath } from "url"
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(HERE, "../../../..")
+const RENDERER = "scripts/meta-images/render-event.mjs"
+const CLAUDE_BIN = process.env.CLAUDE_BIN || "claude"
+
+// alias -> { id, in$/1M, out$/1M }. Output price dominates a generation task and
+// drives the cost ranking; input price is shown for completeness.
+const MODELS = {
+  haiku:  { id: "claude-haiku-4-5-20251001", in: 1,  out: 5  },
+  sonnet: { id: "claude-sonnet-5",           in: 3,  out: 15 },
+  opus:   { id: "claude-opus-4-8",           in: 5,  out: 25 },
+  fable:  { id: "claude-fable-5",            in: 10, out: 50 },
+}
+
+const EXPECTED_SIZES = ["1200x628", "628x628", "1200x675", "1080x1080", "540x960"].sort()
+
+// ---- args -------------------------------------------------------------------
+const argv = process.argv.slice(2)
+const getOpt = (name, def) => {
+  const i = argv.indexOf(name)
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : def
+}
+const hasFlag = (name) => argv.includes(name)
+const models = getOpt("--models", "opus").split(",").map((s) => s.trim()).filter(Boolean)
+const fixtureFilter = getOpt("--fixture", null)
+const noWeb = hasFlag("--no-web")
+const webStrict = hasFlag("--web-strict")
+const keep = hasFlag("--keep")
+
+for (const m of models) if (!MODELS[m]) { console.error(`unknown model alias: ${m} (known: ${Object.keys(MODELS).join(", ")})`); process.exit(2) }
+
+const spec = JSON.parse(readFileSync(join(HERE, "fixtures.json"), "utf-8"))
+let fixtures = spec.fixtures
+if (fixtureFilter) { const want = new Set(fixtureFilter.split(",").map((s) => s.trim())); fixtures = fixtures.filter((f) => want.has(f.id)) }
+if (noWeb) fixtures = fixtures.filter((f) => !f.web)
+if (!fixtures.length) { console.error("no fixtures selected"); process.exit(2) }
+
+// ---- helpers ----------------------------------------------------------------
+function pngSize(path) {
+  const buf = readFileSync(path)
+  if (buf.length < 24 || buf.readUInt32BE(0) !== 0x89504e47) return null // not a PNG
+  return `${buf.readUInt32BE(16)}x${buf.readUInt32BE(20)}`
+}
+
+// Minimal PNG decoder (8-bit RGB/RGBA, non-interlaced — what resvg-js emits).
+// Returns { width, height, ch, data } or null if unsupported/undecodable.
+function decodePNG(path) {
+  const buf = readFileSync(path)
+  if (buf.length < 8 || buf.readUInt32BE(0) !== 0x89504e47) return null
+  let pos = 8, width = 0, height = 0, depth = 0, ctype = 0, interlace = 0
+  const idat = []
+  while (pos + 8 <= buf.length) {
+    const len = buf.readUInt32BE(pos), type = buf.toString("ascii", pos + 4, pos + 8)
+    const data = buf.subarray(pos + 8, pos + 8 + len)
+    if (type === "IHDR") { width = data.readUInt32BE(0); height = data.readUInt32BE(4); depth = data[8]; ctype = data[9]; interlace = data[12] }
+    else if (type === "IDAT") idat.push(data)
+    else if (type === "IEND") break
+    pos += 12 + len
+  }
+  if (depth !== 8 || interlace !== 0 || (ctype !== 6 && ctype !== 2)) return null
+  const ch = ctype === 6 ? 4 : 3
+  const raw = zlib.inflateSync(Buffer.concat(idat))
+  const stride = width * ch, out = Buffer.alloc(height * stride)
+  let ri = 0
+  for (let y = 0; y < height; y++) {
+    const f = raw[ri++]
+    for (let x = 0; x < stride; x++) {
+      const rb = raw[ri++]
+      const a = x >= ch ? out[y * stride + x - ch] : 0
+      const b = y > 0 ? out[(y - 1) * stride + x] : 0
+      const c = x >= ch && y > 0 ? out[(y - 1) * stride + x - ch] : 0
+      let v
+      switch (f) {
+        case 0: v = rb; break
+        case 1: v = rb + a; break
+        case 2: v = rb + b; break
+        case 3: v = rb + ((a + b) >> 1); break
+        case 4: { const p = a + b - c, pa = Math.abs(p - a), pb = Math.abs(p - b), pc = Math.abs(p - c); v = rb + (pa <= pb && pa <= pc ? a : pb <= pc ? b : c); break }
+        default: v = rb
+      }
+      out[y * stride + x] = v & 0xff
+    }
+  }
+  return { width, height, ch, data: out }
+}
+
+// Count "ink" pixels (meaningfully off the #f5f5ff card background) in the
+// partner-logo band of a 1200x628 landscape card — the strip to the right of
+// the Pulumi mark + "+" separator, within the bottom logo row. A visible partner
+// logo lands 3k-6k ink here; an invisible (white / dark-mode) logo lands ~0.
+function partnerInk(img) {
+  const { width, height, ch, data } = img
+  const x0 = Math.round(width * 0.24), x1 = Math.round(width * 0.62)
+  const y0 = height - 90, y1 = height - 30
+  let n = 0
+  for (let y = y0; y < y1; y++) for (let x = x0; x < x1; x++) {
+    const i = (y * width + x) * ch
+    if (Math.abs(data[i] - 245) + Math.abs(data[i + 1] - 245) + Math.abs(data[i + 2] - 255) > 60) n++
+  }
+  return n
+}
+const LOGO_VISIBLE_MIN = 400 // calibrated: visible logos ~3100-5600 ink, invisible = 0
+
+function cacheGlob(basename) {
+  const dir = join(HERE, "..", "assets", "logos")
+  if (!existsSync(dir)) return []
+  return readdirSync(dir).filter((f) => f.replace(/\.[^.]+$/, "") === basename).map((f) => join(dir, f))
+}
+const rmCacheLogo = (basename) => cacheGlob(basename).forEach((p) => rmSync(p, { force: true }))
+
+function includesAll(hay, needles) {
+  const h = (hay || "").toString().toLowerCase()
+  return (needles || []).every((n) => h.includes(n.toLowerCase()))
+}
+
+// Re-run the shared renderer once (1200x628) on the model-written config. This
+// reproduces the skill's own resolution + render with the real resolver, so
+// "could not resolve" warnings surface as a failure — and the produced PNG is
+// reused for the logo-visibility check. Caller deletes `tmp`.
+function renderProbe(cfgAbs) {
+  const tmp = join(REPO_ROOT, ".context", "event-images", "eval", "_probe.png")
+  const r = spawnSync("node", [RENDERER, "--config", cfgAbs, "--size", "1200x628", "--out", tmp],
+    { cwd: REPO_ROOT, encoding: "utf-8" })
+  const warned = /could not resolve/i.test((r.stderr || "") + (r.stdout || ""))
+  return { tmp, rendered: r.status === 0, ok: r.status === 0 && !warned, detail: r.status !== 0 ? `renderer exit ${r.status}` : warned ? "could-not-resolve warning" : "" }
+}
+
+function runSkill(prompt, modelId, outRel) {
+  const full = `/event-meta-image ${prompt.replace(/OUTDIR/g, outRel)}`
+  const r = spawnSync(CLAUDE_BIN, ["-p", full, "--model", modelId, "--output-format", "json", "--dangerously-skip-permissions"],
+    { cwd: REPO_ROOT, encoding: "utf-8", timeout: 15 * 60 * 1000, maxBuffer: 64 * 1024 * 1024 })
+  let cost = null, runErr = null
+  if (r.error) runErr = String(r.error)
+  try {
+    const j = JSON.parse(r.stdout)
+    cost = typeof j.total_cost_usd === "number" ? j.total_cost_usd : null
+    if (j.is_error) runErr = runErr || "claude reported is_error"
+  } catch { runErr = runErr || "could not parse claude --output-format json output" }
+  return { cost, runErr }
+}
+
+// ---- assertions for one fixture run ----------------------------------------
+function assertFixture(fx, outAbs) {
+  const checks = []
+  const add = (name, ok, detail = "") => checks.push({ name, ok, detail })
+
+  const cfgPath = join(outAbs, "config.json")
+  if (!existsSync(cfgPath)) { add("config.json written", false, `missing at ${cfgPath}`); return checks }
+  add("config.json written", true)
+
+  let cfg
+  try { cfg = JSON.parse(readFileSync(cfgPath, "utf-8")) } catch (e) { add("config.json parses", false, String(e)); return checks }
+  add("config.json parses", true)
+
+  const e = fx.expect || {}
+  if (e.showButton !== undefined) add(`showButton == ${e.showButton}`, !!cfg.showButton === e.showButton, `got ${!!cfg.showButton}`)
+  if (e.speakers !== undefined) { const n = (cfg.speakers || []).length; add(`speakers == ${e.speakers}`, n === e.speakers, `got ${n}`) }
+  if (e.logosInclude) for (const needle of e.logosInclude) {
+    const hit = (cfg.logos || []).some((l) => l.toLowerCase().includes(needle.toLowerCase()))
+    add(`logos include "${needle}"`, hit, hit ? "" : `got ${JSON.stringify(cfg.logos || [])}`)
+  }
+  if (e.additionalTextIncludes) for (const needle of e.additionalTextIncludes)
+    add(`byline includes "${needle}"`, includesAll(cfg.additionalText, [needle]), `got ${JSON.stringify(cfg.additionalText || "")}`)
+
+  // One card PNG per expected size (filename-agnostic). Ignore stray PNGs whose
+  // size isn't a card size — the skill saves fetched source photos (headshots)
+  // into the same dir per Step 3, and those must not count against the five cards.
+  const pngs = existsSync(outAbs) ? readdirSync(outAbs).filter((f) => f.endsWith(".png")) : []
+  const sizes = pngs.map((f) => pngSize(join(outAbs, f))).filter(Boolean)
+  const counts = {}
+  for (const s of sizes) if (EXPECTED_SIZES.includes(s)) counts[s] = (counts[s] || 0) + 1
+  const allOnce = EXPECTED_SIZES.every((s) => counts[s] === 1)
+  const cardTotal = Object.values(counts).reduce((a, b) => a + b, 0)
+  const nonCard = sizes.length - cardTotal
+  add("five card PNGs at correct sizes", allOnce && cardTotal === 5,
+    `card sizes: ${Object.keys(counts).sort().join(", ") || "none"}${nonCard ? ` (+${nonCard} non-card asset ignored)` : ""}`)
+
+  const probe = renderProbe(cfgPath)
+  add("renders with no unresolved assets", probe.ok, probe.detail)
+
+  // Logo visibility: a resolved logo can still be invisible (a white / dark-mode
+  // asset on the near-white card). If a non-Pulumi partner logo is expected or
+  // present, it must actually paint ink on the card — resolution alone isn't enough.
+  const partnerExpected = (e.logosInclude || []).some((l) => l.toLowerCase() !== "pulumi")
+    || (cfg.logos || []).some((l) => l.toLowerCase() !== "pulumi" && !l.toLowerCase().includes("/pulumi"))
+  if (partnerExpected && probe.rendered) {
+    const img = decodePNG(probe.tmp)
+    if (!img) add("partner logo visible on card", true, "skipped — render not decodable")
+    else { const n = partnerInk(img); add("partner logo visible on card", n >= LOGO_VISIBLE_MIN, `ink=${n} (min ${LOGO_VISIBLE_MIN})`) }
+  }
+  rmSync(probe.tmp, { force: true })
+
+  return checks
+}
+
+// ---- run --------------------------------------------------------------------
+console.log(`repo: ${REPO_ROOT}`)
+console.log(`models: ${models.join(", ")}   fixtures: ${fixtures.map((f) => f.id).join(", ")}\n`)
+
+const results = {} // model -> { rows:[{fx, passed, gating, cost, checks}], cost }
+let hardFail = false
+
+for (const alias of models) {
+  const { id } = MODELS[alias]
+  results[alias] = { rows: [], cost: 0 }
+  console.log(`\n===== ${alias} (${id}) =====`)
+  for (const fx of fixtures) {
+    // With --keep, namespace output by model so every model's cards survive
+    // (otherwise later models clobber earlier ones in the shared per-fixture dir).
+    const outRel = keep ? join(spec.outBase, fx.id, alias) : join(spec.outBase, fx.id)
+    const outAbs = join(REPO_ROOT, outRel)
+    rmSync(outAbs, { recursive: true, force: true })
+    mkdirSync(outAbs, { recursive: true })
+    if (fx.web && fx.forceMissLogo) rmCacheLogo(fx.forceMissLogo) // force a real fetch
+
+    process.stdout.write(`  ${fx.id} ... `)
+    const { cost, runErr } = runSkill(fx.prompt, id, outRel)
+    const checks = runErr ? [{ name: "skill run", ok: false, detail: runErr }] : assertFixture(fx, outAbs)
+
+    if (fx.web && fx.forceMissLogo) rmCacheLogo(fx.forceMissLogo) // keep committed cache clean
+    if (!keep) rmSync(outAbs, { recursive: true, force: true })
+
+    const passed = checks.every((c) => c.ok)
+    // A fixture gates the exit code unless it's soft, or it's a web fixture and we're not in --web-strict.
+    const gating = !fx.soft && (!fx.web || webStrict)
+    if (!passed && gating) hardFail = true
+    if (cost != null) results[alias].cost += cost
+
+    const tag = fx.web ? "web" : "core"
+    console.log(`${passed ? "PASS" : (gating ? "FAIL" : "warn")} (${tag}${cost != null ? `, $${cost.toFixed(4)}` : ""})`)
+    for (const c of checks) if (!c.ok) console.log(`      ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ""}`)
+    results[alias].rows.push({ fx, passed, gating, cost, checks })
+  }
+}
+
+// ---- summary + cost ranking -------------------------------------------------
+console.log(`\n\n===== summary =====`)
+const rank = models.map((alias) => {
+  const rows = results[alias].rows
+  const core = rows.filter((r) => !r.fx.web)
+  const web = rows.filter((r) => r.fx.web)
+  const corePass = core.filter((r) => r.passed).length
+  const webPass = web.filter((r) => r.passed).length
+  return {
+    alias, corePass, coreTotal: core.length, webPass, webTotal: web.length,
+    allCore: corePass === core.length, cost: results[alias].cost, out: MODELS[alias].out,
+  }
+}).sort((a, b) => (a.allCore !== b.allCore ? (a.allCore ? -1 : 1) : a.cost - b.cost))
+
+const pad = (s, n) => String(s).padEnd(n)
+console.log(`${pad("model", 9)}${pad("core", 8)}${pad("web", 8)}${pad("out $/1M", 10)}${pad("run $", 10)}verdict`)
+for (const r of rank) {
+  const verdict = r.allCore ? "core PASS" : "core FAIL"
+  console.log(`${pad(r.alias, 9)}${pad(`${r.corePass}/${r.coreTotal}`, 8)}${pad(r.webTotal ? `${r.webPass}/${r.webTotal}` : "-", 8)}${pad(`$${r.out}`, 10)}${pad(`$${r.cost.toFixed(4)}`, 10)}${verdict}`)
+}
+const cheapest = rank.find((r) => r.allCore)
+if (cheapest) console.log(`\nCheapest model passing all core fixtures: ${cheapest.alias} (out $${cheapest.out}/1M, this run $${cheapest.cost.toFixed(4)})`)
+else console.log(`\nNo tested model passed all core fixtures.`)
+
+process.exit(hardFail ? 1 : 0)

--- a/EVENT-SOCIAL-CARDS.md
+++ b/EVENT-SOCIAL-CARDS.md
@@ -13,9 +13,9 @@ Find your situation:
 | Your situation | What to do |
 |---|---|
 | An internal event (Pulumi hosts only), and you just need the shared image to look good | Nothing. The build generates it from frontmatter. |
+| You want the extra social sizes (portrait, tall, or square-large) | Run [the render script](#extra-sizes-without-ai). It reads the same frontmatter, so you don't need the skill. |
 | An external co-host whose photo is in `presenters` | Nothing needed for the photo, though the card won't show their company logo. Add the logo with the skill. |
 | You want the co-host's company logo on the card | Use the [`/event-meta-image` skill](#custom-cards-with-the-event-meta-image-skill). |
-| You want the extra social sizes (portrait, tall, or square-large) | Run [the render script](#extra-sizes-without-ai). |
 
 ## What the build generates automatically
 

--- a/EVENT-SOCIAL-CARDS.md
+++ b/EVENT-SOCIAL-CARDS.md
@@ -1,0 +1,63 @@
+# Event social cards (OpenGraph / meta images)
+
+When someone shares an event page (a workshop, webinar, or talk under `content/events/<slug>/index.md`) on X, LinkedIn, or Slack, the image they see is its social card: the `og:image` and `twitter:image`.
+
+You usually don't have to make one. The site generates it automatically at build time from the event's frontmatter. This guide covers when that automatic card is enough and when to make your own.
+
+> This is about the workshop and webinar event bundles under `content/events/`. It doesn't cover the widget-based marketing landing pages (`layout: event-page`, like `content/kubecon/`), which have their own [event page template guide](./EVENT-PAGE-TEMPLATE-GUIDE.md).
+
+## Quick decision guide
+
+Find your situation:
+
+| Your situation | What to do |
+|---|---|
+| An internal event (Pulumi hosts only), and you just need the shared image to look good | Nothing. The build generates it from frontmatter. |
+| An external co-host whose photo is in `presenters` | Nothing needed for the photo, though the card won't show their company logo. Add the logo with the skill. |
+| You want the co-host's company logo on the card | Use the [`/event-meta-image` skill](#custom-cards-with-the-event-meta-image-skill). |
+| You want the extra social sizes (portrait, tall, or square-large) | Run [the render script](#extra-sizes-without-ai). |
+
+## What the build generates automatically
+
+At build time, `scripts/generate-meta-images.mjs` renders each event two cards from frontmatter: a landscape card at 1200×628 and a square one at 628×628. It reads the `title`, the `event_type` (shown as the overline), and each photo under `presenters`, then wires the cards to the page's meta tags for you. You don't set `meta_image` yourself.
+
+The generated cards are ephemeral. For an event at `content/events/<slug>/index.md`, they land at:
+
+```text
+assets/images/generated/events/<slug>/index.png         # landscape, 1200×628
+assets/images/generated/events/<slug>/index.square.png  # square, 628×628
+```
+
+That directory is gitignored and rebuilt on every build, so you never commit or edit these files directly. To change a card, change the frontmatter and rebuild.
+
+For a typical Pulumi-hosted event, that's all you need. Fill in `title`, `event_type`, and the `presenters` (each with a `photo`), and you get a good landscape and square card.
+
+## The external-host gap
+
+If your event has an external co-host, add them to `presenters` with a `photo`, and their headshot shows up on the automatic card. That covers most cases.
+
+The one thing the automatic card can't do is show the co-host's company logo, since it always renders the Pulumi logo on its own. When you want a "Pulumi + Acme" lockup, you'll need a [custom card](#custom-cards-with-the-event-meta-image-skill).
+
+## Extra sizes without AI
+
+Beyond the landscape and square cards, the renderer also supports portrait (540×960), tall (1200×675), and square-large (1080×1080) for manual posting. To render all five straight from frontmatter, with the same look as the automatic card, run:
+
+```bash
+node scripts/meta-images/render-event-cards.mjs <slug-or-path> [--out <dir>]
+```
+
+Pass an event slug, which resolves to `content/events/<slug>/index.md`, or a path to the `index.md`. Without `--out`, the script writes the five images into the event bundle. With `--out <dir>`, it writes them to a folder you choose (for example, a scratch directory) and leaves the bundle untouched. It never modifies frontmatter.
+
+## Custom cards with the /event-meta-image skill
+
+Some cards need judgment a script can't apply: a partner or company logo, a co-presenter who isn't in frontmatter, or a headshot you have to find on the web. For those, use the `/event-meta-image` skill in Claude Code or another agent. It adds the logos and people, renders all five sizes into the event bundle, and sets `meta_image` and `meta_image_square` so the custom card overrides the automatic one. The agent-facing details live in [the skill itself](./.claude/commands/event-meta-image/SKILL.md).
+
+To run it without answering prompts, pass `--yes` (or its alias `--non-interactive`), as in `/event-meta-image <slug> --yes`. The skill then fills in sensible defaults and asks nothing. It still searches for the people and logos it can infer from the event, and skips anything it can't resolve rather than stopping to ask.
+
+### Which model to run it with
+
+For an event whose assets are all local, such as Pulumi hosts with presenter photos already in frontmatter, any model runs the skill well, including the least expensive, Claude Haiku. Sourcing a company logo or headshot from the web is the one step where a smaller model can pick a poor asset, like a white or dark-mode logo that's invisible on the near-white card. For those runs, use Claude Sonnet or larger. The skill's eval, under `.claude/commands/event-meta-image/eval/`, is where this was measured.
+
+## Overriding manually
+
+If you'd rather supply your own image, set `meta_image` in the event's frontmatter, or commit the PNGs the skill produced. Either one overrides the automatic card for that page.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See also:
 * [Build and deployment guide](./BUILD-AND-DEPLOY.md)
 * [Publishing a Pulumi blog post](./BLOGGING.md)
 * [Documentation and coding style guide](./STYLE-GUIDE.md)
+* [Event social cards (OpenGraph / meta images)](./EVENT-SOCIAL-CARDS.md)
 * [AI agent instructions](./AGENTS.md)
 
 # Setup and Development

--- a/scripts/meta-images/events.mjs
+++ b/scripts/meta-images/events.mjs
@@ -244,17 +244,18 @@ export async function eventsTree(fields, { w, h: height }) {
       h("div", { style: { display: "flex", flexDirection: "column", width: innerW, height: innerH } }, main, bottom))
   }
 
-  // portrait: speakers on top, text below. A gap below the speaker row keeps the
-  // text clear of the accent lines that curve down around the photo (space-between
-  // pushes the text block to the bottom, mirroring the Figma frame).
-  const topH = n ? spec.speakersRowH : 0
-  const portraitGap = n ? 64 : 0
+  // portrait: speakers on top, text below. The speaker band is ALWAYS reserved —
+  // even with no speakers — so the text block stays clear of the accent lines that
+  // curve down the top of the frame (an empty spacer holds the space a photo row
+  // would occupy). space-between then pushes the text to the bottom, per Figma.
+  const topH = spec.speakersRowH
+  const portraitGap = 64
   const top = n
     ? h("div", { style: { display: "flex", alignItems: "center", width: innerW, height: topH, flexShrink: 0 } }, speakerCluster(speakers, sS, spec.s))
-    : null
+    : h("div", { style: { width: innerW, height: topH, flexShrink: 0 } })
   const main = mainColumn(fields, spec, font, innerW, innerH - topH - portraitGap)
   return frame(w, height, spec,
-    h("div", { style: { display: "flex", flexDirection: "column", width: innerW, height: innerH, justifyContent: speakers.length ? "space-between" : "flex-start" } }, top, main))
+    h("div", { style: { display: "flex", flexDirection: "column", width: innerW, height: innerH, justifyContent: "space-between" } }, top, main))
 }
 
 // --- Field builders / resolvers ----------------------------------------------

--- a/scripts/meta-images/render-event-cards.mjs
+++ b/scripts/meta-images/render-event-cards.mjs
@@ -1,0 +1,68 @@
+// render-event-cards.mjs — render the DEFAULT event card in all five sizes
+// straight from an event's frontmatter, with NO model / LLM involved.
+//
+// This is the mechanical equivalent of the /event-meta-image skill's default path:
+// it maps frontmatter via eventFieldsFromFrontmatter (the SAME mapping the build
+// uses) and renders the five committed sizes. Use it when you just want the default
+// look from the event's title + presenters — the skill is only needed to ENRICH a
+// card with people or partner logos that aren't in frontmatter (which needs a model
+// to identify/search for them).
+//
+//   node scripts/meta-images/render-event-cards.mjs <slug-or-path-to-index.md> [--out <dir>]
+//
+// <slug-or-path> may be an event slug (resolved to content/events/<slug>/index.md)
+// or a direct path to an index.md. Default --out is the event bundle dir (matching
+// the skill's event-bound filenames); pass --out to write elsewhere (e.g. a preview
+// folder) without touching the bundle. Frontmatter is never modified.
+
+import { readFileSync, mkdirSync, writeFileSync } from "fs"
+import { join, resolve, dirname, basename } from "path"
+import matter from "gray-matter"
+import satori from "satori"
+import { Resvg } from "@resvg/resvg-js"
+import { loadFonts } from "./lib.mjs"
+import { eventsTree, eventFieldsFromFrontmatter } from "./events.mjs"
+
+// Same size → filename mapping the skill writes for event-bound output.
+const SIZES = [
+  [1200, 628, "meta.png"],
+  [628, 628, "meta-square.png"],
+  [1200, 675, "meta-landscape-tall.png"],
+  [1080, 1080, "meta-square-large.png"],
+  [540, 960, "meta-portrait.png"],
+]
+
+function parseArgs(argv) {
+  const out = { target: null, out: null }
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--out") out.out = argv[++i]
+    else if (!out.target) out.target = argv[i]
+  }
+  return out
+}
+
+const args = parseArgs(process.argv.slice(2))
+if (!args.target) {
+  console.error("usage: render-event-frontmatter.mjs <slug-or-path-to-index.md> [--out <dir>]")
+  process.exit(2)
+}
+
+const idxPath = args.target.endsWith(".md")
+  ? resolve(args.target)
+  : resolve("content/events", args.target, "index.md")
+const slug = basename(dirname(idxPath))
+const fm = matter(readFileSync(idxPath, "utf-8")).data
+const fields = eventFieldsFromFrontmatter(fm, slug)
+if (!fields.title) { console.error(`no title in frontmatter: ${idxPath}`); process.exit(2) }
+
+const outDir = args.out ? resolve(args.out) : dirname(idxPath)
+mkdirSync(outDir, { recursive: true })
+const fonts = loadFonts()
+
+for (const [w, h, name] of SIZES) {
+  const tree = await eventsTree(fields, { w, h })
+  const svg = await satori(tree, { width: w, height: h, fonts })
+  const png = new Resvg(svg, { fitTo: { mode: "width", value: w } }).render().asPng()
+  writeFileSync(join(outDir, name), png)
+  console.log(`rendered ${w}x${h} → ${join(outDir, name)}`)
+}

--- a/scripts/meta-images/render-event-cards.mjs
+++ b/scripts/meta-images/render-event-cards.mjs
@@ -43,7 +43,7 @@ function parseArgs(argv) {
 
 const args = parseArgs(process.argv.slice(2))
 if (!args.target) {
-  console.error("usage: render-event-frontmatter.mjs <slug-or-path-to-index.md> [--out <dir>]")
+  console.error("usage: render-event-cards.mjs <slug-or-path-to-index.md> [--out <dir>]")
   process.exit(2)
 }
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.-->

### Proposed changes

Harden and document the `/event-meta-image` skill: a Register button is now opt-in only, a new unattended mode (`-y` / `--yes` / `--non-interactive`) runs with no prompts, and the default flow asks only when it can't resolve an asset. Adds a headless LLM eval (`eval/`) that runs the skill via `claude -p` across fixtures and checks the produced config and rendered cards (button state, speaker count, logo visibility, sizes) while ranking models by cost. Adds `scripts/meta-images/render-event-cards.mjs` to render an event's default card in all five sizes straight from frontmatter with no model, plus a new `EVENT-SOCIAL-CARDS.md` author guide (linked from the README) explaining the automatic build-time cards versus the skill. Also fixes the portrait card's accent lines overlapping the text when an event has no speakers.

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'. -->