### PR TITLE
Fix oversized footer overline headings on /tutorials

### DIFF
--- a/theme/src/scss/docs/_tutorials.scss
+++ b/theme/src/scss/docs/_tutorials.scss
@@ -33,24 +33,28 @@
         }
     }
 
-    h2 {
-        @apply text-2xl;
-    }
+    // Scope content heading sizes to `main` so they don't override the site
+    // footer's `.footer-heading` (which shares the same `h3` etc. tags).
+    main {
+        h2 {
+            @apply text-2xl;
+        }
 
-    h3 {
-        @apply text-xl;
-    }
+        h3 {
+            @apply text-xl;
+        }
 
-    h4 {
-        @apply text-lg;
-    }
+        h4 {
+            @apply text-lg;
+        }
 
-    h5 {
-        @apply text-base;
-    }
+        h5 {
+            @apply text-base;
+        }
 
-    h6 {
-        @apply text-sm;
+        h6 {
+            @apply text-sm;
+        }
     }
 
     // Summaries may not end up in `p` tags (which would style them automatically), so


### PR DESCRIPTION
### Proposed changes

On `/tutorials` pages, the site footer's overline column headings ("Product", "Company", etc.) rendered at ~20px instead of the intended 12px. The cause was `.section-tutorials h3` in `theme/src/scss/docs/_tutorials.scss`, which set content headings to `text-xl` and — sharing the `h3` tag — outranked the footer's `.footer-heading` rule. This scopes the tutorial content heading sizes (`h2`–`h6`) to `<main>`, so they no longer leak into the footer (which renders outside `<main>`). Tutorial page content headings are unchanged.

### Related issues (optional)

<!-- none -->