### PR TITLE
Change CTAs to Get started / Download

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -210,11 +210,10 @@ params:
     cta:
         primary:
             label: "Get started"
-            label_short: "Sign up"
-            href: "https://app.pulumi.com/signup"
+            href: "/docs/iac/get-started"
         secondary:
-            label: "Contact us"
-            href: "/contact/?form=sales"
+            label: "Sign up"
+            href: "https://app.pulumi.com/signup"
 
     canonicalURL: https://www.pulumi.com
     contentRepositoryURL: https://github.com/pulumi/docs

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -212,8 +212,8 @@ params:
             label: "Get started"
             href: "/docs/iac/get-started"
         secondary:
-            label: "Sign up"
-            href: "https://app.pulumi.com/signup"
+            label: "Contact us"
+            href: "/contact/?form=sales"
 
     canonicalURL: https://www.pulumi.com
     contentRepositoryURL: https://github.com/pulumi/docs

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,6 +8,10 @@ include_organization_schema: true
 sections:
   - type: hero
     layout: split
+    cta_primary_text: Get started
+    cta_primary_link: https://app.pulumi.com/signup
+    cta_secondary_text: Download open source
+    cta_secondary_link: /docs/install/
     badge_highlight_text: "New Release:"
     badge_text: "Building for the Agentic Era"
     badge_link: /releases/agentic-infrastructure-era/


### PR DESCRIPTION
Updates our CTA buttons on the home page and in the nav:

* Secondary button on the home page changes to "Download open source" and points to https://www.pulumi.com/docs/install (as it did when this button was last labeled this way)
* Primary "Get started" CTA in the site-wide nav changes to point to https://pulumi.com/docs/iac/get-started
* Primary button on the home page remains unchanged, continues to point to https://app.pulumi.com/signup