### PR TITLE
Align docs theme with DTCG brand tokens (radius, status colors, dark)

### DIFF
--- a/theme/src/scss/_badges.scss
+++ b/theme/src/scss/_badges.scss
@@ -38,7 +38,7 @@
     @apply bg-green-muted text-green-primary;
 }
 .badge-warning {
-    @apply bg-orange-muted text-orange-primary;
+    @apply bg-yellow-muted text-yellow-primary;
 }
 .badge-destructive {
     @apply bg-red-muted text-red-primary;
@@ -57,8 +57,11 @@
 
 // Back-compat aliases — the chooser (`_chooser.scss` @extend) and hand-authored
 // content (`saml/sso.md`) reference these names directly, so they must persist.
+// "PREVIEW" / "BETA" status. Split off its own orange rule (rather than
+// @extend .badge-warning) so warning can follow the token's yellow semantic
+// while preview/beta keeps its established amber identity.
 .badge-preview {
-    @extend .badge-warning; // "PREVIEW" / "BETA" status
+    @apply bg-orange-muted text-orange-primary;
 }
 .badge-required {
     @extend .badge-destructive; // "REQUIRED"

--- a/theme/src/scss/_blog.scss
+++ b/theme/src/scss/_blog.scss
@@ -8,7 +8,7 @@
     // Algolia's autocomplete (theme/src/ts/algolia/autocomplete.ts) upgrades the
     // #search div into a detached *button*. Style it as a plain ghost icon
     // button, identical to the adjacent RSS button (.btn-icon.btn-ghost — a
-    // size-9 square, rounded-lg, text-gray-950/hover:bg-gray-100, size-6 icon).
+    // size-9 square, rounded-md, text-gray-950/hover:bg-gray-100, size-6 icon).
     // Do NOT change detachedMediaQuery — /docs shares the same autocomplete code.
     .aa-DetachedSearchButton {
         @extend .btn, .btn-icon, .btn-ghost;
@@ -69,10 +69,10 @@
     input:not(.hs-button) {
         // This single-field newsletter form has no <fieldset>, so the normalized
         // `.hs-form fieldset input` base never reaches it — set chrome in full here.
-        // h-10 + rounded-lg matches the adjacent submit (.btn-lg). Vertical padding
+        // h-10 + rounded-md matches the adjacent submit (.btn-lg). Vertical padding
         // comes from the .newsletter base py-3 in _hubspot.scss (same specificity,
         // later import — it wins the tie); h-10 pins the height regardless.
-        @apply h-10 rounded-lg border-gray-300 bg-white text-service-black;
+        @apply h-10 rounded-md border-gray-300 bg-white text-service-black;
 
         &:focus {
             @apply border-violet-primary outline-none ring-2 ring-violet-primary/30;
@@ -94,7 +94,7 @@
         // bg-white also masks the footer's global dark newsletter-inline palette).
         // z-10 on focus lifts the input above the seam so its full (focused) border
         // renders over the adjacent button.
-        @apply relative h-9 w-44 rounded-l-lg rounded-r-none! border-gray-300 bg-white py-1.75 text-sm text-service-black;
+        @apply relative h-9 w-44 rounded-l-md rounded-r-none! border-gray-300 bg-white py-1.75 text-sm text-service-black;
 
         &:focus {
             @apply z-10 border-violet-primary outline-none ring-2 ring-violet-primary/30;

--- a/theme/src/scss/_button.scss
+++ b/theme/src/scss/_button.scss
@@ -8,12 +8,12 @@
 .btn {
     @apply inline-flex items-center justify-center gap-1 shrink-0 max-w-full
            overflow-hidden text-ellipsis text-sm font-normal border border-transparent
-           bg-clip-padding rounded-lg transition-all outline-none cursor-pointer select-none
+           bg-clip-padding rounded-md transition-all outline-none cursor-pointer select-none
            focus-visible:border-violet-primary focus-visible:ring-3 focus-visible:ring-violet-primary/50
            active:not-aria-[haspopup]:translate-y-px
            disabled:pointer-events-none disabled:opacity-50
            aria-disabled:pointer-events-none aria-disabled:opacity-50
-           aria-invalid:border-red-600 aria-invalid:ring-3 aria-invalid:ring-red-600/20
+           aria-invalid:border-red-800 aria-invalid:ring-3 aria-invalid:ring-red-800/20
            [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5
            h-9 px-2.5 py-1.75;
 }
@@ -25,8 +25,8 @@
 .btn-ghost         { @apply text-gray-950 hover:bg-gray-100 aria-expanded:bg-gray-100; }
 .btn-ghost-primary { @apply text-violet-primary hover:bg-violet-50 aria-expanded:bg-violet-50; }
 .btn-ghost-nav     { @apply text-gray-950 hover:bg-violet-50 hover:text-violet-primary aria-expanded:text-violet-primary aria-expanded:bg-violet-50 }
-.btn-destructive   { @apply bg-red-600/10 text-red-600 hover:bg-red-600/20
-                            focus-visible:border-red-600/40 focus-visible:ring-red-600/20; }
+.btn-destructive   { @apply bg-red-800/10 text-red-800 hover:bg-red-800/20
+                            focus-visible:border-red-800/40 focus-visible:ring-red-800/20; }
 .btn-link          { @apply h-auto inline-block text-violet-primary font-semibold underline-offset-5 hover:underline decoration-violet-300 border-none min-h-0! p-0! [&_svg]:no-underline; }
 
 // Split button — joins a primary .btn and a caret-only .btn into one control
@@ -56,8 +56,8 @@
     > .btn[aria-pressed="true"],
     > .btn[aria-current="page"]                      { @apply z-10; }
     > .btn:not(:first-child)                         { @apply -ml-px; }
-    > .btn:first-child                               { @apply rounded-l-lg; }
-    > .btn:last-child                                { @apply rounded-r-lg; }
+    > .btn:first-child                               { @apply rounded-l-md; }
+    > .btn:last-child                                { @apply rounded-r-md; }
 }
 
 // Sizes — override the base h-9 / px-2.5

--- a/theme/src/scss/_buttons.scss
+++ b/theme/src/scss/_buttons.scss
@@ -6,7 +6,7 @@
 //   .card-cta-contained-btn   - card-button-download.html
 
 .btn-download {
-    @apply py-3 px-8 rounded-lg;
+    @apply py-3 px-8 rounded-md;
     display: flex;
     align-items: center;
     background-color: #fff;

--- a/theme/src/scss/_footer.scss
+++ b/theme/src/scss/_footer.scss
@@ -44,7 +44,7 @@
     // <fieldset>, so the normalized `.hs-form fieldset input` base never reaches it —
     // the control chrome (border, height, radius) is set in full here.
     input:not(.hs-button) {
-        @apply bg-black text-white border border-gray-800 rounded-l-lg rounded-r-none! h-10 py-0;
+        @apply bg-black text-white border border-gray-800 rounded-l-md rounded-r-none! h-10 py-0;
 
         &::placeholder { @apply text-gray-500; }
     }
@@ -52,6 +52,6 @@
     input.hs-button {
         // 1px violet-primary border so the button's edges line up with the input's
         // border in the joined control (.btn ships a transparent border otherwise).
-        @apply leading-none bg-violet-primary text-white border-violet-primary rounded-l-none! rounded-r-lg! h-10 px-2! py-0 ml-0;
+        @apply leading-none bg-violet-primary text-white border-violet-primary rounded-l-none! rounded-r-md! h-10 px-2! py-0 ml-0;
     }
 }

--- a/theme/src/scss/_forms.scss
+++ b/theme/src/scss/_forms.scss
@@ -20,7 +20,7 @@
 
 // Single radius knob — retune every control at once. Buttons don't vary radius by
 // size, so neither do inputs. Plain border-radius (not @apply) so the CSS var flows.
-$form-radius: var(--radius-lg);
+$form-radius: var(--radius-md);
 
 // Inset depth shadows layered on top of the border (brand tokens shadow.input /
 // shadow.select). Inputs get a top inner shadow; selects a bottom inner shadow.
@@ -35,7 +35,7 @@ $form-select-shadow: inset 0 -2px 4px 0 rgb(0 0 0 / 0.08);
 // Focus adds a 2px violet-800 inset ring ON TOP of the resting shadow, and the
 // border also goes violet-800 — the two merge into one clean ~3px edge.
 $form-focus-ring: inset 0 0 0 2px var(--color-violet-800);
-$form-invalid-ring: inset 0 0 0 2px var(--color-red-600);
+$form-invalid-ring: inset 0 0 0 2px var(--color-red-800);
 
 // Caret chevron drawn as a background SVG (class-wide fix for flush carets). The
 // gray-500 (#9997a0) stroke matches placeholder text; the light variant (gray-300
@@ -75,11 +75,11 @@ $form-radio-svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' w
     // Invalid state — aria-invalid (hand-authored) and HubSpot's .error class.
     &[aria-invalid="true"],
     &.error {
-        @apply border-red-600;
+        @apply border-red-800;
 
         &:focus,
         &:focus-visible {
-            @apply border-red-600;
+            @apply border-red-800;
             box-shadow: $form-invalid-ring, var(--form-resting-shadow, none);
         }
     }
@@ -190,4 +190,4 @@ $form-radio-svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' w
 
 .form-label { @apply block text-sm mb-1 text-gray-950; }
 .form-help  { @apply block text-xs text-gray-500 mt-1; }
-.form-error { @apply block text-xs text-red-600 mt-1; }
+.form-error { @apply block text-xs text-red-800 mt-1; }

--- a/theme/src/scss/_hubspot.scss
+++ b/theme/src/scss/_hubspot.scss
@@ -155,7 +155,7 @@
         // the inline dark (_footer) and light (_blog) variants own it; the plain
         // newsletter falls back to the browser-default white input.
         input:not(.hs-button) {
-            @apply block py-3 px-4 rounded-lg border;
+            @apply block py-3 px-4 rounded-md border;
 
             // Resting inner shadow, matching the .form-input system. Set only here
             // (no variant sets box-shadow), so every newsletter input — plain, blog

--- a/theme/src/scss/docs/_docs-theme.scss
+++ b/theme/src/scss/docs/_docs-theme.scss
@@ -52,12 +52,12 @@ html[data-theme="dark"] body.section-docs {
     --docs-bg: var(--color-service-black);
     --docs-bg-alt: var(--color-violet-950);
     --docs-surface: var(--color-gray-900);
-    --docs-fg: var(--color-white);
+    --docs-fg: var(--color-gray-50);
     --docs-fg-muted: var(--color-gray-300);
-    --docs-border: #ffffff1a;
+    --docs-border: var(--color-gray-800);
     --docs-link: var(--color-violet-300);
     --docs-card: var(--color-service-black);
-    --docs-card-border: #ffffff1a;
+    --docs-card-border: var(--color-gray-800);
     --docs-ring: var(--color-violet-300);
 
     // Brand rule: the primary violet flips to lavender in dark mode everywhere
@@ -585,9 +585,14 @@ html[data-theme="dark"] body.section-docs {
     // --- Badges -------------------------------------------------------------
     // Soft variants are `{color}-muted` bg + `{color}-primary` text in light mode;
     // dark flips them to a deep `{color}-950` fill + light `{color}-300` text.
+    // Warning follows the token's yellow semantic; preview/beta keeps amber.
+    .badge-warning {
+        background-color: var(--color-yellow-950);
+        color: var(--color-yellow-300);
+    }
+
     // The chooser pill is a bare `li > span` that gets its skin from
     // `@extend .badge-preview` (no literal class), so it needs naming here too.
-    .badge-warning,
     .badge-preview,
     pulumi-chooser > ul li > span {
         background-color: var(--color-orange-950);


### PR DESCRIPTION
Just some minor style changes to sync up `docs`, `marketing-web` and `pulumi-service`

---

### Proposed changes

Brings the Hugo theme SCSS into line with the `@pulumi/design-system` (DTCG) brand tokens so docs and marketing-web converge on the same values. Button and form-control radius moves from `lg` (8px) to `md` (6px) — including the hand-styled newsletter inputs/buttons in blog, footer, and HubSpot that hardcoded `rounded-lg` to match buttons — while cards stay `lg`. Destructive/invalid states move from `red-600` to the semantic `red-800` (`btn-destructive`, form invalid ring/border, `form-error`, and the `btn` `aria-invalid` state). `badge-warning` moves from orange to the token's yellow, with `badge-preview` split off its own amber rule so `PREVIEW`/`BETA` keeps its established identity in both modes. Finally, docs dark mode adopts the token dark palette: `--docs-fg` white → gray-50, and `--docs-border`/`--docs-card-border` white hairline → gray-800.

This is a docs-side follow-on to the marketing-web token sync; where a value was ratified for marketing-web, the token is the tie-breaker and docs is the follower. A nav refactor to adopt semantic role utilities (`text-foreground`/`text-muted-foreground`/`border-border`) was left out — those role tokens don't exist in the docs theme yet, so it needs its own PR.