### PR TITLE
Content-review health: fix the console probe, add a reverify signal

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -72,8 +72,8 @@ Read `.content-review-queue.json` from the repo root (written by
   invoke you in that case, but be defensive).
 - `traffic.available: false` is not your problem to fix: the dispatcher's
   degradation-health lane (`scripts/content-review/signal-health.py`) tracks
-  it — along with pulumi/pulumi-service (console-source) access and the
-  holiday feed — and alerts
+  it — along with pulumi/pulumi-service (console-source) access, the
+  holiday feed, and the nightly claims re-verify — and alerts
   #docs-ops after a week of continuous degradation.
 
 Process articles **sequentially**, one at a time, completing each article's

--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -72,7 +72,8 @@ Read `.content-review-queue.json` from the repo root (written by
   invoke you in that case, but be defensive).
 - `traffic.available: false` is not your problem to fix: the dispatcher's
   degradation-health lane (`scripts/content-review/signal-health.py`) tracks
-  it — along with pulumi/console access and the holiday feed — and alerts
+  it — along with pulumi/pulumi-service (console-source) access and the
+  holiday feed — and alerts
   #docs-ops after a week of continuous degradation.
 
 Process articles **sequentially**, one at a time, completing each article's

--- a/.claude/commands/review-existing-content/references/screenshot-verification.md
+++ b/.claude/commands/review-existing-content/references/screenshot-verification.md
@@ -54,15 +54,17 @@ docs-team"). Keep flagging it on every run until the reference is refreshed.
 
 Mirrors the fact-check Pass 1 lane (Pulumi-internal verification via `gh`).
 Use it to verify **UI strings the prose asserts** — button labels, menu
-names, setting names — against the Pulumi Cloud Console source.
+names, setting names — against the Pulumi Cloud Console source: the
+`cmd/console2` app in the private `pulumi/pulumi-service` repo.
 
-1. **Feasibility gate, once per run:** `gh repo view pulumi/console`
-   (the console repo may be private to the workflow token). If it fails,
+1. **Feasibility gate, once per run:** `gh repo view pulumi/pulumi-service`
+   (the repo is private, so the workflow token may lack access). If it fails,
    skip lane 2 for the whole run and mark prose UI claims `unverifiable —
    needs human check` instead. Never guess.
-2. When accessible, search for the literal UI string:
-   `gh search code --repo pulumi/console "<label>"` or
-   `gh api` on likely paths. A hit verifies the label; a confident miss
+2. When accessible, search for the literal UI string scoped to the console
+   app: `gh search code --repo pulumi/pulumi-service "<label> path:cmd/console2"`
+   or `gh api` on likely paths under `cmd/console2/src/`. A hit verifies the
+   label; a confident miss
    (searched variants, found the surrounding component with a different
    label) is evidence of staleness — quote what the source says instead.
 3. Source-verified corrections to **prose** (a renamed button, a moved menu
@@ -79,5 +81,5 @@ lane 2):
 - static/images/docs/stacks-list.png — stale: left nav lacks "Insights & Governance"
   (added 2025); reference: pulumi-cloud-console-current.png (captured 2026-05-29)
 - static/images/docs/arch-diagram.png — n/a, not Pulumi UI
-- prose L42 "click **New Project**" — verified (console: src/routes/projects/new.tsx)
+- prose L42 "click **New Project**" — verified (pulumi-service: cmd/console2/src/app/new/new.component.ts)
 ```

--- a/.github/workflows/claims-reverify.yml
+++ b/.github/workflows/claims-reverify.yml
@@ -17,6 +17,17 @@ name: "Scheduled jobs: Re-verify volatile claims"
 #   'N'   -> on, N entities/night
 # The sweep is a stateless day rotation over the volatile entity set, so all
 # of it is covered every ceil(N_entities/count) nights regardless of the knob.
+#
+# DEGRADATION HEALTH: this lane only Slacks when it finds STALE entities, so a
+# dead lane (claims index gone, API key missing, every check inconclusive)
+# would otherwise look identical to a healthy quiet one. The health steps at
+# the end feed a `reverify` signal — read from the report's meta block — into
+# the same signal-health state the review-existing-content dispatcher uses
+# (ledger bucket, health/ prefix), alerting #docs-ops after a week of
+# continuous degradation. The two workflows share that state object
+# read-modify-write; their schedules (7:00 vs ~14:00 UTC) don't overlap, and
+# each observes disjoint signals, so last-writer-wins is safe in practice —
+# an accepted, documented race, same as signal-health.py's own.
 
 on:
   schedule:
@@ -113,6 +124,9 @@ jobs:
           if [ -n "$BUCKET" ]; then
             echo "ledger_uri=s3://$BUCKET/ledger/" >> "$GITHUB_OUTPUT"
             echo "claims_uri=s3://$BUCKET/claims/" >> "$GITHUB_OUTPUT"
+            # Degradation-health state lives in the same bucket, own prefix
+            # (shared with review-existing-content.yml).
+            echo "health_uri=s3://$BUCKET/health/" >> "$GITHUB_OUTPUT"
           else
             echo "ledger bucket output unavailable; nothing to re-verify"
           fi
@@ -164,6 +178,48 @@ jobs:
             -H "Content-type: application/json; charset=utf-8" \
             --data "$(jq -n --arg ch "#docs-ops" --arg txt "$TEXT" \
               '{channel: $ch, text: $txt, unfurl_links: false}')"
+
+      # --- Degradation-health lane (see header comment). Mirrors the four
+      # fail-open steps in review-existing-content.yml, contributing only the
+      # `reverify` signal — the other signals' entries are left untouched by
+      # design (signal-health.py treats absent observations as no evidence).
+      # workflow_dispatch runs are log-only: state computed and printed, never
+      # persisted, Slack never posted.
+      - name: Fetch health state from S3
+        if: always() && steps.ledger-bucket.outputs.health_uri != ''
+        continue-on-error: true
+        run: |
+          aws s3 cp "${{ steps.ledger-bucket.outputs.health_uri }}state.json" .health-state.json --quiet \
+            || echo "no prior health state (first run or S3 unavailable)"
+      - name: Record degradation signals
+        if: always()
+        continue-on-error: true
+        run: |
+          python3 scripts/content-review/signal-health.py \
+            --state .health-state.json \
+            --reverify-report .claims-reverify-report.json \
+            --alert-out .health-alert.txt \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "--- health state ---"
+          cat .health-state.json
+      # Post before persisting: a job that dies between the two steps then
+      # re-alerts next run (a harmless duplicate) instead of never alerting.
+      - name: Post degradation alert to Slack
+        if: always() && github.event_name == 'schedule' && hashFiles('.health-alert.txt') != ''
+        continue-on-error: true
+        env:
+          SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
+        run: |
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \
+            -H "Content-type: application/json; charset=utf-8" \
+            --data "$(jq -n --arg ch "#docs-ops" --rawfile txt .health-alert.txt \
+              '{channel: $ch, text: $txt, unfurl_links: false}')"
+      - name: Persist health state to S3
+        if: always() && github.event_name == 'schedule' && steps.ledger-bucket.outputs.health_uri != ''
+        continue-on-error: true
+        run: |
+          aws s3 cp .health-state.json "${{ steps.ledger-bucket.outputs.health_uri }}state.json" --quiet
 
 env:
   ESC_ACTION_OIDC_AUTH: true

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -29,7 +29,7 @@ name: "Scheduled jobs: Review existing content (dispatcher)"
 #
 # DEGRADATION HEALTH (issue #20078 §3.4): three inputs degrade gracefully but
 # used to do so silently — the traffic snapshot (selection falls back to
-# tier-only), pulumi/console access (workers' screenshot lane 2 goes
+# tier-only), pulumi/pulumi-service access (workers' screenshot lane 2 goes
 # unverifiable), and the holiday feed (gate fails open). The health steps at
 # the end of the review job track each signal's state in the ledger bucket
 # under health/ and post a one-line-per-signal note to #docs-ops once a signal
@@ -142,21 +142,22 @@ jobs:
           # newest non-bot edit per page), so a shallow clone won't do.
           fetch-depth: 0
       # Lane-2 health probe: the per-article worker's screenshot lane 2
-      # verifies UI strings against the private pulumi/console repo using
+      # verifies UI strings against the Pulumi Cloud Console source — the
+      # cmd/console2 app in the private pulumi/pulumi-service repo — using
       # PULUMI_BOT_TOKEN from the SAME ESC environment this job holds — so
       # probing access here, once per run, is a deterministic proxy for whether
       # every worker dispatched today will silently degrade lane 2 to
       # "unverifiable". Keep the two token sources coupled or this probe lies.
       # Never fails; feeds the degradation-health steps at the end of the job.
-      - name: Probe pulumi/console access (lane-2 health)
+      - name: Probe pulumi/pulumi-service access (lane-2 health)
         id: console-probe
         env:
           GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
         run: |
-          if gh repo view pulumi/console --json name -q .name >/dev/null 2>&1; then
+          if gh repo view pulumi/pulumi-service --json name -q .name >/dev/null 2>&1; then
             echo "status=ok" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::pulumi/console not accessible to the bot token; screenshot lane 2 will be unverifiable"
+            echo "::warning::pulumi/pulumi-service not accessible to the bot token; screenshot lane 2 will be unverifiable"
             echo "status=degraded" >> "$GITHUB_OUTPUT"
           fi
       - name: Install Node
@@ -372,7 +373,7 @@ jobs:
       # dispatcher. signal-health.py is a pure function of (state file,
       # observations, today); these steps move the bytes: state is one JSON
       # object in the ledger bucket under health/, and after THRESHOLD_DAYS of
-      # continuous degradation of any input (traffic snapshot, pulumi/console
+      # continuous degradation of any input (traffic snapshot, pulumi/pulumi-service
       # access, holiday feed) a one-message alert posts to #docs-ops (the
       # check-links.yml posting pattern), re-alerting weekly, not daily.
       # workflow_dispatch runs are log-only: the state is computed and printed

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -34,6 +34,8 @@ name: "Scheduled jobs: Review existing content (dispatcher)"
 # the end of the review job track each signal's state in the ledger bucket
 # under health/ and post a one-line-per-signal note to #docs-ops once a signal
 # has been degraded for a week (see scripts/content-review/signal-health.py).
+# claims-reverify.yml contributes a fourth signal (`reverify`) to the same
+# state object; this workflow neither observes nor overwrites it.
 
 on:
   schedule:

--- a/scripts/content-review/reverify-claims.py
+++ b/scripts/content-review/reverify-claims.py
@@ -250,15 +250,21 @@ def run(args) -> int:
         "schema_version": SCHEMA_VERSION,
         "checked_at": today.isoformat(),
         "entities": [],
-        "meta": {"n_snapshots": 0, "n_entities": 0, "n_checked": 0,
+        "meta": {"n_snapshots": 0, "n_entities": 0, "n_due": 0, "n_checked": 0,
                  "n_stale": 0, "n_fresh": 0, "n_inconclusive": 0},
     }
     out_path = Path(args.out)
 
+    # The meta block doubles as the health observation consumed by
+    # signal-health.py's reverify signal: `skipped` distinguishes "couldn't
+    # run" (degraded) from the quiet-night n_due=0 (healthy), and an
+    # all-inconclusive n_checked is the broken-verifier tell. Keep those
+    # semantics intact when touching the early-exit paths below.
     snapshots = load_snapshots(Path(args.claims_dir))
     report["meta"]["n_snapshots"] = len(snapshots)
     if not snapshots:
         log("no claims snapshots; nothing to re-verify")
+        report["meta"]["skipped"] = "no_snapshots"
         return finish(report, out_path)
 
     ledger = load_ledger(Path(args.ledger_dir))
@@ -267,6 +273,7 @@ def run(args) -> int:
 
     unmarked = sorted(k for k, v in entities.items() if not already_marked(k, v, ledger))
     keys = tonight_chunk(unmarked, args.count, today)
+    report["meta"]["n_due"] = len(keys)
     if not keys:
         log("no volatile entities due tonight")
         return finish(report, out_path)
@@ -274,6 +281,7 @@ def run(args) -> int:
     api_key = os.environ.get("ANTHROPIC_API_KEY", "")
     if not api_key and not args.dry_run:
         warn("ANTHROPIC_API_KEY not set; re-verification skipped")
+        report["meta"]["skipped"] = "no_api_key"
         return finish(report, out_path)
 
     vc = _load_verify_claims()
@@ -399,6 +407,34 @@ def self_test() -> int:
           not already_marked("numerical/team-plan-price",
                              ents["numerical/team-plan-price"], ledger))
 
+    # Health-observation meta: the early-exit paths must say why they stopped
+    # (signal-health.py's reverify signal reads these fields).
+    import tempfile
+
+    def run_report(d: Path, extra_env_unset: list[str]) -> dict:
+        saved = {k: os.environ.pop(k) for k in extra_env_unset if k in os.environ}
+        try:
+            argv = ["--claims-dir", str(d / "claims"), "--ledger-dir", str(d / "ledger"),
+                    "--out", str(d / "report.json"), "--today", "2026-07-06"]
+            args = build_parser().parse_args(argv)
+            run(args)
+            return json.loads((d / "report.json").read_text())
+        finally:
+            os.environ.update(saved)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp)
+        (d / "claims").mkdir()
+        (d / "ledger").mkdir()
+        rep = run_report(d, [])
+        check("empty claims dir -> skipped=no_snapshots",
+              rep["meta"]["skipped"] == "no_snapshots" and rep["meta"]["n_due"] == 0)
+
+        (d / "claims" / "docs-a.json").write_text(json.dumps(snap("a", "2026-07-01", ver)))
+        rep = run_report(d, ["ANTHROPIC_API_KEY"])
+        check("due entities without API key -> skipped=no_api_key",
+              rep["meta"]["skipped"] == "no_api_key" and rep["meta"]["n_due"] == 1)
+
     if failures:
         print(f"\n{len(failures)} failure(s)", file=sys.stderr)
         return 1
@@ -406,7 +442,7 @@ def self_test() -> int:
     return 0
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     p.add_argument("--claims-dir", default=".claims-cache",
                    help="local sync of the claims/ prefix")
@@ -421,7 +457,11 @@ def main() -> int:
     p.add_argument("--dry-run", action="store_true",
                    help="no API calls, no uploads; placeholder verdicts (testing)")
     p.add_argument("--self-test", action="store_true", help="run built-in smoke checks")
-    args = p.parse_args()
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
 
     if args.self_test:
         return self_test()

--- a/scripts/content-review/signal-health.py
+++ b/scripts/content-review/signal-health.py
@@ -8,8 +8,9 @@ gracefully — and, before this script, silently:
   traffic         a missing docs-traffic snapshot flattens article selection to
                   tier-only scoring, quietly erasing intra-tier prioritization
   console-access  the per-article worker's screenshot lane 2 verifies UI strings
-                  against the private pulumi/console repo; without token access
-                  every UI claim silently becomes "unverifiable"
+                  against the console source (cmd/console2) in the private
+                  pulumi/pulumi-service repo; without token access every UI
+                  claim silently becomes "unverifiable"
   holiday-feed    the BambooHR ICS holiday gate fails open by design, so a feed
                   that has been 404ing (or serving garbage) for weeks is invisible
 
@@ -87,9 +88,10 @@ CONSEQUENCES = {
         "it points at."
     ),
     "console-access": (
-        "pulumi/console access: pulumi-bot has had no access for {days} day(s) — "
-        "screenshot lane 2 is marking every UI-string check \"unverifiable\". "
-        "Check the bot token's access to the pulumi/console repo."
+        "pulumi/pulumi-service access: pulumi-bot has had no access for {days} "
+        "day(s) — screenshot lane 2 is marking every UI-string check "
+        "\"unverifiable\". Check the bot token's access to the "
+        "pulumi/pulumi-service repo (console source: cmd/console2)."
     ),
     "holiday-feed": (
         "holiday feed: degraded for {days} day(s) ({detail}) — the holiday gate "
@@ -282,7 +284,8 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     p.add_argument("--state", help="health state JSON (read+written in place)")
     p.add_argument("--queue", help="selection queue JSON (source of the traffic signal)")
-    p.add_argument("--console-status", help="pulumi/console probe result: ok|degraded")
+    p.add_argument("--console-status",
+                   help="pulumi/pulumi-service probe result: ok|degraded")
     p.add_argument("--holiday-status",
                    help="holiday feed status: ok|empty|fetch_failed|unconfigured")
     p.add_argument("--alert-out", default=".health-alert.txt",

--- a/scripts/content-review/signal-health.py
+++ b/scripts/content-review/signal-health.py
@@ -2,8 +2,10 @@
 """Track and alert on silent degradation of the content-review pipeline's inputs.
 
 Observability for §3.4 of the docs-review automation evaluation (pulumi/docs
-issue #20078): three inputs to the review-existing-content dispatcher degrade
-gracefully — and, before this script, silently:
+issue #20078): inputs to the content-review automation degrade gracefully —
+and, before this script, silently. Three signals are observed by the
+review-existing-content dispatcher, a fourth by the nightly claims-reverify
+workflow; all share one state object:
 
   traffic         a missing docs-traffic snapshot flattens article selection to
                   tier-only scoring, quietly erasing intra-tier prioritization
@@ -13,6 +15,11 @@ gracefully — and, before this script, silently:
                   claim silently becomes "unverifiable"
   holiday-feed    the BambooHR ICS holiday gate fails open by design, so a feed
                   that has been 404ing (or serving garbage) for weeks is invisible
+  reverify        the nightly volatile-claims re-verification only Slacks when
+                  it finds STALE entities, so a dead lane (claims index gone,
+                  API key missing, every check inconclusive because the
+                  verifier's gh/API plumbing broke) looks identical to a
+                  healthy quiet one
 
 Graceful degradation is the right behavior; this script adds the missing
 observability. The dispatcher runs it once per scheduled run with that run's
@@ -55,6 +62,7 @@ Usage:
         [--queue .content-review-queue.json] \
         [--console-status ok|degraded] \
         [--holiday-status ok|empty|fetch_failed|unconfigured] \
+        [--reverify-report .claims-reverify-report.json] \
         --alert-out .health-alert.txt \
         [--today YYYY-MM-DD] [--threshold-days N] [--realert-days N] \
         [--run-url URL]
@@ -97,6 +105,12 @@ CONSEQUENCES = {
         "holiday feed: degraded for {days} day(s) ({detail}) — the holiday gate "
         "is running blind (fails open: reviews will run on company holidays). "
         "Regenerate the BAMBOOHR_HOLIDAY_ICS_URL feed."
+    ),
+    "reverify": (
+        "nightly claims re-verify: no conclusive results for {days} day(s) "
+        "({detail}) — volatile-claim drift (version pins, prices, limits) is "
+        "going undetected. Check the claims-index S3 sync, ANTHROPIC_API_KEY, "
+        "and the verifier's gh lane on claims-reverify.yml."
     ),
 }
 
@@ -169,6 +183,36 @@ def observe_traffic(queue_path: Path | None) -> tuple[str, str] | None:
         detail = f"period={traffic.get('period')} pages_matched={traffic.get('pages_matched')}"
         return "ok", detail
     return "degraded", "snapshot missing, empty, or matched zero pages"
+
+
+def observe_reverify(report_path: Path | None) -> tuple[str, str] | None:
+    """(status, detail) from the nightly re-verify report's meta block, or None.
+
+    reverify-claims.py stamps `meta.skipped` on its couldn't-run exits and
+    `meta.n_due` on every run, so a quiet night (nothing due) is distinguishable
+    from a dead lane. A missing/unreadable report is NOT evidence of
+    degradation (the job may not have run at all) — return None.
+    """
+    if report_path is None or not report_path.is_file():
+        return None
+    try:
+        meta = json.loads(report_path.read_text()).get("meta") or {}
+    except (OSError, json.JSONDecodeError) as e:
+        log(f"reverify report unreadable ({e}); no reverify observation")
+        return None
+    skipped = meta.get("skipped")
+    n_due = int(meta.get("n_due") or 0)
+    n_checked = int(meta.get("n_checked") or 0)
+    n_inconclusive = int(meta.get("n_inconclusive") or 0)
+    if skipped == "no_snapshots":
+        return "degraded", "claims index empty or unfetchable"
+    if skipped:
+        return "degraded", f"{n_due} entities due but run skipped ({skipped})"
+    if n_checked and n_inconclusive == n_checked:
+        return "degraded", f"all {n_checked} checks inconclusive"
+    if n_checked:
+        return "ok", f"checked={n_checked} inconclusive={n_inconclusive}"
+    return "ok", "nothing due tonight"
 
 
 def observe_flag(value: str | None, mapping: dict[str, str]) -> tuple[str, str] | None:
@@ -266,6 +310,9 @@ def run(args) -> int:
     })
     if obs:
         observations["holiday-feed"] = obs
+    obs = observe_reverify(Path(args.reverify_report) if args.reverify_report else None)
+    if obs:
+        observations["reverify"] = obs
 
     state, alert = apply(state, observations, today,
                          args.threshold_days, args.realert_days, args.run_url)
@@ -288,6 +335,8 @@ def build_parser() -> argparse.ArgumentParser:
                    help="pulumi/pulumi-service probe result: ok|degraded")
     p.add_argument("--holiday-status",
                    help="holiday feed status: ok|empty|fetch_failed|unconfigured")
+    p.add_argument("--reverify-report",
+                   help="nightly re-verify report JSON (source of the reverify signal)")
     p.add_argument("--alert-out", default=".health-alert.txt",
                    help="alert message path; only written when an alert is due")
     p.add_argument("--today", help="override today's date YYYY-MM-DD (testing)")
@@ -329,7 +378,8 @@ def self_test() -> int:
             print(f"ok: {name}")
 
     def run_once(d: Path, day: str, queue: dict | None = None, console: str | None = None,
-                 holiday: str | None = None) -> tuple[dict, str | None]:
+                 holiday: str | None = None, reverify: dict | None = None,
+                 ) -> tuple[dict, str | None]:
         """Drive run() through argparse the way the workflow would."""
         state = d / "state.json"
         alert = d / "alert.txt"
@@ -344,6 +394,10 @@ def self_test() -> int:
             argv += ["--console-status", console]
         if holiday:
             argv += ["--holiday-status", holiday]
+        if reverify is not None:
+            rp = d / "reverify-report.json"
+            rp.write_text(json.dumps(reverify))
+            argv += ["--reverify-report", str(rp)]
         args = build_parser().parse_args(argv)
         run(args)
         text = alert.read_text() if alert.exists() else None
@@ -446,6 +500,57 @@ def self_test() -> int:
         st, alert = run_once(d, "2026-08-11", queue=q_halted, console="ok", holiday="ok")
         check("halted queue still observes traffic",
               st["signals"]["traffic"]["status"] == "degraded")
+
+    rv_ok = {"meta": {"n_snapshots": 40, "n_entities": 90, "n_due": 25,
+                      "n_checked": 25, "n_stale": 1, "n_fresh": 22, "n_inconclusive": 2}}
+    rv_quiet = {"meta": {"n_snapshots": 40, "n_entities": 90, "n_due": 0,
+                         "n_checked": 0, "n_stale": 0, "n_fresh": 0, "n_inconclusive": 0}}
+    rv_dead = {"meta": {"n_snapshots": 40, "n_entities": 90, "n_due": 25,
+                        "n_checked": 25, "n_stale": 0, "n_fresh": 0, "n_inconclusive": 25}}
+    rv_nokey = {"meta": {"n_snapshots": 40, "n_entities": 90, "n_due": 25,
+                         "n_checked": 0, "n_stale": 0, "n_fresh": 0, "n_inconclusive": 0,
+                         "skipped": "no_api_key"}}
+    rv_nosnaps = {"meta": {"n_snapshots": 0, "n_entities": 0, "n_due": 0,
+                           "n_checked": 0, "n_stale": 0, "n_fresh": 0, "n_inconclusive": 0,
+                           "skipped": "no_snapshots"}}
+
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp)
+
+        # 12. Reverify observations: conclusive results and quiet nights are ok.
+        st, alert = run_once(d, "2026-09-01", reverify=rv_ok)
+        check("reverify with conclusive results is ok",
+              st["signals"]["reverify"]["status"] == "ok")
+        st, alert = run_once(d, "2026-09-02", reverify=rv_quiet)
+        check("reverify quiet night (nothing due) is ok",
+              st["signals"]["reverify"]["status"] == "ok")
+
+        # 13. All-inconclusive and couldn't-run reports degrade; alert names
+        # the consequence once due.
+        st, alert = run_once(d, "2026-09-03", reverify=rv_dead)
+        check("all-inconclusive reverify degrades",
+              st["signals"]["reverify"]["status"] == "degraded"
+              and st["signals"]["reverify"]["degraded_since"] == "2026-09-03")
+        st, alert = run_once(d, "2026-09-06", reverify=rv_nokey)
+        check("skipped run stays degraded with skip detail",
+              st["signals"]["reverify"]["status"] == "degraded"
+              and "no_api_key" in st["signals"]["reverify"]["detail"])
+        st, alert = run_once(d, "2026-09-10", reverify=rv_dead)
+        check("reverify alert fires at threshold and names the consequence",
+              alert is not None and "volatile-claim drift" in alert)
+
+        # 14. Missing report leaves prior state untouched; empty claims index
+        # counts as degraded (mirrors the traffic snapshot semantics).
+        st, alert = run_once(d, "2026-09-11")
+        check("missing reverify report leaves prior state untouched",
+              st["signals"]["reverify"]["status"] == "degraded")
+        st, alert = run_once(d, "2026-09-12", reverify=rv_nosnaps)
+        check("empty claims index degrades with its own detail",
+              "claims index" in st["signals"]["reverify"]["detail"])
+        st, alert = run_once(d, "2026-09-13", reverify=rv_ok)
+        check("reverify recovery clears the clocks",
+              st["signals"]["reverify"]["status"] == "ok"
+              and st["signals"]["reverify"]["degraded_since"] is None)
 
     if failures:
         print(f"\n{len(failures)} failure(s)", file=sys.stderr)


### PR DESCRIPTION
### Proposed changes

Two fixes to the content-review degradation-health lane, prompted by the 2026-07-17 #docs-ops alert.

**1. Fix lane-2 console probe: `pulumi/console` does not exist** (commit 1)

The `review-existing-content` screenshot lane 2 (UI-string verification) and its health probe targeted a repo named `pulumi/console`, which does not exist — the Pulumi Cloud Console source is the `cmd/console2` app inside the private `pulumi/pulumi-service` monorepo. The probe could never succeed for any token (health state confirms `last_ok: null`), lane 2 has been silently "unverifiable" since it shipped, and the alert's remediation text pointed at a permission grant that cannot fix it.

- **`.github/workflows/review-existing-content.yml`** — probe `gh repo view pulumi/pulumi-service`; warning text and comments updated.
- **`scripts/content-review/signal-health.py`** — `console-access` consequence message names the real repo and console source path. Signal key unchanged, so existing S3 health state carries over and self-clears once the probe passes.
- **`review-existing-content` skill** — lane-2 gate and code search target `pulumi/pulumi-service` scoped with `path:cmd/console2`; example cites a verified console2 source path.

**2. Add a `reverify` signal for the nightly claims re-verification** (commit 2)

The nightly `claims-reverify` lane only posts to Slack when it finds *stale* entities, so a dead lane — claims index gone from S3, missing `ANTHROPIC_API_KEY`, or every check inconclusive because the verifier's `gh`/API plumbing broke — looked identical to a healthy quiet one: the same silent-degradation pattern `signal-health` was built for, one workflow over.

- **`scripts/content-review/reverify-claims.py`** — report meta now records `n_due` and a `skipped` reason on couldn't-run exits (`no_snapshots`, `no_api_key`), so a quiet night is distinguishable from a dead lane. Parser extracted to `build_parser()`; new self-tests cover both exit paths.
- **`scripts/content-review/signal-health.py`** — new `reverify` signal read from the report's meta block (`--reverify-report`). Degraded on skipped runs, an empty claims index, or an all-inconclusive sweep; ok on conclusive results or a nothing-due night; missing report = no observation. Self-tests cover ok/quiet/dead/skipped/missing/recovery.
- **`.github/workflows/claims-reverify.yml`** — the four fail-open health steps from the dispatcher (fetch state, record, post due alert, persist), contributing only the `reverify` signal to the shared `health/state.json`. Cross-workflow read-modify-write is an accepted, documented race: schedules don't overlap (7:00 vs ~14:00 UTC) and each workflow observes disjoint signals.

**Verification:** both scripts' `--self-test` suites pass; both workflow files parse; an end-to-end smoke (real `reverify-claims.py` report piped into `signal-health.py`) produces the expected degraded observation with the day clock started.

Also audited every other repo referenced by skills, workflows, and scripts (29 GitHub Actions, tool-download repos, `gh` data sources, the private `pulumi/social` pip dependency — bot access proven by green `schedule-social` runs). All exist and are reachable; `pulumi/console` was the only bad reference.

One follow-up outside this repo's control: pulumi-bot needs read access to `pulumi/pulumi-service` for lane 2 to go green. The renamed probe tests exactly that on the next scheduled run.

### Unreleased product version (optional)

N/A — automation/meta files only.

### Related issues (optional)

Related: #20078 (§3.4), #20150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GG7qUmwm9SdQp1Cdm7rH2d