### PR TITLE
Tint docs code chrome violet to match marketing-web

### DIFF
--- a/theme/src/scss/components/_chooser.scss
+++ b/theme/src/scss/components/_chooser.scss
@@ -1,24 +1,24 @@
 pulumi-chooser {
-    // Standard (non-language) chooser: a gray strip of small tabs matching the
-    // language chooser's toolbar — surface background, rounded top, 1px bottom
-    // border that the active tab's underline sits on. --docs-* tokens (with
-    // non-docs fallbacks); the dark rule in _docs-theme.scss re-asserts the
-    // border colors the unlayered `*` border reset would otherwise override.
+    // Standard (non-language) chooser: a flat violet chrome strip of small tabs
+    // matching the language chooser's toolbar — chrome background, rounded top,
+    // 1px bottom border that the active tab's underline sits on. --chrome-* tokens
+    // (with non-docs gray fallbacks); the dark rule in _docs-theme.scss re-asserts
+    // the border colors the unlayered `*` border reset would otherwise override.
     > ul {
         @apply m-0 mb-4 flex rounded-t-lg;
 
         padding: 0 !important;
         list-style-type: none !important;
 
-        background: var(--docs-surface, theme("colors.gray.100"));
-        border-bottom: 1px solid var(--docs-border, theme("colors.gray.200"));
+        background: var(--chrome-bg, theme("colors.gray.100"));
+        border-bottom: 1px solid var(--chrome-border, theme("colors.gray.200"));
 
         li {
             @apply font-display text-xs p-0 m-0 border-b-2 border-transparent transition text-center w-full;
             @include transition;
 
             &:hover {
-                border-bottom-color: var(--docs-border, theme("colors.gray.200"));
+                border-bottom-color: var(--chrome-border-hover, theme("colors.gray.200"));
             }
 
             &.active {
@@ -69,14 +69,14 @@ pulumi-chooser {
         @apply block rounded-lg px-4 pb-4 mb-4 overflow-hidden;
 
         background: var(--docs-card, theme("colors.white"));
-        border: 1px solid var(--docs-border, theme("colors.gray.200"));
+        border: 1px solid var(--chrome-border, theme("colors.gray.200"));
 
         // Height comes from the label's padding; the tabs stretch to fill it so each
         // tab's bottom border sits flush with the toolbar's bottom edge.
         .chooser-toolbar {
             @apply -mx-4 mb-4 flex justify-between gap-2 px-4;
 
-            background: var(--docs-surface, theme("colors.gray.100"));
+            background: var(--chrome-bg, theme("colors.gray.100"));
 
             // On mobile the logo + name label is hidden and the tab row scrolls
             // horizontally; from md up the label returns and the tabs right-align.
@@ -109,7 +109,7 @@ pulumi-chooser {
                     @include transition;
 
                     &:hover {
-                        border-bottom-color: var(--docs-border, theme("colors.gray.200"));
+                        border-bottom-color: var(--chrome-border-hover, theme("colors.gray.200"));
                     }
 
                     &.active {
@@ -188,7 +188,7 @@ pulumi-chooser {
                 @apply  mb-0;
 
                 //background: transparent;
-                border-bottom: 1px solid var(--docs-border, theme("colors.gray.200"));
+                border-bottom: 1px solid var(--chrome-border, theme("colors.gray.200"));
             }
         }
 

--- a/theme/src/scss/docs/_code-light.scss
+++ b/theme/src/scss/docs/_code-light.scss
@@ -8,13 +8,21 @@
 html:not([data-theme="dark"]) body.section-docs {
     // Flip the dark code surface + text (set in _chroma.scss / _code.scss).
     pre {
-        background: var(--color-violet-50);
+        background: color-mix(in srgb, var(--color-violet-50) 50%, transparent);
         color: #212121;
+    }
+
+    // Standalone fenced code blocks (a `.highlight` not inside a chooser,
+    // example-program, terminal chrome, or code-tabbed demo) get the chooser's
+    // chrome border, so the faint-violet panel reads as a bordered card matching
+    // the chooser card treatment.
+    .highlight:not(pulumi-chooser *, .example-program *, .code-chrome *, .code-tabbed *) pre:not(.mermaid) {
+        border: 1px solid var(--chrome-border);
     }
 
     .chroma,
     .bg {
-        background-color: var(--color-violet-50);
+        background-color: color-mix(in srgb, var(--color-violet-50) 50%, transparent);
         color: #212121;
     }
 
@@ -127,7 +135,7 @@ html:not([data-theme="dark"]) body.section-docs {
 
     // example-program footer (the code panel's bottom lip).
     .example-program .example-program-footer {
-        background: var(--color-violet-50);
+        background: color-mix(in srgb, var(--color-violet-50) 50%, transparent);
 
         a {
             color: var(--color-gray-700);
@@ -143,7 +151,7 @@ html:not([data-theme="dark"]) body.section-docs {
         .code-tabbed-tabs,
         .code-tabbed-content,
         .code-tabbed-status {
-            background: var(--color-violet-50);
+            background: color-mix(in srgb, var(--color-violet-50) 50%, transparent);
         }
 
         .code-tabbed-tab {

--- a/theme/src/scss/docs/_docs-theme.scss
+++ b/theme/src/scss/docs/_docs-theme.scss
@@ -27,6 +27,17 @@ body.section-docs {
     --docs-card-border: var(--color-gray-200);
     --docs-ring: var(--color-violet-700);
 
+    // Code chrome — the flat violet tint on code-adjacent "chrome" (chooser
+    // toolbars, tab strips, card borders, terminal dots), mirroring marketing-web
+    // (apps/www). Centralized in four tunable props so the tint lives in one place;
+    // the dark block below re-points them to the standard brand inversion. All
+    // values trace to @pulumi/design-tokens. (--chrome-dots is defined for parity
+    // with www; docs has no light-chrome terminal title bar consuming it yet.)
+    --chrome-bg: var(--color-violet-100);
+    --chrome-border: var(--color-violet-200);
+    --chrome-border-hover: var(--color-violet-300);
+    --chrome-dots: var(--color-violet-400);
+
     // Re-expose the semantic tokens under Tailwind's --color-* namespace so the
     // generated utilities (bg-docs-bg, text-docs-fg, border-docs-border, …) resolve
     // and flip with the theme. This MUST live here, not just in @theme: a --color-*
@@ -59,6 +70,13 @@ html[data-theme="dark"] body.section-docs {
     --docs-card: var(--color-service-black);
     --docs-card-border: var(--color-gray-800);
     --docs-ring: var(--color-violet-300);
+
+    // Code chrome — standard brand inversion of the light steps above (100↔900,
+    // 200↔800, 300↔700; dots use 300 so they stay visible on the darker chrome).
+    --chrome-bg: var(--color-violet-900);
+    --chrome-border: var(--color-violet-800);
+    --chrome-border-hover: var(--color-violet-700);
+    --chrome-dots: var(--color-violet-300);
 
     // Brand rule: the primary violet flips to lavender in dark mode everywhere
     // EXCEPT solid buttons (those pin violet-700, re-pinned below). Remapping the
@@ -521,14 +539,31 @@ html[data-theme="dark"] body.section-docs {
         }
     }
 
+    // --- Chooser chrome: the violet card border, standard-strip bottom border,
+    //     and standalone-toolbar bottom border are all flattened to --docs-border
+    //     by the unlayered `*` border reset below; re-assert the --chrome-border
+    //     step so the dark chrome stays violet. (Backgrounds flip automatically —
+    //     --chrome-* is a per-mode custom property and `*` only resets border-color.)
+    pulumi-chooser > ul {
+        border-bottom-color: var(--chrome-border);
+    }
+
+    pulumi-chooser[type="language"]:not([option-style="none"]) {
+        border-color: var(--chrome-border);
+
+        .chooser-toolbar {
+            border-bottom-color: var(--chrome-border);
+        }
+    }
+
     // --- Chooser tabs: re-assert the underline colors (inactive = transparent,
-    //     hover = border, active = link) so the unlayered `*` border reset below
-    //     doesn't override them. ---------------------------------------------
+    //     hover = chrome-border-hover, active = link) so the unlayered `*` border
+    //     reset below doesn't override them. ----------------------------------
     pulumi-chooser > ul li {
         border-bottom-color: transparent;
 
         &:hover {
-            border-bottom-color: var(--docs-border);
+            border-bottom-color: var(--chrome-border-hover);
         }
 
         a {
@@ -549,12 +584,13 @@ html[data-theme="dark"] body.section-docs {
     }
 
     // Language toolbar tabs: re-assert the underline colors (inactive = transparent,
-    // active = link) so the unlayered `*` border reset below doesn't override them.
+    // hover = chrome-border-hover, active = link) so the unlayered `*` border reset
+    // below doesn't override them.
     .chooser-toolbar > ul li {
         border-bottom-color: transparent;
 
         &:hover {
-            border-bottom-color: var(--docs-border);
+            border-bottom-color: var(--chrome-border-hover);
         }
 
         a {

--- a/theme/src/scss/docs/_docs-theme.scss
+++ b/theme/src/scss/docs/_docs-theme.scss
@@ -610,6 +610,30 @@ html[data-theme="dark"] body.section-docs {
         }
     }
 
+    // --- Code panels (dark): mirror the light treatment in _code-light.scss —
+    //     wash the code surface with the darkest violet step at 50% opacity (the
+    //     page shows through the rest) and give standalone fenced code blocks the
+    //     chooser's --chrome-border, so a lone block reads as a bordered card. The
+    //     solid violet-950 surface + Min Dark syntax colors otherwise come from
+    //     _code.scss / _chroma.scss. The border shorthand also restores width/style
+    //     the unlayered `*` reset (color-only) can't touch. -------------------
+    pre:not(.mermaid),
+    .chroma,
+    .bg {
+        background-color: color-mix(in srgb, var(--color-violet-950) 50%, transparent);
+    }
+
+    .example-program .example-program-footer,
+    .code-tabbed .code-tabbed-tabs,
+    .code-tabbed .code-tabbed-content,
+    .code-tabbed .code-tabbed-status {
+        background: color-mix(in srgb, var(--color-violet-950) 50%, transparent);
+    }
+
+    .highlight:not(pulumi-chooser *, .example-program *, .code-chrome *, .code-tabbed *) pre:not(.mermaid) {
+        border: 1px solid var(--chrome-border);
+    }
+
     pulumi-tabs::part(tab) {
         border-bottom-color: var(--docs-border);
     }


### PR DESCRIPTION
Let me know your opinions here - I think it looks better with the violet chrome (the gray kept bugging me not matching the code background), but is it _too much_ violet?

<img width="1234" height="889" alt="Screenshot 2026-07-16 at 3 14 06 PM" src="https://github.com/user-attachments/assets/9f90147b-0ef1-489e-9cdd-9cc14d30b2af" />

---

### Proposed changes

Switches the `/docs` code-adjacent "chrome" — the language-chooser card border and toolbar, the standard (non-language) tab strip, and tab hover underlines — from gray to flat violet brand steps, matching the treatment marketing-web (apps/www) already ships so the two sites look consistent. The tint is centralized in four tunable `--chrome-*` custom properties on `body.section-docs` (violet-100/200/300/400) with a standard dark-mode inversion (violet-900/800/700/300), all tracing to `@pulumi/design-tokens`. Because docs' unlayered `*` border reset would otherwise flatten the violet borders back to gray in dark mode, the chrome borders are re-asserted in the dark block. Text on chrome, the active-tab brand underline, and non-docs choosers (which keep their gray fallback) are unchanged.

### Related issues (optional)

N/A