### PR TITLE
Enable AI pre-merge reviews for Eon-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -443,9 +443,13 @@ jobs:
           REPO_FULL="${{ github.repository }}"
           AUTHOR="${{ steps.pr-context.outputs.author }}"
 
-          if [[ "$AUTHOR" == "github-copilot[bot]" ]]; then
+          # GitHub App bots are not collaborators, so the permission API
+          # below returns "none" for them. Trusted agent bots that open
+          # PRs on this repo are whitelisted by name instead. Keep this
+          # list in sync with the matching check in claude-triage.yml.
+          if [[ "$AUTHOR" == "github-copilot[bot]" || "$AUTHOR" == "eon-pulumi-agent[bot]" ]]; then
             echo "has_write_access=true" >> $GITHUB_OUTPUT
-            echo "✓ Copilot bot $AUTHOR is whitelisted for Claude reviews"
+            echo "✓ Bot $AUTHOR is whitelisted for Claude reviews"
             exit 0
           fi
 

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -108,9 +108,13 @@ jobs:
           REPO_FULL="${{ github.repository }}"
           AUTHOR="${{ github.event.pull_request.user.login }}"
 
-          if [[ "$AUTHOR" == "github-copilot[bot]" ]]; then
+          # GitHub App bots are not collaborators, so the permission API
+          # below returns "none" for them. Trusted agent bots that open
+          # PRs on this repo are whitelisted by name instead. Keep this
+          # list in sync with the matching check in claude-code-review.yml.
+          if [[ "$AUTHOR" == "github-copilot[bot]" || "$AUTHOR" == "eon-pulumi-agent[bot]" ]]; then
             echo "has_write_access=true" >> $GITHUB_OUTPUT
-            echo "✓ Copilot bot $AUTHOR is whitelisted for triage"
+            echo "✓ Bot $AUTHOR is whitelisted for triage"
             exit 0
           fi
 


### PR DESCRIPTION
### Proposed changes

PRs opened by the Eon agent (`eon-pulumi-agent[bot]`) never received the AI pre-merge review. GitHub App bots are not repo collaborators, so the write-access check in `claude-triage.yml` and `claude-code-review.yml` resolved their permission to `none`, and every review step silently skipped. This also blocked the manual `@claude #new-review` escape hatch: the forced dispatch bypasses the skip-reason heuristics but still gates on the PR *author's* write access (see [#20290](https://github.com/pulumi/docs/pull/20290), where a `#new-review` produced no review).

This change whitelists `eon-pulumi-agent[bot]` alongside the existing `github-copilot[bot]` entry in both access checks, following the established Copilot precedent, so Eon PRs flow through the normal triage → review chain. Both checks carry a comment noting the two lists must stay in sync.

No other gates need changes: the `bot-author` skip in `claude-code-review.yml` and the triage job-level filter only match `pulumi-bot`/`dependabot[bot]`, and `claude-update.yml`/`claude-new.yml` gate on the commenter, not the PR author.

After this merges, a fresh `@claude #new-review` on #20290 will generate the review there (the dispatched workflow runs from `master`).

### Unreleased product version (optional)

N/A

### Related issues (optional)

Context: https://pulumi.slack.com/archives/C85BS3LJZ/p1784126858275999 and #20290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PajeF1zxbk7BrG1hC1GKwG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PajeF1zxbk7BrG1hC1GKwG)_