### PR TITLE
triage: add review:oversized lane for PRs too large to review

### DIFF
--- a/.claude/commands/docs-review/scripts/set-review-label.sh
+++ b/.claude/commands/docs-review/scripts/set-review-label.sh
@@ -13,7 +13,8 @@
 #
 # These five labels are mutually exclusive. Setting any one removes the
 # other four. Skip-reason labels (review:trivial, review:frontmatter-only,
-# review:prose-flagged) are informational and live outside this set.
+# review:oversized, review:prose-flagged) are informational and live outside
+# this set.
 #
 # Usage:
 #   set-review-label.sh --pr 123 --label review:in-progress [--repo owner/repo]

--- a/.claude/commands/docs-review/scripts/test_triage_classify.py
+++ b/.claude/commands/docs-review/scripts/test_triage_classify.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Tests for triage-classify.py — the deterministic PR triage classifier.
+
+Self-contained — run with `python3 test_triage_classify.py` (no pytest dep).
+Shells out to the script the same way claude-triage.yml does (PR JSON on
+argv[1], unified diff on stdin) and asserts on the JSON it emits.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CLASSIFY = HERE / "triage-classify.py"
+
+_failures: list[str] = []
+_passes = 0
+
+
+def check(cond: bool, msg: str) -> None:
+    global _passes
+    if cond:
+        _passes += 1
+    else:
+        _failures.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def run_classify(pr_data: dict, diff: str = "") -> dict:
+    with tempfile.TemporaryDirectory() as td:
+        pf = Path(td) / "pr.json"
+        pf.write_text(json.dumps(pr_data))
+        r = subprocess.run([sys.executable, str(CLASSIFY), str(pf)],
+                           input=diff, capture_output=True, text=True)
+        assert r.returncode == 0, f"triage-classify.py exited {r.returncode}: {r.stderr}"
+        return json.loads(r.stdout)
+
+
+def _pr(additions: int, deletions: int, paths: list[str]) -> dict:
+    return {
+        "additions": additions,
+        "deletions": deletions,
+        "files": [{"path": p, "additions": additions // max(len(paths), 1), "deletions": 0}
+                  for p in paths],
+        "labels": [],
+    }
+
+
+def test_oversized_threshold() -> None:
+    print("test_oversized_threshold")
+    # A generated-corpus monster (the PR #20274 shape) is oversized.
+    big = run_classify(_pr(99_664, 1_759, ["data/policy_pack_policies/cis.yaml",
+                                           "content/docs/reference/x/_index.md",
+                                           "scripts/gen-policy-docs.ts"]))
+    check(big["oversized"] is True, f"99K-line PR classifies oversized; got {big['oversized']}")
+
+    # Exactly at the threshold: not oversized (strict >).
+    at = run_classify(_pr(10_000, 5_000, ["content/docs/a.md"]))
+    check(at["oversized"] is False, f"15,000 changed lines is NOT oversized (strict >); got {at['oversized']}")
+
+    # Just over: oversized. Deletions count toward the total.
+    over = run_classify(_pr(1, 15_000, ["content/docs/a.md"]))
+    check(over["oversized"] is True, f"15,001 changed lines (deletion-heavy) IS oversized; got {over['oversized']}")
+
+    # A normal hand-written PR is nowhere near it.
+    normal = run_classify(_pr(406, 1, ["content/blog/post/index.md"]))
+    check(normal["oversized"] is False, "a 407-line PR is not oversized")
+    check("oversized" in normal, "oversized field always present")
+
+
+def main() -> int:
+    tests = [test_oversized_threshold]
+    for t in tests:
+        try:
+            t()
+        except AssertionError as e:
+            _failures.append(f"{t.__name__}: assertion error: {e}")
+            print(f"  FAIL: {t.__name__}: {e}", file=sys.stderr)
+        except Exception as e:  # noqa: BLE001
+            _failures.append(f"{t.__name__}: {type(e).__name__}: {e}")
+            print(f"  FAIL: {t.__name__}: {type(e).__name__}: {e}", file=sys.stderr)
+
+    print(f"\n{_passes} check(s) passed, {len(_failures)} failed.")
+    return 1 if _failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/commands/docs-review/scripts/triage-classify.py
+++ b/.claude/commands/docs-review/scripts/triage-classify.py
@@ -21,6 +21,15 @@ from collections.abc import Iterable
 
 WEBPACK_RE = re.compile(r"^webpack\.[^/]+\.js$")
 
+# Above this many changed lines (additions + deletions), the PR is `oversized`:
+# too big for the review pipeline to finish inside its job timeout, and at this
+# scale the bulk is invariably generated output that an LLM line-review adds no
+# value to (PR #20274: ~100K generated lines; the main review step was killed
+# at the 25-minute mark on every attempt). Triage labels it `review:oversized`
+# and the review workflow skips it with an advisory comment instead of
+# error-cycling. Hand-written PRs run one to two orders of magnitude smaller.
+OVERSIZED_TOTAL_LINES = 15_000
+
 
 def classify_path(path: str) -> str | None:
     # Programs first — both static/programs/** AND scripts/programs/** are
@@ -295,6 +304,7 @@ def classify_pr(pr_data: dict, file_flags: list[dict]) -> dict:
         "mixed": len(domains) > 1,
         "trivial": trivial,
         "frontmatter_only": frontmatter_only,
+        "oversized": total_lines > OVERSIZED_TOTAL_LINES,
         "prose_check_needed": trivial or frontmatter_only,
         "summary": {
             "lines": total_lines,

--- a/.github/labels-pr-review.md
+++ b/.github/labels-pr-review.md
@@ -24,6 +24,7 @@ Load-bearing — these gate workflow execution.
 |---|---|---|
 | `review:trivial` | `c2e0c6` | Tiny prose-only change. Skips Claude review entirely; lint still runs. Set by triage. |
 | `review:frontmatter-only` | `e0f5d8` | Hugo content `.md` files where every change is inside the frontmatter block. Skips Claude review; lint still runs. Set by triage. |
+| `review:oversized` | `f9d0c4` | Diff exceeds the automated review budget (>15K changed lines — in practice generated corpora). Skips Claude review; triage posts a `<!-- TRIAGE_OVERSIZED -->` advisory comment. Set by triage. |
 | `review:prose-flagged` | `fef2c0` | Trivial or frontmatter-only PR where triage's prose-check pass found possible spelling/grammar issues. See the `<!-- TRIAGE_PROSE -->` comment. Set by triage. |
 | `review:triaging` | `e8db95` | Claude Triage is currently classifying the PR (domain routing, trivial/frontmatter-only short-circuit). Visible from PR-open until triage finishes (~10-60s). |
 | `review:in-progress` | `fbca04` | Claude review is currently running for this PR's current state. |
@@ -47,6 +48,7 @@ gh label create "domain:programs"        --color fbca04 --description "PR touche
 gh label create "domain:mixed"           --color bfd4f2 --description "PR touches more than one domain"
 gh label create "review:trivial"         --color c2e0c6 --description "Tiny prose-only change; skips Claude review"
 gh label create "review:frontmatter-only" --color e0f5d8 --description "Frontmatter-only Hugo content edit; skips Claude review"
+gh label create "review:oversized"       --color f9d0c4 --description "Diff too large for automated review (generated corpora); skips Claude review"
 gh label create "review:prose-flagged"   --color fef2c0 --description "Triage's prose-check found possible spelling/grammar issues on a short-circuited PR"
 gh label create "review:triaging"        --color e8db95 --description "Claude Triage is currently classifying the PR"
 gh label create "review:in-progress"     --color fbca04 --description "Claude review is currently running"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -317,9 +317,9 @@ jobs:
 
           # force=true (set by claude-new.yml on #new-review dispatch)
           # bypasses the auto-skip heuristics. The user explicitly asked
-          # for a regenerate; trivial / fmonly / draft / bot-author /
-          # already-reviewed are all overridable. Empty-diff is NOT
-          # overridable — there's nothing to review.
+          # for a regenerate; trivial / fmonly / oversized / draft /
+          # bot-author / already-reviewed are all overridable. Empty-diff is
+          # NOT overridable — there's nothing to review.
           SKIP=""
           if [[ "$FORCE" != "true" ]]; then
             if [[ "$IS_DRAFT" == "true" ]]; then
@@ -328,6 +328,13 @@ jobs:
               SKIP="trivial"
             elif [[ ",$LABELS_CSV," == *",review:frontmatter-only,"* ]]; then
               SKIP="frontmatter-only"
+            # Oversized PRs (triage-set; >15K changed lines — in practice
+            # generated corpora) can't finish inside the job timeout: every
+            # attempt burns ~25 minutes of runner + API spend, then
+            # error-cycles the labels. Triage posts a TRIAGE_OVERSIZED
+            # advisory comment explaining the skip and the alternatives.
+            elif [[ ",$LABELS_CSV," == *",review:oversized,"* ]]; then
+              SKIP="oversized"
             # Bot-authored PRs are slop-skipped — EXCEPT content-review/*, which
             # are first-class automated docs fixes we want reviewed. Those fall
             # through to the already-reviewed guard below (so they still can't
@@ -500,6 +507,23 @@ jobs:
             --pr "${{ steps.pr-context.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
             --label review:in-progress
+
+      # An oversized skip supersedes any leftover terminal state from earlier
+      # attempts (typically review:error from a pre-label timeout run) —
+      # without this, the stale error label sits next to review:oversized and
+      # reads as "the pipeline is still broken" when the skip is deliberate.
+      # Other skip paths (trivial / fmonly / draft / bot) never had a prior
+      # state label, so they don't need this.
+      - name: Clear stale review-state label (oversized skip)
+        if: steps.check-access.outputs.has_write_access == 'true' && steps.pr-context.outputs.skip_reason == 'oversized'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          .claude/commands/docs-review/scripts/set-review-label.sh \
+            --pr "${{ steps.pr-context.outputs.pr_number }}" \
+            --repo "${{ github.repository }}" \
+            --clear
 
       # Run Vale on PR-changed files in content/docs and content/blog. Findings
       # are filtered to PR-introduced lines only, capped (10/file, 50 total),

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -183,6 +183,7 @@ jobs:
           MIXED=$(echo "$CLASS" | jq -r '.mixed // false')
           TRIVIAL=$(echo "$CLASS" | jq -r '.trivial // false')
           FRONTMATTER_ONLY=$(echo "$CLASS" | jq -r '.frontmatter_only // false')
+          OVERSIZED=$(echo "$CLASS" | jq -r '.oversized // false')
           PROSE_CHECK_NEEDED=$(echo "$CLASS" | jq -r '.prose_check_needed // false')
 
           # 3. Conditional prose check (model call only for trivial /
@@ -251,6 +252,7 @@ jobs:
           elif [[ "$FRONTMATTER_ONLY" == "true" ]]; then
             TARGET["review:frontmatter-only"]=1
           fi
+          [[ "$OVERSIZED" == "true" ]] && TARGET["review:oversized"]=1
           # Prose concerns flag — applies to either trivial or
           # frontmatter-only when EITHER the Haiku spelling/grammar check
           # OR the Vale style check turned up issues.
@@ -267,7 +269,7 @@ jobs:
             case "$lbl" in
               review:triaging|review:in-progress|review:outstanding-issues|review:no-blockers|review:stale|review:error|needs-author-response)
                 continue ;;
-              domain:*|review:trivial|review:frontmatter-only|review:prose-flagged)
+              domain:*|review:trivial|review:frontmatter-only|review:oversized|review:prose-flagged)
                 EXISTING["$lbl"]=1 ;;
             esac
           done < <(echo "$PR_DATA" | jq -r '.labels[].name')
@@ -331,13 +333,42 @@ jobs:
               gh pr comment "$PR" --repo "$REPO" --body "$BODY" || true
           fi
 
+          # 8b. Oversized advisory comment. Same delete-and-repost semantics
+          # as TRIAGE_PROSE: always clear any prior copy first (so a PR that
+          # shrinks below the threshold on re-push loses the stale notice),
+          # then post fresh while the PR classifies as oversized.
+          gh api "repos/$REPO/issues/$PR/comments" \
+              --jq '.[] | select(.body | startswith("<!-- TRIAGE_OVERSIZED -->")) | .id' \
+              | while read -r cid; do
+                  [[ -n "$cid" ]] && gh api -X DELETE "repos/$REPO/issues/comments/$cid" >/dev/null 2>&1 || true
+                done
+
+          if [[ "$OVERSIZED" == "true" ]]; then
+              PR_ADDITIONS=$(echo "$PR_DATA" | jq -r '.additions')
+              PR_DELETIONS=$(echo "$PR_DATA" | jq -r '.deletions')
+              PR_FILES=$(echo "$PR_DATA" | jq -r '.files | length')
+              BODY=$(cat <<EOF
+          <!-- TRIAGE_OVERSIZED -->
+          📦 **Oversized PR** — this diff (+$PR_ADDITIONS/−$PR_DELETIONS across $PR_FILES files) exceeds the automated review budget, so the Claude review is skipped (\`review:oversized\`).
+
+          A diff this size is usually mostly generated output, which an automated line-review can't finish (and wouldn't add value to). What works better:
+
+          - Split the hand-written source (scripts, workflows, layouts, templates) into its own PR — that PR gets a normal full review.
+          - Have a human spot-check a sample of the generated output here.
+
+          \`@claude #new-review\` still force-runs a full review, but on a diff this size it will likely hit the job timeout.
+          EOF
+          )
+              gh pr comment "$PR" --repo "$REPO" --body "$BODY" || true
+          fi
+
           # 9. Summary line for the workflow log.
           DOMAINS_CSV=$(echo "$DOMAINS_JSON" | paste -sd, -)
           ADDED_CSV="${ADD_LIST[*]:-}"; ADDED_CSV="${ADDED_CSV// /,}"
           REMOVED_CSV="${REMOVE_LIST[*]:-}"; REMOVED_CSV="${REMOVED_CSV// /,}"
           PROSE_COUNT=$(echo "$PROSE_CONCERNS" | grep -c . || true)
           VALE_COUNT=$(echo "$VALE_CONCERNS" | grep -c . || true)
-          echo "triage: pr=$PR domains=${DOMAINS_CSV:-none} trivial=$TRIVIAL frontmatter-only=$FRONTMATTER_ONLY prose-checked=$PROSE_CHECK_NEEDED prose-concerns=$PROSE_COUNT vale-concerns=$VALE_COUNT added=${ADDED_CSV:-none} removed=${REMOVED_CSV:-none}"
+          echo "triage: pr=$PR domains=${DOMAINS_CSV:-none} trivial=$TRIVIAL frontmatter-only=$FRONTMATTER_ONLY oversized=$OVERSIZED prose-checked=$PROSE_CHECK_NEEDED prose-concerns=$PROSE_COUNT vale-concerns=$VALE_COUNT added=${ADDED_CSV:-none} removed=${REMOVED_CSV:-none}"
 
       # Clear the triaging label whether classification succeeded or not
       # — the early-set step ran unconditionally (no access gate), so the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,12 +54,13 @@ The `<!-- CLAUDE_REVIEW N/M -->` comments are managed by the pipeline. Don't del
 
 The pinned comment is also the pipeline's outcome ledger: after a PR closes, a weekly scrape derives what happened to each finding (fixed, conceded, disputed, or merged over) and aggregates it into the Monday `#docs-ops` digest, which is how the review's severity rules get tuned over time.
 
-### Trivial and frontmatter-only short-circuits
+### Trivial, frontmatter-only, and oversized short-circuits
 
-Two label-driven short-circuits skip the full Claude review (linters still run):
+Three label-driven short-circuits skip the full Claude review (linters still run):
 
 - **`review:trivial`** — ≤10 added lines, prose-only body changes, ≤2 docs/blog `.md` files, no frontmatter changes, no link changes, no code blocks. Typo fixes, wording polish, small same-claim sweeps across siblings, and removal-dominant cleanup (no upper bound on deletions). Marketing/website pages (`domain:website`) get full review regardless of size.
 - **`review:frontmatter-only`** — any number of docs/blog `.md` files where every change is inside the frontmatter block. Aliases sweeps, `draft: false` flips, `meta_desc` rewrites, social copy edits.
+- **`review:oversized`** — more than 15K changed lines. At that scale the bulk is invariably generated output: the review can't finish inside its job timeout and wouldn't add value to generated lines anyway. Triage posts a `<!-- TRIAGE_OVERSIZED -->` advisory comment suggesting the hand-written source be split into its own PR. `@claude #new-review` force-overrides the skip.
 
 For both categories, triage runs a focused spelling/grammar pass on the relevant diff slice. If it finds anything, it posts a single advisory comment listing the concerns AND applies `review:prose-flagged` so reviewers don't miss it. The short-circuit label still applies and the full review still skips. This is a guard against rubber-stamping — a typo "fix" that introduces a typo, or a `meta_desc` rewrite with a wrong-word substitution, gets flagged before merge.
 


### PR DESCRIPTION
## What

PRs above **15K changed lines** — in practice generated corpora — cannot finish the review pipeline inside its 25-minute job timeout. #20274 (~100K generated policy-pack lines) has burned the full budget on three attempts, cycling `review:in-progress` → `review:error` without ever publishing a pinned review. #20277 (per-file claim scrutiny) fixed the bulk-mechanical timeout class but can't help here: the main review step itself can't read a diff this size in the time remaining.

This gives the triager the lane decision, following the existing trivial / frontmatter-only short-circuit pattern:

- **`triage-classify.py`** emits `oversized` — deterministic, `additions + deletions > 15,000`. Hand-written PRs run one to two orders of magnitude smaller.
- **`claude-triage.yml`** applies/removes `review:oversized` (managed like the other triage labels, so a PR that shrinks on re-push self-heals) and posts a `<!-- TRIAGE_OVERSIZED -->` advisory comment — delete-and-repost on re-triage, same semantics as `TRIAGE_PROSE` — explaining the skip and suggesting the hand-written source (scripts, workflows, layouts) be split into its own PR for a normal full review.
- **`claude-code-review.yml`** skips on the label. `force=true` (`@claude #new-review`) still overrides, with the documented caveat that a forced run will likely still hit the timeout. The skip also clears any leftover `review:error` state label so a deliberate skip doesn't read as an ongoing pipeline failure.

Label docs (`.github/labels-pr-review.md`), `CONTRIBUTING.md`, and the `set-review-label.sh` header are updated, and the `review:oversized` label has been created in the repo.

## Validation

- New `test_triage_classify.py`: threshold boundary (strict `>`, deletions counted), plus the #20274 shape.
- Classifier run against the real PR JSON: #20274 → `oversized: true`, #20224 → `false`.
- Both modified workflow shell blocks extracted and `bash -n` clean; YAML parses.

## Notes

Once this merges, the next triage pass on #20274 (or any push to it) will label it, clear the error state, and post the advisory comment — no more 25-minute error loops.

This is the skip lane we discussed. A future refinement could give oversized PRs a *scoped* review (hand-written files + sampled output) instead of a skip, but that requires threading a file allowlist through every pre-step and the composed draft, and is deliberately out of scope here.