### PR TITLE
Emit FAQPage schema for the Pulumi vs. Terraform comparison section

### DIFF
--- a/content/docs/iac/comparisons/terraform/_index.md
+++ b/content/docs/iac/comparisons/terraform/_index.md
@@ -4,6 +4,7 @@ authors: ["joe-duffy"]
 meta_desc: "Pulumi vs. Terraform: Pulumi uses general-purpose languages (Python, TypeScript, Go) across any cloud; Terraform uses HCL with HashiCorp's providers."
 title: Terraform
 h1: Pulumi vs. Terraform
+faq_schema: true
 include_floqer: true
 menu:
     iac:

--- a/layouts/partials/schema/graph-builder.html
+++ b/layouts/partials/schema/graph-builder.html
@@ -54,10 +54,27 @@
      flag keeps this a reusable template mechanism (not a per-page hack) while
      avoiding that regression; add `faq_schema: true` to any blog post's
      frontmatter once it has a genuine FAQ section (## or ### headings ending
-     in "?") to pick up FAQPage schema automatically. */}}
+     in "?") to pick up FAQPage schema automatically.
+     Docs *section* pages (Hugo branch bundles, e.g. an `_index.md` with child
+     pages) are `.Kind "section"`, so `.IsPage` is false for them and they never
+     reach this block even when they carry a genuine multi-question FAQ (for
+     example content/docs/iac/comparisons/terraform/_index.md, which has its own
+     children terraform/opentofu.md and terraform/terminology.md). A repo-wide
+     scan of docs section pages found several with a single narrative heading
+     that happens to end in "?" (e.g. "## Why integration testing?") which is
+     not a real FAQ block, so relaxing the gate to all docs sections would
+     mirror the blog false-positive problem. Instead, docs sections opt in the
+     same way blog posts do: set `faq_schema: true` in a section's frontmatter
+     once it has a genuine Q&A block, and faq-entity.html's own "?"-heading
+     extraction still governs what actually gets emitted. */}}
 {{ $faqPage := dict }}
 {{ $isDedicatedFaqPage := or (strings.Contains (lower .RelPermalink) "/faq") (strings.Contains (lower .Title) "faq") (strings.Contains (lower .Title) "frequently asked") }}
-{{ if and .IsPage (not $isDedicatedFaqPage) (or (eq .Type "what-is") (eq .Type "docs") (and (eq .Type "blog") .Params.faq_schema)) }}
+{{ $qualifiesForFaqSchema := or
+  (and .IsPage (or (eq .Type "what-is") (eq .Type "docs")))
+  (and (eq .Type "blog") .Params.faq_schema)
+  (and (eq .Type "docs") (not .IsPage) .Params.faq_schema)
+}}
+{{ if and $qualifiesForFaqSchema (not $isDedicatedFaqPage) }}
   {{ $faqPage = partial "schema/collectors/faq-entity.html" . }}
   {{ if and $faqPage (ne $faqPage (dict)) }}
     {{ $faqPage = merge $faqPage (dict "@id" "#faq") }}


### PR DESCRIPTION
## What

Adds FAQPage structured-data schema to the Pulumi vs. Terraform comparison page (`/docs/iac/comparisons/terraform/`), which was silently excluded from the site's existing FAQ auto-detection because it is a Hugo *section* page (an `_index.md` with children `terraform/opentofu` and `terraform/terminology`) rather than a leaf page.

## Why

This is the flagship "Pulumi vs. Terraform" comparison page — highest-value real estate for both traditional search and LLM/AI-answer citation on our top Tier-1/2 comparison keyword. It already has 9 genuine Q&A headings in its content (What is Pulumi?, What is Terraform?, Can Pulumi use existing Terraform providers?, and six more), but because `schema/graph-builder.html`'s FAQ auto-detection is gated on `.IsPage`, section pages never reach that code path, so none of those questions were surfaced as FAQPage schema — unlike every other comparison page in the same section.

A full sweep of all 15 pages under `/docs/iac/comparisons/` confirmed this is the *only* gap: the 9 sibling pages with real question headings already emit FAQPage correctly, and pages without question headings correctly emit nothing.

## Fix

Extends the same opt-in pattern already used for blog posts (`Params.faq_schema`) to docs section pages:

- `content/docs/iac/comparisons/terraform/_index.md`: adds `faq_schema: true` to frontmatter.
- `layouts/partials/schema/graph-builder.html`: the FAQ-qualification condition now also allows `.Type "docs"` section pages (not just leaf pages) when they opt in via `faq_schema: true`.

This intentionally does not relax the gate for *all* docs sections, because a few docs sections in the repo have a single narrative heading that happens to end in "?" (e.g. "Why integration testing?") that is not a real FAQ block — the same false-positive risk the blog opt-in flag already guards against. `faq-entity.html`'s own "?"-heading extraction still governs what's actually emitted, so this change only unlocks pages that both opt in and have genuine question headings. No new content or claims are introduced — the FAQPage entities are built entirely from the page's existing Q&A headings.

## Verification

Built a local Hugo harness against this branch's templates and content:
- `/docs/iac/comparisons/terraform/` now emits `@type: FAQPage` with all 9 existing questions verbatim.
- `/docs/iac/comparisons/terraform/opentofu/` (leaf sibling) is unaffected — still correctly has no FAQPage, since it has no question headings.

---
🧠 *This PR was created by [workprentice](https://github.com/workprentice) on behalf of @joeduffy.*
