### PR TITLE
Add review-admin: browse and export the S3 review ledgers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,8 @@ _vendor/
 /.ledger-cache/
 /.traffic-snapshot
 /.synthetic.patch
+# Local cache for scripts/review-admin (synced S3 ledgers, exports, dashboard).
+/.review-admin-cache/
 # Lint re-gate scratch (worker re-lints the fix branch and captures output).
 /.lint.log
 /.lint-comment.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -82,3 +82,4 @@ static/js
 /.review-changes.patch
 /.review-changes.paths
 /.applied.paths
+/.review-admin-cache/

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,16 @@ generate-related-tags:
 	cd scripts/python && pipenv install && pipenv run python generate_tag_related.py
 	@echo -e "\033[0;32mDone! Updated data/related.yaml\033[0m"
 
+.PHONY: review-admin-sync
+review-admin-sync:
+	@echo -e "\033[0;32mSyncing review ledgers from S3...\033[0m"
+	python3 scripts/review-admin/review-admin.py sync
+
+.PHONY: review-admin-dashboard
+review-admin-dashboard:
+	@echo -e "\033[0;32mGenerating review-ledger dashboard...\033[0m"
+	python3 scripts/review-admin/review-admin.py html --open
+
 .PHONY: build
 build:
 	@echo -e "\033[0;32mBUILD:\033[0m"

--- a/scripts/review-admin/README.md
+++ b/scripts/review-admin/README.md
@@ -1,0 +1,66 @@
+# review-admin
+
+Browse and export the review/state data our automated processes keep in S3:
+
+| Data | S3 location | Producer |
+|------|-------------|----------|
+| Docs review ledger | `content-review-ledger-*/ledger/` | review-existing-content workflow |
+| Fact-check claims | `content-review-ledger-*/claims/` | content-review claim pipeline |
+| Blog known-issues index | `content-review-ledger-*/blog-review/` | blog-review-index workflow |
+| Signal health | `content-review-ledger-*/health/state.json` | signal-health check |
+| Social post state | `social-post-state-*/posted*.json` | schedule-social workflow |
+
+None of this is human-browsable in the S3 console (one small JSON object at a
+time). This tool syncs everything into a local cache and then works offline.
+It is **read-only** — it never writes to S3.
+
+This is the interim browse/export layer until the DWH ingestion in pulumi/data
+lands; the exports are already in the flat shape ingestion wants (and DuckDB
+reads them directly, e.g. `duckdb -c "select * from 'claims.jsonl'"`).
+
+## Prerequisites
+
+- The AWS CLI with read access to the buckets (set `AWS_PROFILE` to a profile
+  in the Pulumi AWS account; refresh your SSO session if sync fails).
+- Only `sync` touches AWS; every other subcommand reads the local cache at
+  `.review-admin-cache/` (gitignored; override with `--cache-dir` or
+  `$REVIEW_ADMIN_CACHE`).
+
+Bucket names are Pulumi auto-named and discovered by name prefix; set
+`CONTENT_REVIEW_LEDGER_BUCKET` / `SOCIAL_STATE_BUCKET` to pin them explicitly.
+
+## Usage
+
+```bash
+# Pull both buckets into the local cache (or: make review-admin-sync)
+scripts/review-admin/review-admin.py sync
+
+# Console overview of everything captured
+scripts/review-admin/review-admin.py summary
+
+# Filterable listings per domain (docs | claims | blog | social)
+scripts/review-admin/review-admin.py list claims --verdict contradicted
+scripts/review-admin/review-admin.py list docs --status reviewed --since 2026-07-01
+
+# Full paper trail for one article/post across all domains
+scripts/review-admin/review-admin.py show docs-iac-get-started-aws-configure
+
+# DWH/DuckDB-ready flat exports (CSV + JSONL) into <cache>/exports/
+scripts/review-admin/review-admin.py export
+
+# Self-contained HTML dashboard (or: make review-admin-dashboard)
+scripts/review-admin/review-admin.py html --open
+```
+
+## Testing
+
+```bash
+scripts/review-admin/review-admin.py --self-test
+python3 -m pytest scripts/review-admin/test_review_admin.py
+```
+
+## Version history
+
+The ledger buckets are versioned, and this tool intentionally shows current
+state only. To reconstruct how records changed over time, use
+`scripts/content-review/reconstruct-ledger-history.py`.

--- a/scripts/review-admin/review-admin.py
+++ b/scripts/review-admin/review-admin.py
@@ -1,0 +1,970 @@
+#!/usr/bin/env python3
+"""Browse and export the S3 review/state ledgers from one place.
+
+Several automated processes persist state as small JSON objects in two private
+S3 buckets, none of it human-browsable without pulling objects one at a time:
+
+  content-review-ledger-* (shared bucket, one prefix per producer)
+    ledger/<slug>.json            existing-content docs review outcomes
+    claims/<slug>.json            fact-check claim extraction + verdicts
+    blog-review/ledger/…          blog known-issues index (per post)
+    blog-review/runs/<date>/…     per-run blog review findings
+    blog-review/index/_summary.json  aggregate summary
+    health/state.json             selection-signal health
+  social-post-state-* posted-social.json / posted.json
+                                  per-post social publish timestamps
+
+This tool syncs both buckets into a local cache and then works entirely
+offline: console summaries, filterable listings, per-article paper trails,
+DWH-ready CSV/JSONL exports, and a self-contained HTML dashboard. It is
+read-only — it never writes to S3. For ledger *version history* (how a record
+changed over time), see scripts/content-review/reconstruct-ledger-history.py.
+
+Usage:
+
+    review-admin.py sync                  # pull both buckets into the cache
+    review-admin.py summary               # console overview of everything
+    review-admin.py list claims --verdict contradicted
+    review-admin.py show docs-iac-get-started-aws-configure
+    review-admin.py export --format csv
+    review-admin.py html --open
+
+Needs the AWS CLI with read access to the buckets (sync only; every other
+subcommand reads the local cache). Bucket names are Pulumi auto-named — they
+are discovered by name prefix, or set CONTENT_REVIEW_LEDGER_BUCKET /
+SOCIAL_STATE_BUCKET explicitly. Run `--self-test` for an offline smoke test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import webbrowser
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+CONTENT_BUCKET_ENV = "CONTENT_REVIEW_LEDGER_BUCKET"
+SOCIAL_BUCKET_ENV = "SOCIAL_STATE_BUCKET"
+CONTENT_BUCKET_PREFIX = "content-review-ledger-"
+SOCIAL_BUCKET_PREFIX = "social-post-state-"
+CACHE_ENV = "REVIEW_ADMIN_CACHE"
+CACHE_DIRNAME = ".review-admin-cache"
+
+DOMAINS = ("docs", "claims", "blog", "social")
+
+# Preferred column order for exports; unknown fields are appended after these.
+DOCS_COLUMNS = [
+    "slug", "path", "lane", "status", "tier", "score", "fixes",
+    "skipped_findings", "attempts", "clarity_flag", "retirement",
+    "pr_number", "pr", "head_sha", "monthly_visits", "traffic_available",
+    "signals_available", "reviewed_at", "note",
+]
+CLAIM_COLUMNS = [
+    "slug", "path", "claim_id", "type", "verdict", "confidence",
+    "line_range", "volatile", "entity_key", "text", "evidence", "source",
+    "commit", "model", "article_reviewed_at", "schema_version",
+]
+BLOG_COLUMNS = [
+    "slug", "path", "lane", "status", "issues", "score", "post_date",
+    "monthly_visits", "traffic_available", "signals_available", "attempts",
+    "head_sha", "reviewed_at", "note", "schema_version",
+]
+BLOG_ISSUE_COLUMNS = [
+    "slug", "path", "run_date", "post_date", "status", "noindex_signal",
+    "issue_category", "issue_severity",
+]
+SOCIAL_COLUMNS = ["url", "platform", "posted_at", "failures", "source_file"]
+
+
+def log(msg: str) -> None:
+    print(f"review-admin: {msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"review-admin: {msg}", file=sys.stderr)
+
+
+def die(msg: str) -> None:
+    warn(msg)
+    sys.exit(1)
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def cache_dir(args) -> Path:
+    if getattr(args, "cache_dir", None):
+        return Path(args.cache_dir)
+    env = os.environ.get(CACHE_ENV, "").strip()
+    if env:
+        return Path(env)
+    return repo_root() / CACHE_DIRNAME
+
+
+# ---- sync -------------------------------------------------------------------
+
+
+def aws(argv: list[str]) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(["aws", *argv], capture_output=True, text=True)
+    except FileNotFoundError:
+        die("aws CLI not found on PATH — install it (or run inside the devcontainer)")
+
+
+def credential_hint() -> str:
+    profile = os.environ.get("AWS_PROFILE", "")
+    lines = ["Could not talk to S3 — check your AWS credentials."]
+    if profile:
+        lines.append(f"Current AWS_PROFILE={profile}; if SSO, the token may have expired (refresh your SSO session).")
+    else:
+        lines.append("No AWS_PROFILE set — export the profile that has read access to the review buckets,")
+        lines.append("e.g. one of the profiles in ~/.aws/credentials, plus AWS_DEFAULT_REGION.")
+    return "\n".join(lines)
+
+
+def resolve_bucket(env_var: str, prefix: str) -> str:
+    explicit = os.environ.get(env_var, "").strip()
+    if explicit:
+        return explicit
+    proc = aws(["s3api", "list-buckets",
+                "--query", f"Buckets[?starts_with(Name, '{prefix}')].Name",
+                "--output", "json"])
+    if proc.returncode != 0:
+        die(f"bucket discovery failed:\n{proc.stderr.strip()}\n{credential_hint()}")
+    names = json.loads(proc.stdout or "[]")
+    if len(names) == 1:
+        return names[0]
+    if not names:
+        die(f"no bucket matching '{prefix}*' visible to these credentials; set {env_var} explicitly")
+    die(f"multiple buckets match '{prefix}*' ({', '.join(names)}); set {env_var} to pick one")
+
+
+def sync_prefix(uri: str, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    proc = aws(["s3", "sync", uri, str(dest), "--delete", "--no-progress"])
+    for line in (proc.stdout or "").splitlines():
+        if line.strip():
+            print(f"  {line.strip()}")
+    if proc.returncode != 0:
+        die(f"sync failed for {uri}:\n{proc.stderr.strip()}\n{credential_hint()}")
+
+
+def cmd_sync(args) -> int:
+    cache = cache_dir(args)
+    content_bucket = resolve_bucket(CONTENT_BUCKET_ENV, CONTENT_BUCKET_PREFIX)
+    social_bucket = resolve_bucket(SOCIAL_BUCKET_ENV, SOCIAL_BUCKET_PREFIX)
+    log(f"syncing s3://{content_bucket} and s3://{social_bucket} -> {cache}")
+    sync_prefix(f"s3://{content_bucket}/", cache / "content-review")
+    sync_prefix(f"s3://{social_bucket}/", cache / "social")
+    counts = {
+        "content-review": sum(1 for _ in (cache / "content-review").rglob("*.json")),
+        "social": sum(1 for _ in (cache / "social").rglob("*.json")),
+    }
+    meta = {
+        "synced_at": utc_now().isoformat(timespec="seconds"),
+        "buckets": {"content_review": content_bucket, "social": social_bucket},
+        "objects": counts,
+    }
+    (cache / "sync-meta.json").write_text(json.dumps(meta, indent=2) + "\n")
+    log(f"done: {counts['content-review']} content-review objects, {counts['social']} social objects")
+    return 0
+
+
+def read_sync_meta(cache: Path) -> dict | None:
+    try:
+        return json.loads((cache / "sync-meta.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def describe_cache(cache: Path) -> str:
+    meta = read_sync_meta(cache)
+    if not meta:
+        return f"cache {cache} has never been synced — run `review-admin.py sync` first"
+    synced = meta.get("synced_at", "")
+    try:
+        age = utc_now() - datetime.fromisoformat(synced)
+        hours = age.total_seconds() / 3600
+        age_str = f"{hours / 24:.1f}d ago" if hours >= 48 else f"{hours:.1f}h ago"
+    except ValueError:
+        age_str = "unknown age"
+    return f"cache: {cache} (synced {synced}, {age_str})"
+
+
+def require_cache(args) -> Path:
+    cache = cache_dir(args)
+    if not (cache / "content-review").is_dir():
+        die(f"no cache at {cache} — run `review-admin.py sync` first")
+    print(describe_cache(cache))
+    return cache
+
+
+# ---- loaders ----------------------------------------------------------------
+
+
+def load_json_dir(directory: Path) -> list[dict]:
+    """All *.json records in a directory, each tagged with its _file."""
+    records: list[dict] = []
+    if not directory.is_dir():
+        return records
+    for f in sorted(directory.glob("*.json")):
+        try:
+            record = json.loads(f.read_text())
+        except (OSError, json.JSONDecodeError):
+            warn(f"unreadable JSON skipped: {f}")
+            continue
+        if isinstance(record, dict):
+            record["_file"] = str(f)
+            records.append(record)
+    return records
+
+
+def load_json_file(path: Path) -> dict | None:
+    try:
+        data = json.loads(path.read_text())
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def load_docs(cache: Path) -> list[dict]:
+    return load_json_dir(cache / "content-review" / "ledger")
+
+
+def load_claims(cache: Path) -> list[dict]:
+    return load_json_dir(cache / "content-review" / "claims")
+
+
+def load_blog_ledger(cache: Path) -> list[dict]:
+    return load_json_dir(cache / "content-review" / "blog-review" / "ledger")
+
+
+def load_blog_runs(cache: Path) -> list[dict]:
+    """All run records across dates, each tagged with _run_date."""
+    runs_dir = cache / "content-review" / "blog-review" / "runs"
+    records: list[dict] = []
+    if not runs_dir.is_dir():
+        return records
+    for day in sorted(runs_dir.iterdir()):
+        if not day.is_dir():
+            continue
+        for record in load_json_dir(day):
+            record["_run_date"] = day.name
+            records.append(record)
+    return records
+
+
+def latest_runs(runs: list[dict]) -> list[dict]:
+    """Latest run record per slug (runs are tagged with _run_date)."""
+    by_slug: dict[str, dict] = {}
+    for record in runs:
+        slug = record.get("slug") or ""
+        if slug not in by_slug or record.get("_run_date", "") >= by_slug[slug].get("_run_date", ""):
+            by_slug[slug] = record
+    return [by_slug[s] for s in sorted(by_slug)]
+
+
+def load_blog_summary(cache: Path) -> dict | None:
+    return load_json_file(cache / "content-review" / "blog-review" / "index" / "_summary.json")
+
+
+def load_health(cache: Path) -> dict | None:
+    return load_json_file(cache / "content-review" / "health" / "state.json")
+
+
+def load_social(cache: Path) -> list[dict]:
+    """One row per (url, platform) across the social state files.
+
+    posted.json and posted-social.json largely mirror each other; rows are
+    deduplicated on (url, platform, posted_at), keeping the first source seen.
+    """
+    rows: list[dict] = []
+    seen: set[tuple] = set()
+    for name in ("posted-social.json", "posted.json"):
+        data = load_json_file(cache / "social" / name)
+        if not data:
+            continue
+        for url, platforms in (data.get("posts") or {}).items():
+            if not isinstance(platforms, dict):
+                continue
+            failures = platforms.get("_failures")
+            for platform, posted_at in platforms.items():
+                if platform.startswith("_"):
+                    continue
+                key = (url, platform, posted_at)
+                if key in seen:
+                    continue
+                seen.add(key)
+                rows.append({
+                    "url": url, "platform": platform, "posted_at": posted_at,
+                    "failures": failures, "source_file": name,
+                })
+    rows.sort(key=lambda r: (r.get("posted_at") or "", r["url"]), reverse=True)
+    return rows
+
+
+# ---- flatteners -------------------------------------------------------------
+
+
+def flatten_claims(articles: list[dict]) -> list[dict]:
+    """One row per claim, with article fields denormalized onto each row."""
+    rows: list[dict] = []
+    for article in articles:
+        base = {k: v for k, v in article.items() if k not in ("claims", "_file")}
+        base["article_reviewed_at"] = base.pop("reviewed_at", None)
+        for claim in article.get("claims") or []:
+            if isinstance(claim, dict):
+                rows.append({**base, **claim})
+    return rows
+
+
+def flatten_blog_issues(runs: list[dict]) -> list[dict]:
+    """One row per issue from the latest run per post."""
+    rows: list[dict] = []
+    for run in latest_runs(runs):
+        base = {
+            "slug": run.get("slug"), "path": run.get("path"),
+            "run_date": run.get("_run_date"), "post_date": run.get("post_date"),
+            "status": run.get("status"), "noindex_signal": run.get("noindex_signal"),
+        }
+        for issue in run.get("issues") or []:
+            if isinstance(issue, dict):
+                prefixed = {f"issue_{k}": v for k, v in issue.items()}
+                rows.append({**base, **prefixed})
+    return rows
+
+
+# ---- summary ----------------------------------------------------------------
+
+
+def counter_line(counter: Counter) -> str:
+    return ", ".join(f"{k or '(none)'}={v}" for k, v in counter.most_common()) or "(none)"
+
+
+def date_span(records: list[dict], field: str) -> str:
+    dates = sorted(r.get(field) for r in records if r.get(field))
+    if not dates:
+        return "n/a"
+    return f"{dates[0]} .. {dates[-1]}"
+
+
+def build_summary(cache: Path) -> dict:
+    docs = load_docs(cache)
+    claims_articles = load_claims(cache)
+    claim_rows = flatten_claims(claims_articles)
+    blog = load_blog_ledger(cache)
+    runs = load_blog_runs(cache)
+    social = load_social(cache)
+    return {
+        "docs": {
+            "articles": len(docs),
+            "by_status": Counter(r.get("status") for r in docs),
+            "by_lane": Counter(r.get("lane") for r in docs),
+            "fixes": sum(r.get("fixes") or 0 for r in docs),
+            "reviewed_span": date_span(docs, "reviewed_at"),
+        },
+        "claims": {
+            "articles": len(claims_articles),
+            "claims": len(claim_rows),
+            "by_verdict": Counter(r.get("verdict") for r in claim_rows),
+            "by_confidence": Counter(r.get("confidence") for r in claim_rows),
+            "reviewed_span": date_span(claims_articles, "reviewed_at"),
+        },
+        "blog": {
+            "posts": len(blog),
+            "by_status": Counter(r.get("status") for r in blog),
+            "runs": len(runs),
+            "run_dates": sorted({r.get("_run_date") for r in runs if r.get("_run_date")}),
+            "issues": len(flatten_blog_issues(runs)),
+            "by_severity": Counter(r.get("issue_severity") for r in flatten_blog_issues(runs)),
+            "by_category": Counter(r.get("issue_category") for r in flatten_blog_issues(runs)),
+        },
+        "social": {
+            "rows": len(social),
+            "posts": len({r["url"] for r in social}),
+            "by_platform": Counter(r.get("platform") for r in social),
+            "with_failures": len({r["url"] for r in social if r.get("failures")}),
+            "latest_post": max((r.get("posted_at") or "" for r in social), default="n/a"),
+        },
+    }
+
+
+def cmd_summary(args) -> int:
+    cache = require_cache(args)
+    s = build_summary(cache)
+    print()
+    print(f"Docs review ledger      {s['docs']['articles']} articles, {s['docs']['fixes']} fixes applied, reviewed {s['docs']['reviewed_span']}")
+    print(f"  status: {counter_line(s['docs']['by_status'])}")
+    print(f"  lane:   {counter_line(s['docs']['by_lane'])}")
+    print()
+    print(f"Fact-check claims       {s['claims']['claims']} claims across {s['claims']['articles']} articles, reviewed {s['claims']['reviewed_span']}")
+    print(f"  verdict:    {counter_line(s['claims']['by_verdict'])}")
+    print(f"  confidence: {counter_line(s['claims']['by_confidence'])}")
+    print()
+    run_dates = s["blog"]["run_dates"]
+    run_span = f"{run_dates[0]} .. {run_dates[-1]}" if run_dates else "n/a"
+    print(f"Blog known-issues index {s['blog']['posts']} posts, {s['blog']['runs']} run records ({run_span}), {s['blog']['issues']} open issues")
+    print(f"  status:   {counter_line(s['blog']['by_status'])}")
+    print(f"  severity: {counter_line(s['blog']['by_severity'])}")
+    print(f"  category: {counter_line(s['blog']['by_category'])}")
+    blog_summary = load_blog_summary(cache)
+    if blog_summary:
+        print(f"  _summary.json: indexed={blog_summary.get('posts_indexed')} clean={blog_summary.get('posts_clean')} "
+              f"with_issues={blog_summary.get('posts_with_issues')} noindex_candidates={len(blog_summary.get('noindex_candidates') or [])}")
+    print()
+    print(f"Social post state       {s['social']['posts']} posts, {s['social']['rows']} platform sends, latest {s['social']['latest_post'][:10] or 'n/a'}")
+    print(f"  platform: {counter_line(s['social']['by_platform'])}")
+    print(f"  posts with recorded failures: {s['social']['with_failures']}")
+    print()
+    health = load_health(cache)
+    if health:
+        print(f"Signal health           (updated {health.get('updated')})")
+        for name, sig in (health.get("signals") or {}).items():
+            status = sig.get("status")
+            extra = f" since {sig.get('degraded_since')}" if status != "ok" and sig.get("degraded_since") else ""
+            marker = "" if status == "ok" else "  <-- attention"
+            print(f"  {name}: {status}{extra}{marker}")
+    return 0
+
+
+# ---- list -------------------------------------------------------------------
+
+
+def truncate(value, width: int) -> str:
+    text = "" if value is None else str(value).replace("\n", " ")
+    return text if len(text) <= width else text[: width - 1] + "…"
+
+
+def print_table(rows: list[dict], columns: list[tuple[str, int]]) -> None:
+    header = "  ".join(name.ljust(width) for name, width in columns)
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        print("  ".join(truncate(row.get(name), width).ljust(width) for name, width in columns))
+    print(f"({len(rows)} rows)")
+
+
+def list_rows(cache: Path, domain: str) -> tuple[list[dict], list[tuple[str, int]], str]:
+    """Rows, display columns, and the default sort field for a domain."""
+    if domain == "docs":
+        return (load_docs(cache), [
+            ("slug", 52), ("status", 9), ("lane", 9), ("fixes", 5),
+            ("pr_number", 9), ("reviewed_at", 11), ("note", 60),
+        ], "reviewed_at")
+    if domain == "claims":
+        rows = flatten_claims(load_claims(cache))
+        return (rows, [
+            ("slug", 42), ("claim_id", 8), ("type", 10), ("verdict", 12),
+            ("confidence", 10), ("line_range", 10), ("text", 60),
+        ], "article_reviewed_at")
+    if domain == "blog":
+        return (load_blog_ledger(cache), [
+            ("slug", 52), ("status", 10), ("issues", 6), ("post_date", 11),
+            ("reviewed_at", 11), ("note", 60),
+        ], "reviewed_at")
+    if domain == "social":
+        rows = load_social(cache)
+        return (rows, [
+            ("url", 64), ("platform", 8), ("posted_at", 20), ("failures", 8),
+        ], "posted_at")
+    die(f"unknown domain '{domain}' (expected one of: {', '.join(DOMAINS)})")
+
+
+def cmd_list(args) -> int:
+    cache = require_cache(args)
+    rows, columns, sort_field = list_rows(cache, args.domain)
+    if args.status:
+        rows = [r for r in rows if r.get("status") == args.status]
+    if args.verdict:
+        rows = [r for r in rows if r.get("verdict") == args.verdict]
+    if args.since:
+        date_field = "posted_at" if args.domain == "social" else \
+            "article_reviewed_at" if args.domain == "claims" else "reviewed_at"
+        rows = [r for r in rows if (r.get(date_field) or "") >= args.since]
+    rows.sort(key=lambda r: r.get(sort_field) or "", reverse=True)
+    if args.limit:
+        rows = rows[: args.limit]
+    print()
+    print_table(rows, columns)
+    return 0
+
+
+# ---- show -------------------------------------------------------------------
+
+
+def record_matches(record: dict, needle: str) -> bool:
+    for field in ("slug", "path", "url"):
+        value = record.get(field) or ""
+        if needle == value or needle in value:
+            return True
+    return False
+
+
+def cmd_show(args) -> int:
+    cache = require_cache(args)
+    needle = args.slug
+    sections = [
+        ("docs review ledger", load_docs(cache)),
+        ("fact-check claims", load_claims(cache)),
+        ("blog-review ledger", load_blog_ledger(cache)),
+        ("blog-review runs", load_blog_runs(cache)),
+        ("social post state", load_social(cache)),
+    ]
+    hits = 0
+    for title, records in sections:
+        matched = [r for r in records if record_matches(r, needle)]
+        for record in matched:
+            hits += 1
+            source = record.get("_file") or record.get("source_file") or ""
+            print(f"\n=== {title} — {source}")
+            printable = {k: v for k, v in record.items() if k != "_file"}
+            print(json.dumps(printable, indent=2))
+    if not hits:
+        warn(f"no records match '{needle}' (try a slug like docs-get-started or a /blog/... URL)")
+        return 1
+    print(f"\n({hits} records)")
+    return 0
+
+
+# ---- export -----------------------------------------------------------------
+
+
+def export_columns(rows: list[dict], preferred: list[str]) -> list[str]:
+    if not rows:
+        return preferred
+    extras = sorted({k for r in rows for k in r} - set(preferred) - {"_file", "_run_date"})
+    return [c for c in preferred if any(c in r for r in rows)] + extras
+
+
+def csv_value(value):
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    return value
+
+
+def write_exports(rows: list[dict], out_dir: Path, name: str, preferred: list[str], formats: set[str]) -> None:
+    clean = [{k: v for k, v in r.items() if k not in ("_file", "_run_date")} for r in rows]
+    if "jsonl" in formats:
+        path = out_dir / f"{name}.jsonl"
+        path.write_text("".join(json.dumps(r) + "\n" for r in clean))
+        log(f"wrote {path} ({len(clean)} rows)")
+    if "csv" in formats:
+        path = out_dir / f"{name}.csv"
+        columns = export_columns(clean, preferred)
+        with path.open("w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=columns, extrasaction="ignore")
+            writer.writeheader()
+            for row in clean:
+                writer.writerow({k: csv_value(row.get(k)) for k in columns})
+        log(f"wrote {path} ({len(clean)} rows)")
+
+
+def cmd_export(args) -> int:
+    cache = require_cache(args)
+    out_dir = Path(args.out) if args.out else cache / "exports"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    formats = {"csv", "jsonl"} if args.format == "both" else {args.format}
+    runs = load_blog_runs(cache)
+    write_exports(load_docs(cache), out_dir, "docs-ledger", DOCS_COLUMNS, formats)
+    write_exports(flatten_claims(load_claims(cache)), out_dir, "claims", CLAIM_COLUMNS, formats)
+    write_exports(load_blog_ledger(cache), out_dir, "blog-review", BLOG_COLUMNS, formats)
+    write_exports(flatten_blog_issues(runs), out_dir, "blog-review-issues", BLOG_ISSUE_COLUMNS, formats)
+    write_exports(load_social(cache), out_dir, "social-posts", SOCIAL_COLUMNS, formats)
+    return 0
+
+
+# ---- html dashboard ---------------------------------------------------------
+
+HTML_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Review ledgers</title>
+<style>
+:root { --bg:#fff; --fg:#1a1a2e; --muted:#667; --border:#d8d8e4; --surface:#f4f4fa;
+        --accent:#805ac3; --bad:#c0392b; --good:#1e7e46; --warn:#a66900; }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#16161f; --fg:#e8e8f0; --muted:#99a; --border:#3a3a4c; --surface:#20202c;
+          --accent:#b49aea; --bad:#e57368; --good:#5dbb85; --warn:#d9a04a; }
+}
+* { box-sizing: border-box; }
+body { margin:0; font:14px/1.45 system-ui, sans-serif; background:var(--bg); color:var(--fg); }
+header { padding:14px 20px; border-bottom:1px solid var(--border); display:flex; gap:16px;
+         align-items:baseline; flex-wrap:wrap; }
+header h1 { font-size:17px; margin:0; }
+header .meta { color:var(--muted); font-size:12px; }
+nav { display:flex; gap:4px; padding:8px 20px 0; border-bottom:1px solid var(--border); flex-wrap:wrap; }
+nav button { border:1px solid var(--border); border-bottom:none; background:var(--surface);
+             color:var(--fg); padding:7px 14px; border-radius:6px 6px 0 0; cursor:pointer; font-size:13px; }
+nav button.active { background:var(--bg); font-weight:600; border-color:var(--accent); }
+main { padding:16px 20px 40px; }
+.controls { display:flex; gap:10px; margin:0 0 12px; flex-wrap:wrap; align-items:center; }
+.controls input { padding:6px 10px; border:1px solid var(--border); border-radius:6px;
+                  background:var(--bg); color:var(--fg); width:280px; }
+.chip { border:1px solid var(--border); background:var(--surface); color:var(--fg);
+        border-radius:12px; padding:3px 11px; cursor:pointer; font-size:12px; }
+.chip.on { border-color:var(--accent); color:var(--accent); font-weight:600; }
+.count { color:var(--muted); font-size:12px; }
+.tablewrap { overflow-x:auto; border:1px solid var(--border); border-radius:8px; }
+table { border-collapse:collapse; width:100%; }
+th, td { text-align:left; padding:6px 10px; border-bottom:1px solid var(--border);
+         vertical-align:top; max-width:420px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+th { background:var(--surface); cursor:pointer; user-select:none; position:sticky; top:0; }
+tr.datarow:hover { background:var(--surface); cursor:pointer; }
+tr.detail td { white-space:pre-wrap; font-family:ui-monospace, monospace; font-size:12px;
+               background:var(--surface); max-width:none; }
+.badge { padding:1px 8px; border-radius:10px; font-size:12px; border:1px solid var(--border); }
+.badge.ok { color:var(--good); border-color:var(--good); }
+.badge.bad { color:var(--bad); border-color:var(--bad); }
+.badge.warn { color:var(--warn); border-color:var(--warn); }
+.cards { display:flex; gap:14px; flex-wrap:wrap; margin-bottom:18px; }
+.card { border:1px solid var(--border); border-radius:8px; padding:12px 16px; background:var(--surface);
+        min-width:200px; }
+.card h3 { margin:0 0 6px; font-size:13px; color:var(--muted); font-weight:600; }
+.card .big { font-size:24px; font-weight:700; }
+.card .sub { font-size:12px; color:var(--muted); margin-top:4px; }
+h2 { font-size:15px; margin:20px 0 8px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Review ledgers</h1>
+  <span class="meta" id="genmeta"></span>
+</header>
+<nav id="tabs"></nav>
+<main id="main"></main>
+<script type="application/json" id="data">__DATA__</script>
+<script>
+const DATA = JSON.parse(document.getElementById('data').textContent);
+const TABS = [
+  {id:'overview', label:'Overview'},
+  {id:'docs', label:'Docs ledger', rows:DATA.docs, chips:'status',
+   cols:['slug','status','lane','fixes','skipped_findings','pr_number','reviewed_at','note']},
+  {id:'claims', label:'Claims', rows:DATA.claims, chips:'verdict',
+   cols:['slug','claim_id','type','verdict','confidence','line_range','text']},
+  {id:'blog', label:'Blog review', rows:DATA.blog, chips:'status',
+   cols:['slug','status','issues','post_date','reviewed_at','note']},
+  {id:'social', label:'Social', rows:DATA.social, chips:'platform',
+   cols:['url','platform','posted_at','failures','source_file']},
+];
+let active = 'overview';
+const state = {};   // per-tab: {q, chip, sortCol, sortDir}
+
+function el(tag, attrs, ...children) {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs || {})) {
+    if (k === 'onclick') node.onclick = v; else if (k === 'class') node.className = v;
+    else node.setAttribute(k, v);
+  }
+  for (const child of children) node.append(child);
+  return node;
+}
+
+function renderTabs() {
+  const nav = document.getElementById('tabs');
+  nav.replaceChildren(...TABS.map(t =>
+    el('button', {class: t.id === active ? 'active' : '',
+                  onclick: () => { active = t.id; render(); }},
+       t.label + (t.rows ? ` (${t.rows.length})` : ''))));
+}
+
+function verdictClass(v) {
+  if (['verified','ok','clean','reviewed'].includes(v)) return 'ok';
+  if (['contradicted','degraded','incomplete'].includes(v)) return 'bad';
+  return 'warn';
+}
+
+function renderOverview(main) {
+  const s = DATA.summary, cards = el('div', {class:'cards'});
+  const mk = (title, big, sub) => cards.append(
+    el('div', {class:'card'}, el('h3', {}, title), el('div', {class:'big'}, String(big)),
+       el('div', {class:'sub'}, sub)));
+  mk('Docs articles reviewed', s.docs.articles, `${s.docs.fixes} fixes · ${fmtCounter(s.docs.by_status)}`);
+  mk('Fact-check claims', s.claims.claims, `${s.claims.articles} articles · ${fmtCounter(s.claims.by_verdict)}`);
+  mk('Blog posts indexed', s.blog.posts, `${s.blog.issues} open issues · ${fmtCounter(s.blog.by_status)}`);
+  mk('Social sends', s.social.rows, `${s.social.posts} posts · ${fmtCounter(s.social.by_platform)}`);
+  main.append(cards);
+  if (DATA.health && DATA.health.signals) {
+    main.append(el('h2', {}, `Signal health (updated ${DATA.health.updated || '?'})`));
+    const wrap = el('div', {class:'cards'});
+    for (const [name, sig] of Object.entries(DATA.health.signals)) {
+      const cls = sig.status === 'ok' ? 'ok' : 'bad';
+      wrap.append(el('div', {class:'card'}, el('h3', {}, name),
+        el('span', {class:`badge ${cls}`}, sig.status +
+           (sig.degraded_since ? ` since ${sig.degraded_since}` : '')),
+        el('div', {class:'sub'}, sig.detail || '')));
+    }
+    main.append(wrap);
+  }
+  if (DATA.blog_summary) {
+    const b = DATA.blog_summary;
+    main.append(el('h2', {}, 'Blog-review index summary (_summary.json)'),
+      el('div', {class:'sub count'},
+        `generated ${b.generated} · indexed ${b.posts_indexed} · clean ${b.posts_clean} · ` +
+        `with issues ${b.posts_with_issues} · noindex candidates ${(b.noindex_candidates || []).length}`));
+  }
+}
+
+function fmtCounter(counter) {
+  return Object.entries(counter || {}).map(([k, v]) => `${k || '(none)'} ${v}`).join(' · ') || '—';
+}
+
+function renderTable(main, tab) {
+  const st = state[tab.id] ||= {q:'', chip:null, sortCol:null, sortDir:-1};
+  const chipValues = [...new Set(tab.rows.map(r => r[tab.chips]).filter(Boolean))].sort();
+  const controls = el('div', {class:'controls'});
+  const input = el('input', {placeholder:'filter…', value:st.q});
+  input.oninput = () => { st.q = input.value; render(true); };
+  controls.append(input);
+  for (const v of chipValues) {
+    controls.append(el('button', {class:'chip' + (st.chip === v ? ' on' : ''),
+      onclick: () => { st.chip = st.chip === v ? null : v; render(); }}, v));
+  }
+  let rows = tab.rows.filter(r =>
+    (!st.chip || r[tab.chips] === st.chip) &&
+    (!st.q || JSON.stringify(r).toLowerCase().includes(st.q.toLowerCase())));
+  if (st.sortCol) rows = [...rows].sort((a, b) =>
+    String(a[st.sortCol] ?? '').localeCompare(String(b[st.sortCol] ?? '')) * st.sortDir);
+  controls.append(el('span', {class:'count'}, `${rows.length} of ${tab.rows.length} rows — click a row for full record`));
+  main.append(controls);
+  const thead = el('tr', {}, ...tab.cols.map(c =>
+    el('th', {onclick: () => { st.sortDir = st.sortCol === c ? -st.sortDir : -1; st.sortCol = c; render(); }},
+       c + (st.sortCol === c ? (st.sortDir < 0 ? ' ↓' : ' ↑') : ''))));
+  const tbody = el('tbody', {});
+  for (const row of rows.slice(0, 2000)) {
+    const tr = el('tr', {class:'datarow'}, ...tab.cols.map(c => {
+      const value = row[c];
+      if ((c === 'verdict' || c === 'status') && value)
+        return el('td', {}, el('span', {class:`badge ${verdictClass(value)}`}, String(value)));
+      return el('td', {title: value == null ? '' : String(value)},
+                value == null ? '' : String(value));
+    }));
+    tr.onclick = () => {
+      if (tr.nextSibling && tr.nextSibling.classList.contains('detail')) { tr.nextSibling.remove(); return; }
+      tbody.querySelectorAll('tr.detail').forEach(n => n.remove());
+      tr.after(el('tr', {class:'detail'},
+        el('td', {colspan: String(tab.cols.length)}, JSON.stringify(row, null, 2))));
+    };
+    tbody.append(tr);
+  }
+  main.append(el('div', {class:'tablewrap'}, el('table', {}, el('thead', {}, thead), tbody)));
+}
+
+function render(keepFocus) {
+  renderTabs();
+  const main = document.getElementById('main');
+  const focused = keepFocus && document.activeElement === main.querySelector('input');
+  main.replaceChildren();
+  const tab = TABS.find(t => t.id === active);
+  if (tab.id === 'overview') renderOverview(main); else renderTable(main, tab);
+  if (focused) { const inp = main.querySelector('input'); inp.focus(); inp.setSelectionRange(inp.value.length, inp.value.length); }
+}
+
+document.getElementById('genmeta').textContent =
+  `generated ${DATA.generated}` + (DATA.sync_meta ? ` · synced ${DATA.sync_meta.synced_at}` : ' · cache never synced');
+render();
+</script>
+</body>
+</html>
+"""
+
+
+def counters_to_plain(obj):
+    """Recursively convert Counter values into plain dicts for JSON."""
+    if isinstance(obj, Counter):
+        return dict(obj.most_common())
+    if isinstance(obj, dict):
+        return {k: counters_to_plain(v) for k, v in obj.items()}
+    return obj
+
+
+def render_html(cache: Path) -> str:
+    runs = load_blog_runs(cache)
+    data = {
+        "generated": utc_now().isoformat(timespec="seconds"),
+        "sync_meta": read_sync_meta(cache),
+        "summary": counters_to_plain(build_summary(cache)),
+        "docs": [{k: v for k, v in r.items() if k != "_file"} for r in load_docs(cache)],
+        "claims": flatten_claims(load_claims(cache)),
+        "blog": [{k: v for k, v in r.items() if k != "_file"} for r in load_blog_ledger(cache)],
+        "blog_issues": flatten_blog_issues(runs),
+        "social": load_social(cache),
+        "health": load_health(cache),
+        "blog_summary": load_blog_summary(cache),
+    }
+    # </ must not appear literally inside the inline <script> data block.
+    payload = json.dumps(data).replace("</", "<\\/")
+    return HTML_TEMPLATE.replace("__DATA__", payload)
+
+
+def cmd_html(args) -> int:
+    cache = require_cache(args)
+    out = Path(args.out) if args.out else cache / "review-dashboard.html"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(render_html(cache))
+    log(f"wrote {out}")
+    if args.open:
+        webbrowser.open(out.resolve().as_uri())
+    return 0
+
+
+# ---- self-test --------------------------------------------------------------
+
+FIXTURES = {
+    "content-review/ledger/docs-get-started.json": {
+        # Legacy record shape: no schema_version.
+        "path": "content/docs/get-started/_index.md", "slug": "docs-get-started",
+        "lane": "priority", "status": "clean", "pr": None, "pr_number": 0,
+        "head_sha": "", "fixes": 0, "skipped_findings": 2, "retirement": False,
+        "note": "all clean", "reviewed_at": "2026-06-16",
+    },
+    "content-review/claims/docs-example.json": {
+        "schema_version": 1, "path": "content/docs/example.md", "slug": "docs-example",
+        "commit": "abc123", "reviewed_at": "2026-07-16", "model": "claude-sonnet-5",
+        "claims": [
+            {"claim_id": "c1", "type": "behavior", "text": "It works. </script> honest.",
+             "line_range": "L19", "verdict": "verified", "confidence": "high",
+             "evidence": "source says so", "source": "repo:content/docs/example.md",
+             "entity_key": None, "volatile": False},
+            {"claim_id": "c2", "type": "url", "text": "Dead link", "line_range": "L21",
+             "verdict": "contradicted", "confidence": "high", "evidence": "404",
+             "source": "web", "entity_key": None, "volatile": True},
+        ],
+    },
+    "content-review/blog-review/ledger/example-post.json": {
+        "schema_version": 1, "path": "content/blog/example-post/index.md",
+        "slug": "example-post", "lane": "manual", "status": "reviewed", "issues": 1,
+        "note": "", "attempts": 1, "score": None, "post_date": "2020-01-01",
+        "head_sha": "def456", "reviewed_at": "2026-07-16",
+    },
+    "content-review/blog-review/runs/2026-07-16/example-post.json": {
+        "schema_version": 1, "path": "content/blog/example-post/index.md",
+        "slug": "example-post", "url": "/blog/example-post/", "post_date": "2020-01-01",
+        "reviewed_at": "2026-07-16", "status": "reviewed", "clean": False,
+        "issues": [{"category": "dead-link", "severity": "medium", "detail": "404 on example.com"}],
+        "issue_counts": {"total": 1}, "noindex_signal": None,
+    },
+    "content-review/blog-review/index/_summary.json": {
+        "schema_version": 1, "generated": "2026-07-16", "posts_indexed": 1,
+        "posts_clean": 0, "posts_with_issues": 1, "issues_by_severity": {"medium": 1},
+        "issues_by_category": {"dead-link": 1}, "noindex_candidates": [],
+    },
+    "content-review/health/state.json": {
+        "version": 1, "updated": "2026-07-16",
+        "signals": {"traffic": {"status": "ok", "detail": "ok", "last_ok": "2026-07-16",
+                                "degraded_since": None, "last_alerted": None},
+                    "console-access": {"status": "degraded", "detail": "degraded",
+                                       "last_ok": None, "degraded_since": "2026-07-10",
+                                       "last_alerted": None}},
+    },
+    "social/posted-social.json": {
+        "posts": {"/blog/example-post/": {"x": "2026-04-01T09:00:00+00:00",
+                                          "linkedin": "2026-04-01T09:01:00+00:00",
+                                          "_failures": 1}},
+    },
+}
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = Path(tmp)
+        for rel, record in FIXTURES.items():
+            path = cache / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(record, indent=2) + "\n")
+
+        docs = load_docs(cache)
+        assert len(docs) == 1 and docs[0]["slug"] == "docs-get-started", docs
+        claim_rows = flatten_claims(load_claims(cache))
+        assert len(claim_rows) == 2, claim_rows
+        assert claim_rows[0]["slug"] == "docs-example" and claim_rows[0]["claim_id"] == "c1"
+        assert {r["verdict"] for r in claim_rows} == {"verified", "contradicted"}
+
+        runs = load_blog_runs(cache)
+        issues = flatten_blog_issues(runs)
+        assert len(issues) == 1 and issues[0]["issue_category"] == "dead-link", issues
+        social = load_social(cache)
+        assert len(social) == 2 and social[0]["failures"] == 1, social
+
+        summary = build_summary(cache)
+        assert summary["claims"]["by_verdict"]["contradicted"] == 1
+        assert summary["blog"]["issues"] == 1
+        assert summary["social"]["posts"] == 1
+
+        out_dir = cache / "exports"
+        out_dir.mkdir()
+        write_exports(claim_rows, out_dir, "claims", CLAIM_COLUMNS, {"csv", "jsonl"})
+        csv_lines = (out_dir / "claims.csv").read_text().splitlines()
+        assert len(csv_lines) == 3, csv_lines  # header + 2 claims
+        assert csv_lines[0].startswith("slug,path,claim_id")
+        jsonl = [json.loads(line) for line in (out_dir / "claims.jsonl").read_text().splitlines()]
+        assert jsonl[1]["verdict"] == "contradicted"
+
+        html = render_html(cache)
+        assert "Review ledgers" in html
+        assert "</script> honest" not in html          # escaped in embedded JSON
+        assert "<\\/script> honest" in html
+        assert "docs-get-started" in html
+
+    print("self-test OK")
+    return 0
+
+
+# ---- main -------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Browse and export the S3 review/state ledgers (read-only).")
+    parser.add_argument("--self-test", action="store_true", help="run the offline smoke test and exit")
+    parser.add_argument("--cache-dir", help=f"local cache directory (default: <repo>/{CACHE_DIRNAME}, or ${CACHE_ENV})")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("sync", help="sync both buckets into the local cache")
+    sub.add_parser("summary", help="console overview of all captured data")
+
+    p_list = sub.add_parser("list", help="list records for one domain")
+    p_list.add_argument("domain", choices=DOMAINS)
+    p_list.add_argument("--status", help="filter by status (docs/blog)")
+    p_list.add_argument("--verdict", help="filter by claim verdict (claims)")
+    p_list.add_argument("--since", help="only records on/after this date (YYYY-MM-DD)")
+    p_list.add_argument("--limit", type=int, help="max rows")
+
+    p_show = sub.add_parser("show", help="print every record matching a slug, path, or URL")
+    p_show.add_argument("slug")
+
+    p_export = sub.add_parser("export", help="write normalized CSV/JSONL exports")
+    p_export.add_argument("--out", help="output directory (default: <cache>/exports)")
+    p_export.add_argument("--format", choices=["csv", "jsonl", "both"], default="both")
+
+    p_html = sub.add_parser("html", help="generate the self-contained HTML dashboard")
+    p_html.add_argument("--out", help="output file (default: <cache>/review-dashboard.html)")
+    p_html.add_argument("--open", action="store_true", help="open in a browser after writing")
+
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return self_test()
+    handlers = {"sync": cmd_sync, "summary": cmd_summary, "list": cmd_list,
+                "show": cmd_show, "export": cmd_export, "html": cmd_html}
+    if not args.command:
+        parser.print_help()
+        return 2
+    return handlers[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/review-admin/test_review_admin.py
+++ b/scripts/review-admin/test_review_admin.py
@@ -1,0 +1,145 @@
+"""Tests for review-admin.py (offline — no AWS, no network)."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+SPEC = importlib.util.spec_from_file_location(
+    "review_admin", Path(__file__).parent / "review-admin.py")
+ra = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ra)
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> Path:
+    """A populated cache directory built from the module's own fixtures."""
+    for rel, record in ra.FIXTURES.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record) + "\n")
+    return tmp_path
+
+
+def test_self_test_passes():
+    assert ra.self_test() == 0
+
+
+def test_load_docs_tolerates_legacy_records_without_schema_version(cache: Path):
+    docs = ra.load_docs(cache)
+    assert len(docs) == 1
+    assert "schema_version" not in docs[0]
+    assert docs[0]["slug"] == "docs-get-started"
+
+
+def test_load_json_dir_skips_unreadable_files(cache: Path, capsys):
+    (cache / "content-review" / "ledger" / "broken.json").write_text("{not json")
+    docs = ra.load_docs(cache)
+    assert len(docs) == 1
+    assert "unreadable JSON skipped" in capsys.readouterr().err
+
+
+def test_flatten_claims_denormalizes_article_fields(cache: Path):
+    rows = ra.flatten_claims(ra.load_claims(cache))
+    assert len(rows) == 2
+    for row in rows:
+        assert row["slug"] == "docs-example"
+        assert row["commit"] == "abc123"
+        assert row["article_reviewed_at"] == "2026-07-16"
+        assert "claims" not in row
+    assert rows[1]["verdict"] == "contradicted"
+
+
+def test_flatten_blog_issues_uses_latest_run_per_slug(cache: Path):
+    older = dict(ra.FIXTURES["content-review/blog-review/runs/2026-07-16/example-post.json"])
+    older["issues"] = [{"category": "stale", "severity": "low"}] * 3
+    old_dir = cache / "content-review" / "blog-review" / "runs" / "2026-07-01"
+    old_dir.mkdir(parents=True)
+    (old_dir / "example-post.json").write_text(json.dumps(older))
+
+    issues = ra.flatten_blog_issues(ra.load_blog_runs(cache))
+    assert len(issues) == 1
+    assert issues[0]["issue_category"] == "dead-link"
+    assert issues[0]["run_date"] == "2026-07-16"
+
+
+def test_load_social_dedupes_across_state_files(cache: Path):
+    duplicate = ra.FIXTURES["social/posted-social.json"]
+    (cache / "social" / "posted.json").write_text(json.dumps(duplicate))
+    rows = ra.load_social(cache)
+    assert len(rows) == 2  # x + linkedin, not doubled
+    assert all(r["source_file"] == "posted-social.json" for r in rows)
+    assert all(r["failures"] == 1 for r in rows)
+
+
+def test_build_summary_counts(cache: Path):
+    s = ra.build_summary(cache)
+    assert s["docs"]["by_status"]["clean"] == 1
+    assert s["claims"]["by_verdict"] == {"verified": 1, "contradicted": 1}
+    assert s["blog"]["by_severity"]["medium"] == 1
+    assert s["social"]["by_platform"] == {"x": 1, "linkedin": 1}
+
+
+def test_export_csv_and_jsonl_shapes(cache: Path, tmp_path: Path):
+    out = tmp_path / "out"
+    out.mkdir()
+    rows = ra.flatten_claims(ra.load_claims(cache))
+    ra.write_exports(rows, out, "claims", ra.CLAIM_COLUMNS, {"csv", "jsonl"})
+
+    with (out / "claims.csv").open() as fh:
+        parsed = list(csv.DictReader(fh))
+    assert len(parsed) == 2
+    assert parsed[0]["claim_id"] == "c1"
+    assert parsed[0]["volatile"] == "False"
+
+    jsonl = [json.loads(line) for line in (out / "claims.jsonl").read_text().splitlines()]
+    assert jsonl[0]["volatile"] is False
+    assert "_file" not in jsonl[0]
+
+
+def test_export_preserves_unknown_fields(cache: Path, tmp_path: Path):
+    docs = ra.load_docs(cache)
+    docs[0]["brand_new_field"] = {"nested": True}
+    out = tmp_path / "out"
+    out.mkdir()
+    ra.write_exports(docs, out, "docs-ledger", ra.DOCS_COLUMNS, {"csv", "jsonl"})
+    with (out / "docs-ledger.csv").open() as fh:
+        parsed = list(csv.DictReader(fh))
+    assert parsed[0]["brand_new_field"] == '{"nested": true}'
+
+
+def test_html_embeds_data_and_escapes_script_close(cache: Path):
+    html = ra.render_html(cache)
+    assert html.count("<script") == 2  # data block + app JS
+    assert "</script> honest" not in html
+    assert "docs-get-started" in html
+    assert "console-access" in html
+
+
+def test_record_matches_slug_path_and_url():
+    record = {"slug": "docs-example", "path": "content/docs/example.md"}
+    assert ra.record_matches(record, "docs-example")
+    assert ra.record_matches(record, "content/docs/example.md")
+    assert ra.record_matches(record, "example")
+    assert not ra.record_matches(record, "unrelated")
+    assert ra.record_matches({"url": "/blog/example-post/"}, "/blog/example-post/")
+
+
+def test_list_filters(cache: Path, capsys):
+    class Args:
+        cache_dir = str(cache)
+        domain = "claims"
+        status = None
+        verdict = "contradicted"
+        since = None
+        limit = None
+
+    assert ra.cmd_list(Args()) == 0
+    out = capsys.readouterr().out
+    assert "(1 rows)" in out
+    assert "contradicted" in out
+    assert "verified" not in out


### PR DESCRIPTION
## Summary

Several automated processes (existing-content review, fact-check claims, blog-review index, signal health, social post scheduler) keep state as small JSON objects in two private S3 buckets, none of it human-browsable without pulling objects one at a time. The DWH ingestion in pulumi/data is logged but unaddressed, and won't cover everything.

This adds `scripts/review-admin/review-admin.py` — a read-only, stdlib-only CLI that syncs both buckets into a gitignored local cache (`.review-admin-cache/`) and then works offline:

- `sync` — pull both buckets (aws CLI, bucket names discovered by prefix or pinned via env vars)
- `summary` — console overview of everything captured
- `list` / `show` — filterable listings per domain and per-article paper trails across all domains
- `export` — DWH/DuckDB-ready flat CSV/JSONL (one row per claim, per blog issue, per social send)
- `html` — self-contained dashboard (search, sort, filter chips, row expansion; no external assets)

Plus `make review-admin-sync` / `make review-admin-dashboard` targets, pytest coverage, and a `--self-test` offline smoke test.

Version history intentionally stays with `scripts/content-review/reconstruct-ledger-history.py`; this tool shows current state only.

## Testing

- `--self-test` and 12 pytest cases pass offline
- Verified live against both buckets: sync (125 + 2 objects), summary, filtered listings, exports (376 claim rows), and the dashboard exercised in a browser (tab switching, verdict chips, row expansion)
- `make lint` passes (cache dir added to `.prettierignore` so Prettier ignores synced JSON)