### PR TITLE
Noindex April Fools blog posts (Interstellar, Vibe Clouding)

### DIFF
--- a/content/blog/pulumi-interstellar/index.md
+++ b/content/blog/pulumi-interstellar/index.md
@@ -7,7 +7,9 @@ authors:
     - sophia-parafina
 tags:
     - announcements
+    - april-fools
 category: product
+block_external_search_index: true
 ---
 
 Earth is just the beginning. We are putting down the foundations of space so our children can build their future.  At Pulumi, we are committed to making life multi-planetary. We are excited to announce Pulumi Interstellar, a collection of resource providers that will help us reach the future of a space-faring and multi-planet species.

--- a/content/blog/vibe-clouding/index.md
+++ b/content/blog/vibe-clouding/index.md
@@ -10,6 +10,7 @@ tags:
     - announcements
     - april-fools
 category: product
+block_external_search_index: true
 ---
 
 {{< notes type="info" >}}

--- a/data/blog_tags.yaml
+++ b/data/blog_tags.yaml
@@ -152,6 +152,7 @@ community:
   - pulumi-interns
   - pulumi-culture
   - kubecon
+  - april-fools          # satirical April Fools' Day posts; noindexed
 
 ecosystem:
   # Non-Pulumi tools and platforms we compare to or integrate with.


### PR DESCRIPTION
Sets both of Pulumi's April Fools joke posts to noindex so they no longer rank in external search engines or surface in AI answer engines, where a reader could mistake them for real product news. They remain visible in the on-site /blog/ listing.

## Changes
- Add `block_external_search_index: true` to Pulumi Interstellar (2021) and Vibe Clouding (2025)
- Tag Interstellar with `april-fools` (Vibe Clouding already had it)
- Register the `april-fools` tag in `data/blog_tags.yaml`

A full-repo sweep confirmed these are the only two April Fools posts across 800 blog posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)