### PR TITLE
Add social-media cards for case-study industry pages

### DIFF
--- a/layouts/partials/meta-image-key.html
+++ b/layouts/partials/meta-image-key.html
@@ -6,19 +6,22 @@
     pages with no backing file. Shared by meta-image-url.html and
     meta-image-square-url.html so the landscape and square lookups stay in sync.
 
-    Blog taxonomy term pages (category/tag/series) have no backing file, so they
-    key off the term instead: category → "category/<term>", tag →
-    "tags/<urlize term>", series → "series/<term>". These mirror the virtual
-    pages in scripts/meta-images/terms.mjs (category ids and series slugs are
-    already url-safe; tag slugs use urlize, matching that module's port).
+    Blog taxonomy term pages (category/tag/series) and case-study industry term
+    pages have no backing file, so they key off the term instead: category →
+    "category/<term>", tag → "tags/<urlize term>", series → "series/<term>",
+    industry → "industry/<term>". These mirror the virtual pages in
+    scripts/meta-images/terms.mjs and industries.mjs (category/series/industry
+    ids are already url-safe; tag slugs use urlize, matching that module's port).
 */ -}}
 {{- $key := "" -}}
-{{- if and (eq .Kind "term") (in (slice "category" "tag" "series") .Data.Singular) -}}
+{{- if and (eq .Kind "term") (in (slice "category" "tag" "series" "industry") .Data.Singular) -}}
     {{- $slug := .Data.Term | urlize -}}
     {{- if eq .Data.Singular "category" -}}
         {{- $key = printf "category/%s" $slug -}}
     {{- else if eq .Data.Singular "series" -}}
         {{- $key = printf "series/%s" $slug -}}
+    {{- else if eq .Data.Singular "industry" -}}
+        {{- $key = printf "industry/%s" $slug -}}
     {{- else -}}
         {{- $key = printf "tags/%s" $slug -}}
     {{- end -}}

--- a/scripts/generate-meta-images.mjs
+++ b/scripts/generate-meta-images.mjs
@@ -41,6 +41,7 @@ import {
 import { eventFieldsFromFrontmatter } from "./meta-images/events.mjs"
 import { renderPng, CANVAS_W, CANVAS_H } from "./meta-images/render.mjs"
 import { termPages } from "./meta-images/terms.mjs"
+import { industryPages } from "./meta-images/industries.mjs"
 
 const require = createRequire(import.meta.url)
 const yaml = require("js-yaml")
@@ -322,11 +323,12 @@ function listPages() {
     for (const p of secPages) p.key = cacheKey(p)
     pages.push(...secPages)
   }
-  // Virtual "terms" section: blog category/tag term pages have no backing file,
-  // so their page objects come from termPages() rather than a content walk. They
-  // flow through the same mid/out/key/prune machinery as file-backed pages.
+  // Virtual "terms" section: blog category/tag term pages and case-study
+  // industry term pages have no backing file, so their page objects come from
+  // termPages()/industryPages() rather than a content walk. They flow through
+  // the same mid/out/key/prune machinery as file-backed pages.
   if (!ONLY.length || ONLY.includes("terms")) {
-    for (const t of termPages()) {
+    for (const t of [...termPages(), ...industryPages()]) {
       const page = { id: t.id, mid: t.id, section: "terms", template: t.template, fields: t.fields, w: t.w, h: t.h, out: join(OUT_ROOT, `${t.id}.png`) }
       page.key = cacheKey(page)
       pages.push(page)

--- a/scripts/meta-images/industries.mjs
+++ b/scripts/meta-images/industries.mjs
@@ -1,0 +1,56 @@
+// industries.mjs — virtual pages for the case-study INDUSTRY term cards.
+//
+// Industry term pages (/case-studies/industry/<slug>/) are a taxonomy with no
+// backing content file, so generate-meta-images.mjs can't discover them by
+// walking content/. This module enumerates them instead: one card per industry
+// in data/case_study_industries.yaml (the single source of truth the linter and
+// the term-page templates also read). This is the case-study analogue of the
+// blog term cards in terms.mjs.
+//
+// Each card uses the LIGHT docs-style card ("tutorial" template) — a "Case
+// Studies" badge, an "Industry" corner label, and the industry name as the
+// title — so industry cards share the light field of the case-study cards
+// (the "case-study"/"title" templates) with no new template.
+//
+// The id is BOTH the output path (assets/images/generated/industry/<id>.png)
+// and the runtime lookup key. partials/meta-image-key.html maps an industry
+// term page to that key with `urlize .Data.Term`, so the slug produced here
+// MUST match Hugo's urlize. Industry ids in the data file are already url-safe
+// slugs (financial-services, ai-ml, …), so this is a pass-through.
+
+import { readFileSync } from "fs"
+import { join } from "path"
+import { createRequire } from "module"
+import { REPO_ROOT, clean } from "./lib.mjs"
+
+const require = createRequire(import.meta.url)
+const yaml = require("js-yaml")
+
+const CANVAS_W = 1200
+const CANVAS_H = 628
+
+// One virtual industry term page per entry in data/case_study_industries.yaml.
+// The LIGHT "tutorial" card carries a "Case Studies" badge and an "Industry"
+// corner label; the optional per-industry description fills the body under the
+// title (omit it and the title stands alone, like the blog term cards).
+export function industryPages() {
+  const file = join(REPO_ROOT, "data", "case_study_industries.yaml")
+  const industries = (yaml.load(readFileSync(file, "utf-8")) || {}).industries || []
+  const pages = []
+  for (const ind of industries) {
+    if (!ind || !ind.id) continue
+    pages.push({
+      id: `industry/${ind.id}`,
+      template: "tutorial",
+      fields: {
+        sectionLabel: "Case Studies",
+        subSectionLabel: "Industry",
+        title: clean(ind.name) || ind.id,
+        description: clean(ind.description),
+      },
+      w: CANVAS_W,
+      h: CANVAS_H,
+    })
+  }
+  return pages
+}


### PR DESCRIPTION
This change gives case-study industry (`/case-studies/industry/<slug>/`) auto-generated social cards at build time, following the approach we've taken for category pages in the blog.

<img width="456" height="293" alt="image" src="https://github.com/user-attachments/assets/8f0991ac-aed4-413b-a664-bd5a944ad133" />
