### PR TITLE
Make violet code chrome a site-wide default so every chooser gets it

### DIFF
--- a/theme/src/scss/components/_chooser.scss
+++ b/theme/src/scss/components/_chooser.scss
@@ -1,3 +1,20 @@
+// Code chrome — the flat violet tint on code-adjacent "chrome" (chooser toolbars,
+// tab strips, card borders, terminal dots), mirroring marketing-web (apps/www).
+// These are the site-wide LIGHT defaults so every chooser reads violet regardless
+// of section (docs, templates, product, blog, homepage, …); the fallbacks baked
+// into the rules below are now only a belt-and-suspenders for the theoretical case
+// of a chooser rendered before this declaration applies. Docs re-points these to
+// the brand dark inversion under html[data-theme="dark"] (see _docs-theme.scss);
+// docs is the only section with a dark-mode toggle. Values trace to
+// @pulumi/design-tokens. (--chrome-dots is defined for parity with www; nothing in
+// light mode consumes it yet.)
+body {
+    --chrome-bg: var(--color-violet-100);
+    --chrome-border: var(--color-violet-200);
+    --chrome-border-hover: var(--color-violet-300);
+    --chrome-dots: var(--color-violet-400);
+}
+
 pulumi-chooser {
     // Standard (non-language) chooser: a flat violet chrome strip of small tabs
     // matching the language chooser's toolbar — chrome background, rounded top,

--- a/theme/src/scss/docs/_docs-theme.scss
+++ b/theme/src/scss/docs/_docs-theme.scss
@@ -27,16 +27,11 @@ body.section-docs {
     --docs-card-border: var(--color-gray-200);
     --docs-ring: var(--color-violet-700);
 
-    // Code chrome — the flat violet tint on code-adjacent "chrome" (chooser
-    // toolbars, tab strips, card borders, terminal dots), mirroring marketing-web
-    // (apps/www). Centralized in four tunable props so the tint lives in one place;
-    // the dark block below re-points them to the standard brand inversion. All
-    // values trace to @pulumi/design-tokens. (--chrome-dots is defined for parity
-    // with www; docs has no light-chrome terminal title bar consuming it yet.)
-    --chrome-bg: var(--color-violet-100);
-    --chrome-border: var(--color-violet-200);
-    --chrome-border-hover: var(--color-violet-300);
-    --chrome-dots: var(--color-violet-400);
+    // Code chrome (--chrome-bg/-border/-border-hover/-dots) — the light-mode violet
+    // tint now lives as a SITE-WIDE default on `body` in components/_chooser.scss, so
+    // every chooser reads violet regardless of section, not just docs. The dark block
+    // below re-points those props to the standard brand inversion; docs is the only
+    // section with a dark-mode toggle, so this file still owns the dark half.
 
     // Re-expose the semantic tokens under Tailwind's --color-* namespace so the
     // generated utilities (bg-docs-bg, text-docs-fg, border-docs-border, …) resolve


### PR DESCRIPTION
### Proposed changes

The recent violet code-chrome tint (chooser toolbars, tab strips, card borders) was scoped to `body.section-docs`, so choosers rendered outside `/docs` — template catalog pages like `/templates/container-service/azure/`, the Terraform-converter blog post, product pages — fell back to gray. This promotes the light-mode `--chrome-*` tokens to a site-wide default on `body` in `components/_chooser.scss` so every chooser reads violet regardless of section, and leaves the dark-mode inversion in `_docs-theme.scss` (docs is the only section with a dark toggle). The tint now has a single light source and a single dark source, with no duplicated declarations to drift.

### Related issues (optional)

N/A