### PR TITLE
Cover all Pulumi languages in the stack references tutorial

### DIFF
--- a/content/tutorials/building-with-pulumi/stack-references/index.md
+++ b/content/tutorials/building-with-pulumi/stack-references/index.md
@@ -16,7 +16,7 @@ In this section, you'll create a new project and stack that'll use the stack out
 
 Let's start by making a new program in a new directory, alongside `my-first-app`:
 
-{{< chooser language "typescript,python" />}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" />}}
 
 {{% choosable language typescript %}}
 
@@ -38,6 +38,62 @@ $ pulumi new python -y
 
 {{% /choosable %}}
 
+{{% choosable language go %}}
+
+```bash
+$ mkdir ../my-second-app
+$ cd ../my-second-app
+$ pulumi new go -y
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```bash
+$ mkdir ../my-second-app
+$ cd ../my-second-app
+$ pulumi new csharp -y
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```bash
+$ mkdir ../my-second-app
+$ cd ../my-second-app
+$ pulumi new java -y
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```bash
+$ mkdir ../my-second-app
+$ cd ../my-second-app
+$ pulumi new yaml -y
+```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```bash
+$ mkdir ../my-second-app
+$ cd ../my-second-app
+```
+
+There is no `pulumi new` template for Pulumi HCL yet, so create the project file by hand. Add a `Pulumi.yaml` with the following contents:
+
+```yaml
+name: my-second-app
+runtime: hcl
+```
+
+{{% /choosable %}}
+
 Let's go ahead and create a `staging` stack here as well:
 
 ```bash
@@ -49,7 +105,7 @@ Now comes the fun part! Let's add a little code to pull in the values from the
 
 Add this code to the {{< langfile >}} file inside of `my-second-app`:
 
-{{< chooser language "typescript,python" />}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" />}}
 
 {{% choosable language typescript %}}
 
@@ -64,14 +120,6 @@ const stackRef = new pulumi.StackReference(`${org}/my-first-app/${stack}`)
 
 export const shopUrl = stackRef.getOutput("url");
 ```
-
-The `org` configuration variable is new, as is the `stackRef` declaration. That
-declaration sets up an instance of the `StackReference` class, which needs the
-fully qualified name of the stack as an input. Here, `org` is the
-organization associated with your account, `my-first-app` is the name of the
-project you've been working in, and `stack` is the stack that you want to
-reference. If you have an individual account, the org is your account name. The
-export then grabs the `url` output from the other stack.
 
 {{% /choosable %}}
 
@@ -89,15 +137,135 @@ stack_ref = pulumi.StackReference(f"{org}/my-first-app/{stack}")
 pulumi.export("shopUrl", stack_ref.get_output("url"))
 ```
 
-The `org` configuration variable is new, as is the `stack_ref` declaration. That
-declaration sets up an instance of the `StackReference` class, which needs the
-fully qualified name of the stack as an input. Here, `org` is the
-organization associated with your account, `my-first-app` is the name of the
-project you've been working in, and `stack` is the stack that you want to
-reference. If you have an individual account, the org is your account name. The
-export then grabs the `url` output from the other stack.
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		cfg := config.New(ctx, "")
+		org := cfg.Require("org")
+		stack := ctx.Stack()
+
+		stackRef, err := pulumi.NewStackReference(ctx,
+			fmt.Sprintf("%s/my-first-app/%s", org, stack), nil)
+		if err != nil {
+			return err
+		}
+
+		ctx.Export("shopUrl", stackRef.GetOutput(pulumi.String("url")))
+		return nil
+	})
+}
+```
 
 {{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+using System.Collections.Generic;
+using Pulumi;
+
+return await Deployment.RunAsync(() =>
+{
+    var config = new Config();
+    var org = config.Require("org");
+    var stack = Deployment.Instance.StackName;
+
+    var stackRef = new StackReference($"{org}/my-first-app/{stack}");
+
+    return new Dictionary<string, object?>
+    {
+        ["shopUrl"] = stackRef.GetOutput("url"),
+    };
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+package myproject;
+
+import com.pulumi.Pulumi;
+import com.pulumi.resources.StackReference;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(ctx -> {
+            var org = ctx.config().require("org");
+            var stack = ctx.stackName();
+
+            var stackRef = new StackReference(
+                String.format("%s/my-first-app/%s", org, stack));
+
+            ctx.export("shopUrl", stackRef.output("url"));
+        });
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```yaml
+name: my-second-app
+runtime: yaml
+
+config:
+  org:
+    type: string
+
+resources:
+  stackRef:
+    type: pulumi:pulumi:StackReference
+    properties:
+      name: ${org}/my-first-app/${pulumi.stack}
+
+outputs:
+  shopUrl: ${stackRef.outputs["url"]}
+```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```hcl
+variable "org" {
+  type = string
+}
+
+resource "pulumi_stack_reference" "stack_ref" {
+  name = "${var.org}/my-first-app/${pulumi.stack}"
+}
+
+output "shopUrl" {
+  value = pulumi_stack_reference.stack_ref.outputs["url"]
+}
+```
+
+{{% /choosable %}}
+
+The `org` configuration variable is new, as is the stack reference declaration.
+That declaration sets up an instance of the `StackReference` type, which needs
+the fully qualified name of the stack as an input. Here, `org` is the
+organization associated with your account, `my-first-app` is the name of the
+project you've been working in, and the current stack name selects the stack
+that you want to reference. If you have an individual account, the org is your
+account name. The export then grabs the `url` output from the other stack.
 
 Set the `org` configuration variable using `pulumi config set`:
 

--- a/content/tutorials/building-with-pulumi/stack-references/index.md
+++ b/content/tutorials/building-with-pulumi/stack-references/index.md
@@ -83,13 +83,7 @@ $ pulumi new yaml -y
 ```bash
 $ mkdir ../my-second-app
 $ cd ../my-second-app
-```
-
-There is no `pulumi new` template for Pulumi HCL yet, so create the project file by hand. Add a `Pulumi.yaml` with the following contents:
-
-```yaml
-name: my-second-app
-runtime: hcl
+$ pulumi new hcl -y
 ```
 
 {{% /choosable %}}

--- a/layouts/shortcodes/langfile.html
+++ b/layouts/shortcodes/langfile.html
@@ -1,5 +1,5 @@
 {{- /* Used to display a language-specific filename based on the chosen language. */ -}}
-<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp,fsharp,visualbasic,java,yaml" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp,fsharp,visualbasic,java,yaml,hcl" option-style="none" class="inline">
     <pulumi-choosable type="language" value="javascript"><code>index.js</code></pulumi-choosable>
     <pulumi-choosable type="language" value="typescript"><code>index.ts</code></pulumi-choosable>
     <pulumi-choosable type="language" value="python"><code>__main__.py</code></pulumi-choosable>
@@ -9,4 +9,5 @@
     <pulumi-choosable type="language" value="visualbasic"><code>Program.vb</code></pulumi-choosable>
     <pulumi-choosable type="language" value="java"><code>App.java</code></pulumi-choosable>
     <pulumi-choosable type="language" value="yaml"><code>Pulumi.yaml</code></pulumi-choosable>
+    <pulumi-choosable type="language" value="hcl"><code>main.tf</code></pulumi-choosable>
 </pulumi-chooser>


### PR DESCRIPTION
The [stack references tutorial](https://www.pulumi.com/tutorials/building-with-pulumi/stack-references/) only showed the example in TypeScript and Python. This adds the same program in Go, C#, Java, YAML, and Pulumi HCL, so the tutorial covers every Pulumi language.

Notes:

- The HCL example uses the canonical `pulumi_stack_reference` resource form, and the setup step uses the `hcl` starter template added in https://github.com/pulumi/templates/pull/1141.
- The `langfile` shortcode gains an `hcl` entry (`main.tf`) so the "Add this code to the ... file" sentence renders the right filename. The chooser web component already supports the `hcl` key.
- The Java example uses `StackReference.output(String)`, which is the method on the current SDK ([StackReference.java](https://github.com/pulumi/pulumi-java/blob/main/sdk/java/pulumi/src/main/java/com/pulumi/resources/StackReference.java)); some older docs pages show a `getOutput` method that no longer exists.
- The explanation paragraph was previously duplicated verbatim per language; it is now a single language-neutral paragraph below the chooser.

Verification: the site builds cleanly with the pinned Hugo (0.157.0) and the rendered page contains both choosers with the full language set. The HCL example was run end-to-end against a local backend with two stacks; the consumer stack produced `shopUrl: "http://localhost:3002"` exactly as the tutorial shows. `pulumi new hcl -y` was verified to scaffold a project now that the template PR is merged.