### PR TITLE
Add faq_schema to top-cited blog pages with genuine FAQ sections

### DIFF
--- a/content/blog/infrastructure-as-code-tools/index.md
+++ b/content/blog/infrastructure-as-code-tools/index.md
@@ -15,6 +15,7 @@ tags:
     - kubernetes
     - devops
 category: general
+faq_schema: true
 ---
 
 Infrastructure as Code (IaC) has evolved beyond simple automation into a fundamental shift toward applying software engineering practices to infrastructure management. In 2025, leading organizations aren't just provisioning infrastructure—they're treating it as software, complete with testing, version control, code reviews, and continuous integration.

--- a/content/blog/pulumi-ai-new/index.md
+++ b/content/blog/pulumi-ai-new/index.md
@@ -10,6 +10,7 @@ tags:
     - ai
     - llm
 category: product
+faq_schema: true
 ---
 
 {{< notes type="info" >}}


### PR DESCRIPTION
## What

Adds `faq_schema: true` to two top-cited blog pages that have genuine FAQ/Q&A sections but were not opted into FAQPage schema emission:

- `content/blog/infrastructure-as-code-tools/index.md` — our #1 AI-cited page (247 citations in the trailing 28 days per Profound). Has a `## Frequently Asked Questions` section with 9 real Q&A pairs (e.g. "Which IaC tool should I choose for AWS?", "Is Terraform still worth learning in 2025?").
- `content/blog/pulumi-ai-new/index.md` — has a `## FAQs: Pulumi AI and Cloud Deployment` section with 5 real Q&A pairs (e.g. "What is Pulumi AI?", "How does pulumi new --ai work?").

## Why

Per `layouts/partials/schema/graph-builder.html`, blog posts only get FAQPage schema when the page's `Type` is `blog` **and** `.Params.faq_schema` is true — unlike `what-is` and `docs` pages, which get it automatically. Both pages already had real H2/H3 headings ending in "?" that `faq-entity.html` parses into FAQPage entities; they only needed the opt-in flag.

This directly supports the site-wide FAQPage schema deployment initiative: prioritizing pages most likely to be extracted by AI answer engines (OpenAI dominates our crawl mix). `infrastructure-as-code-tools` in particular is our single highest-cited page across AI engines, so this is the highest-leverage FAQPage gap we could close today.

## Scope check

Before flagging these two, I audited the other blog pages currently ranking in our top AI-cited set (`the-present-and-future-of-ai-and-iac`, `mcp-server-ai-assistants`, `pulumi-ai`) and none of them have genuine FAQ/Q&A heading sections — they use narrative "?" headings (e.g. "Why Pulumi AI?", "Is this the right level of abstraction?") that are not real FAQ pairs, so per house guidance I did **not** set `faq_schema` on those; doing so would either emit garbage FAQPage entities or (per the collector's graceful degradation) emit nothing useful. `ai-infrastructure-tools` already had `faq_schema: true` from a prior increment — no change needed there.

Organization schema (with `sameAs` links to GitHub, LinkedIn, X/Twitter, YouTube, Wikidata, and Wikipedia) is already fully deployed in `graph-builder.html` — reconfirmed, no changes needed.

## Testing

No template changes — this is a pure frontmatter opt-in, using the same mechanism already proven on `ai-infrastructure-tools`. Relying on CI + docs build to confirm no frontmatter/YAML errors.

---
🧠 *This PR was created by [workprentice](https://github.com/workprentice) on behalf of @joeduffy.*
