### PR TITLE
Add SoftwareApplication schema to /pricing/ page

### DIFF
--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -3,6 +3,7 @@ title: Pricing
 meta_desc: Pulumi IaC and Pulumi ESC are available in various editions and are free to individuals
 type: page
 layout: pricing
+schema_type: product
 include_floqer: true
 menu:
     header:


### PR DESCRIPTION
## Summary

Daily SEO optimization increment 9 (technical SEO / AEO). This is a small, template-reuse fix: the `/pricing/` page — a Tier-1, bottom-funnel, high commercial-intent page — currently emits no structured data at all (no FAQPage, no SoftwareApplication, nothing in the page's `@graph`). This PR opts it into the existing `schema_type: product` frontmatter key, which the site already uses for `/product/` pages, so AI answer engines and search crawlers can resolve a well-typed `SoftwareApplication` entity for Pulumi's pricing/plans page instead of an untyped one.

## Why this page, why now

This week's diagnostic (fresh Profound citations pull across all AI models, `2026-06-18` to `2026-07-16`, grouped by page) confirmed `pulumi.com/pricing/` is a recurring cited page (rank ~240 by citation count among all cited domains/pages site-wide, and one of the highest-intent pages in that set). A source-level check of `content/pricing/_index.md` and `layouts/partials/schema/graph-builder.html` / `main-entity.html` confirmed no schema entity is emitted for this page today — it falls through every auto-detection branch (not blog, not tutorials, not events, no "faq" in title/URL) and has no explicit `schema_type` set.

Recently-touched pages from increments 7 and 8 (IaC tools pillar, pulumi-ai-new, how-to-test-infrastructure-as-code, the two `/what-is/` consolidation sources, ai-infrastructure-tools, terraform comparison, agentic-infrastructure-era, why-switch-to-pulumi) were excluded from this pass to avoid churn.

## What changed

- `content/pricing/_index.md`: added `schema_type: product` to frontmatter (single line).

This routes the page through the existing, already-tested `product-entity.html` partial (used today by `/product/`), which builds a `SoftwareApplication` entity from `.Title` / `.Params.meta_desc` — no new template logic, no fabricated facts, no prose changes.

## Verification

- Confirmed via the live site that `/product/` already renders `SoftwareApplication` schema through this same code path.
- Confirmed via `layouts/partials/schema/collectors/main-entity.html` that `schema_type: product` is a supported, existing frontmatter override (not a new field).
- Confirmed the frontmatter edit applied cleanly (single added line, no other diff).

---
🧠 *This PR was created by [workprentice](https://github.com/workprentice) on behalf of @joeduffy.*
