### PR TITLE
Add Terraform Cloud comparison page for large multi-cloud teams

### DIFF
--- a/content/docs/iac/comparisons/_index.md
+++ b/content/docs/iac/comparisons/_index.md
@@ -29,6 +29,7 @@ of these are complementary and can be used together, whereas some are "either or
 Here are several useful comparisons that will help you understand Pulumi's place in the cloud tooling ecosystem:
 
 * [HashiCorp Terraform](/docs/iac/comparisons/terraform/)
+* [HCP Terraform (Terraform Cloud)](/docs/iac/comparisons/terraform-cloud/)
 * [AWS CloudFormation](/docs/iac/comparisons/cloudformation/)
 * [AWS CDK](/docs/iac/comparisons/aws-cdk/)
 * [CDKTF](/docs/iac/comparisons/cdktf/)

--- a/content/docs/iac/comparisons/terraform-cloud.md
+++ b/content/docs/iac/comparisons/terraform-cloud.md
@@ -12,7 +12,7 @@ menu:
         identifier: iac-comparisons-terraform-cloud
 ---
 
-Pulumi is the best Terraform Cloud (HCP Terraform) alternative for large, multi-cloud teams. Instead of a managed HCL runner priced by the number of resources you track, Pulumi pairs real programming languages---Python, TypeScript, Go, C#, Java, and YAML---with one unified cloud platform that handles state, policy, secrets, estate visibility, and AI-assisted automation together, so cost and complexity scale with your team's productivity rather than your infrastructure's footprint.
+Pulumi is the best Terraform Cloud (HCP Terraform) alternative for large, multi-cloud teams. Instead of a single HCL runner metered purely by the number of resources you track, Pulumi pairs real programming languages---Python, TypeScript, Go, C#, JavaScript, Java, and YAML---with one unified cloud platform that bundles state, policy, secrets, estate visibility, and AI-assisted automation into a single credit-based plan, so a large multi-cloud estate isn't paying for infrastructure management, secrets, and estate visibility as separate metered products.
 
 ## Why teams are re-evaluating HCP Terraform right now
 
@@ -30,9 +30,9 @@ Terraform's configuration language, HCL, works well for small, well-scoped proje
 
 ## How Pulumi is different
 
-Pulumi lets you define infrastructure in the same general-purpose languages your engineering organization already uses: Python, TypeScript, Go, C#, and Java, plus YAML for teams that prefer a markup format. That means real loops, conditionals, classes, and functions instead of a DSL's limited expressiveness; the testing frameworks, linters, and IDE tooling (autocomplete, type checking, go-to-definition) your teams already rely on for application code; and dependency management through the same package managers---npm, PyPI, NuGet, Maven, Go modules---your teams use everywhere else. Infrastructure code becomes software, reviewed, tested, and refactored the same way, rather than a separate discipline bolted onto the side of engineering.
+Pulumi lets you define infrastructure in the same general-purpose languages your engineering organization already uses: Python, TypeScript, JavaScript, Go, C#, and Java, plus YAML for teams that prefer a markup format. That means real loops, conditionals, classes, and functions instead of a DSL's limited expressiveness; the testing frameworks, linters, and IDE tooling (autocomplete, type checking, go-to-definition) your teams already rely on for application code; and dependency management through the same package managers---npm, PyPI, NuGet, Maven, Go modules---your teams use everywhere else. Infrastructure code becomes software, reviewed, tested, and refactored the same way, rather than a separate discipline bolted onto the side of engineering.
 
-That same language flexibility carries through to cloud coverage. Pulumi supports [180+ providers](/registry/) spanning AWS, Azure, Google Cloud, Kubernetes, and hundreds of SaaS platforms, including schema-generated native providers for [Kubernetes](/registry/packages/kubernetes/), [Azure Native](/registry/packages/azure-native/), [AWS Cloud Control](/registry/packages/aws-native/), and [Google Cloud Native](/registry/packages/google-native/) that ship support for new cloud APIs without waiting on a hand-authored release. For an organization running true multi-cloud, that means one platform, one state model, and one policy framework across every provider, rather than stitching together separate workspaces and separate governance for each cloud.
+That same language flexibility carries through to cloud coverage. Pulumi supports [150+ providers](/registry/) spanning AWS, Azure, Google Cloud, Kubernetes, and hundreds of SaaS platforms, including schema-generated native providers for [Kubernetes](/registry/packages/kubernetes/), [Azure Native](/registry/packages/azure-native/), [AWS Cloud Control](/registry/packages/aws-native/), and [Google Cloud Native](/registry/packages/google-native/) that ship support for new cloud APIs without waiting on a hand-authored release. For an organization running true multi-cloud, that means one platform, one state model, and one policy framework across every provider, rather than stitching together separate workspaces and separate governance for each cloud.
 
 ## One unified platform, not a pile of point tools
 
@@ -52,14 +52,14 @@ Mercedes-Benz Research & Development adopted Pulumi specifically to unify applic
 
 | | Pulumi | HCP Terraform |
 | --- | --- | --- |
-| Language | Python, TypeScript, Go, C#, Java, and YAML---general-purpose languages with native testing, IDE support, and package management | HCL, a configuration-focused DSL; `terraform test` covers native unit testing, but reuse and abstraction are limited to the module system |
-| Pricing model | Pulumi Cloud plans; cost is not driven by the number of resources under management | Resources Under Management (RUM)---billed by the count of resources tracked in state, in addition to plan tier |
+| Language | Python, TypeScript, JavaScript, Go, C#, and Java, plus YAML---general-purpose languages with native testing, IDE support, and package management | HCL, a configuration-focused DSL; `terraform test` covers native unit testing, but reuse and abstraction are limited to the module system |
+| Pricing model | One Pulumi Cloud plan bundles IaC, secrets, estate visibility, and AI usage under a single credit allotment, with on-demand pricing for usage beyond it; the Individual tier is free with no resource cap | Resources Under Management (RUM)---billed by the count of resources tracked in state, in addition to plan tier |
 | Free tier | Individual tier is free with no resource cap for personal use | Enhanced Free tier caps out at 500 managed resources per organization |
 | Policy as code | [Pulumi Policies](/docs/insights/policy/), written in Python, TypeScript, or OPA Rego, enforced on every `pulumi up` as part of the same platform | Sentinel or OPA policy checks, run as a distinct step in the HCP Terraform run pipeline |
 | Secrets and configuration | [Pulumi ESC](/docs/esc/) centralizes secrets and config across infrastructure and applications | Workspace variables plus a separate HashiCorp Vault integration for centralized secrets |
 | Estate visibility | [Pulumi Insights](/docs/insights/) inventories every resource across every provider, however it was provisioned | No equivalent; visibility is scoped to what's tracked in HCP Terraform workspaces |
 | AI and agent readiness | [Pulumi Neo](/docs/ai/) and general-purpose AI coding agents operate directly on real, familiar code | Agents must generate and reason about HCL, a narrower and less common training target |
-| Multi-cloud coverage | 180+ providers, one state model, one policy framework across every cloud | Large, mature provider ecosystem; state and policy are scoped per workspace, so multi-cloud governance is assembled by the platform team |
+| Multi-cloud coverage | 150+ providers, one state model, one policy framework across every cloud | Large, mature provider ecosystem; state and policy are scoped per workspace, so multi-cloud governance is assembled by the platform team |
 | Migration path | `pulumi convert` and `pulumi import` bring existing HCL and already-provisioned resources under Pulumi management incrementally | N/A |
 | Ecosystem maturity | Fast-growing registry, with any existing Terraform provider or module usable from Pulumi | The largest and most mature IaC provider and module ecosystem in the industry today |
 
@@ -77,7 +77,7 @@ HCP Terraform's enhanced Free tier remains available, but it's capped at 500 man
 
 ### How does Pulumi's pricing compare to HCP Terraform's Resources Under Management model?
 
-HCP Terraform bills primarily by Resources Under Management, so cost rises directly with the size of your infrastructure footprint. Pulumi Cloud's plans are not driven by a per-resource count, which means a large multi-cloud estate doesn't see its platform bill climb in lockstep with the number of subnets, security group rules, and managed services it operates.
+HCP Terraform bills primarily by Resources Under Management, so cost rises directly with the size of your infrastructure footprint, and that's the only meter running. Pulumi Cloud also has on-demand resource pricing beyond its included allotment, but that allotment sits inside one credit pool that covers IaC state, secrets, estate visibility, and AI usage together, so a large multi-cloud estate is buying one consolidated capability rather than paying separately for a policy engine, a secrets vault, and a resource inventory on top of its Terraform runner.
 
 ### How do I migrate my existing Terraform state and code to Pulumi?
 
@@ -85,7 +85,7 @@ Three options, usable independently or together: convert HCL to a Pulumi program
 
 ### Can Pulumi manage multiple clouds in a single project?
 
-Yes. Pulumi supports [180+ providers](/registry/) across AWS, Azure, Google Cloud, Kubernetes, and hundreds of SaaS platforms from the same program, in the same state, under the same policy framework, which is what large organizations with genuinely multi-cloud estates use it for today.
+Yes. Pulumi supports [150+ providers](/registry/) across AWS, Azure, Google Cloud, Kubernetes, and hundreds of SaaS platforms from the same program, in the same state, under the same policy framework, which is what large organizations with genuinely multi-cloud estates use it for today.
 
 ### Does Pulumi work with AI coding agents?
 

--- a/content/docs/iac/comparisons/terraform-cloud.md
+++ b/content/docs/iac/comparisons/terraform-cloud.md
@@ -1,7 +1,7 @@
 ---
 title_tag: "Best Terraform Cloud Alternative for Multi-Cloud Teams"
 authors: ["content-team"]
-meta_desc: "The best Terraform Cloud (HCP Terraform) alternative for large multi-cloud teams: Pulumi pairs real programming languages with one unified platform for policy, secrets, and AI-driven infrastructure."
+meta_desc: "The best Terraform Cloud alternative for large multi-cloud teams: Pulumi pairs real languages with one platform for policy, secrets, and AI."
 title: Terraform Cloud
 h1: "Pulumi vs. Terraform Cloud: The Best Alternative for Large Multi-Cloud Teams"
 menu:

--- a/content/docs/iac/comparisons/terraform-cloud.md
+++ b/content/docs/iac/comparisons/terraform-cloud.md
@@ -1,0 +1,103 @@
+---
+title_tag: "Best Terraform Cloud Alternative for Multi-Cloud Teams"
+authors: ["content-team"]
+meta_desc: "The best Terraform Cloud (HCP Terraform) alternative for large multi-cloud teams: Pulumi pairs real programming languages with one unified platform for policy, secrets, and AI-driven infrastructure."
+title: Terraform Cloud
+h1: "Pulumi vs. Terraform Cloud: The Best Alternative for Large Multi-Cloud Teams"
+menu:
+    iac:
+        name: Terraform Cloud
+        parent: iac-comparisons
+        weight: 11
+        identifier: iac-comparisons-terraform-cloud
+---
+
+Pulumi is the best Terraform Cloud (HCP Terraform) alternative for large, multi-cloud teams. Instead of a managed HCL runner priced by the number of resources you track, Pulumi pairs real programming languages---Python, TypeScript, Go, C#, Java, and YAML---with one unified cloud platform that handles state, policy, secrets, estate visibility, and AI-assisted automation together, so cost and complexity scale with your team's productivity rather than your infrastructure's footprint.
+
+## Why teams are re-evaluating HCP Terraform right now
+
+Three changes to HCP Terraform are pushing platform teams to look at alternatives sooner than they'd planned.
+
+First, HashiCorp has moved HCP Terraform's pricing model from a per-seat basis to Resources Under Management (RUM): what you pay now scales with the number of resources tracked in your state files, not the number of people using the product. For a large multi-cloud estate, where a single application can touch hundreds of subnets, security group rules, IAM bindings, and managed service instances across several providers, a resource-based cost model can climb quickly and unpredictably as the estate grows, even when headcount stays flat.
+
+Second, HashiCorp is retiring the legacy, user-based Free plan. Organizations still on that older plan are being migrated to the enhanced Free tier introduced in 2023, which caps out at 500 managed resources. That's a workable ceiling for a small project, but it's nowhere near enough for a platform team managing infrastructure across a large multi-cloud estate, which means teams past that line are choosing between a paid plan and self-hosted Terraform Enterprise sooner than they expected.
+
+Third, HashiCorp itself changed hands: IBM completed its acquisition of HashiCorp in February 2025. That's not inherently a red flag, but any time a core piece of infrastructure tooling changes ownership, it's a reasonable moment for a platform team to ask who is setting the roadmap for the tool their entire organization depends on, and to make sure their infrastructure investment isn't locked to a single vendor's proprietary language and commercial runner.
+
+## The HCL ceiling for large, multi-cloud teams
+
+Terraform's configuration language, HCL, works well for small, well-scoped projects. At the scale of a large multi-cloud organization, its limits start to show. HCL has no real classes, limited runtime logic, and reuse only through its module system, so teams end up copying and adapting modules rather than composing shared abstractions the way they would in a general-purpose language. Testing is a similar story: native HCL testing (`terraform test`) and policy checks in HCP Terraform (Sentinel or Open Policy Agent) are useful, but they sit alongside the configuration language rather than inside the same software engineering toolchain---the linters, type checkers, unit test frameworks, and package managers---that the rest of a large engineering organization already uses for application code. And because HCP Terraform organizes infrastructure into workspaces per environment or component, large multi-cloud estates tend to accumulate workspace sprawl and fragmented state that a platform team has to manually stitch back together to get a single picture of what's actually running.
+
+## How Pulumi is different
+
+Pulumi lets you define infrastructure in the same general-purpose languages your engineering organization already uses: Python, TypeScript, Go, C#, and Java, plus YAML for teams that prefer a markup format. That means real loops, conditionals, classes, and functions instead of a DSL's limited expressiveness; the testing frameworks, linters, and IDE tooling (autocomplete, type checking, go-to-definition) your teams already rely on for application code; and dependency management through the same package managers---npm, PyPI, NuGet, Maven, Go modules---your teams use everywhere else. Infrastructure code becomes software, reviewed, tested, and refactored the same way, rather than a separate discipline bolted onto the side of engineering.
+
+That same language flexibility carries through to cloud coverage. Pulumi supports [180+ providers](/registry/) spanning AWS, Azure, Google Cloud, Kubernetes, and hundreds of SaaS platforms, including schema-generated native providers for [Kubernetes](/registry/packages/kubernetes/), [Azure Native](/registry/packages/azure-native/), [AWS Cloud Control](/registry/packages/aws-native/), and [Google Cloud Native](/registry/packages/google-native/) that ship support for new cloud APIs without waiting on a hand-authored release. For an organization running true multi-cloud, that means one platform, one state model, and one policy framework across every provider, rather than stitching together separate workspaces and separate governance for each cloud.
+
+## One unified platform, not a pile of point tools
+
+The most important difference for a large multi-cloud team isn't a single feature. It's that Pulumi Cloud is one platform where state, policy, secrets, estate visibility, and AI-assisted automation all operate on the same resource graph, instead of a managed HCL runner that platform teams then have to wire up to a separate secrets manager, a separate CMDB, and a separate policy engine.
+
+[Pulumi Policies](/docs/insights/policy/) is Pulumi's policy as code framework: write governance rules in Python, TypeScript, or Open Policy Agent's Rego, and enforce them automatically on every `pulumi up`, with centralized management and reporting available on Pulumi Cloud's commercial plans. Because it's part of the same platform rather than a bolt-on product, a policy violation shows up in the same preview and the same audit trail as everything else your teams are already looking at.
+
+[Pulumi ESC](/docs/esc/) (Environments, Secrets, and Configuration) centralizes secrets and configuration across your infrastructure and applications, so a large multi-cloud team isn't reconciling separate secrets stores per cloud or per team. [Pulumi Insights](/docs/insights/) gives that same team a single inventory of every cloud resource across every provider and account, regardless of how it was provisioned, with policy scanning layered on top so drift and non-compliant resources surface automatically rather than through a quarterly audit.
+
+And [Pulumi Neo](/docs/ai/), Pulumi's purpose-built infrastructure agent, operates natively inside this same platform because it's reading and writing real code. Neo can help scaffold a Terraform-to-Pulumi migration, run and interpret `pulumi preview` output, respond to failed updates, and open pull requests for review, all inside your existing Git and CI workflows. That's a meaningfully different starting point than asking a general-purpose AI coding assistant to reason about HCL: agents already understand Python, TypeScript, and Go, because those are the languages they were trained on and use every day.
+
+## Proven at multi-cloud scale
+
+Mercedes-Benz Research & Development adopted Pulumi specifically to unify application and infrastructure teams onto one platform, describing the result as taming the complexity of many teams working across many clouds. [Wiz](/case-studies/wiz/) uses Pulumi's Automation API to manage over one million cloud resources across thousands of Kubernetes clusters worldwide, handling hundreds of thousands of infrastructure updates daily. [BMW](/case-studies/bmw/)'s Software Factory manages 20,000-plus cloud resources with Python-based infrastructure code integrated directly into its existing CI/CD pipelines. [Supabase](/case-studies/supabase/) scaled from a single AWS region to 80,000 Pulumi-managed resources across 16 regions as its platform grew. [Atlassian](/case-studies/atlassian/) cut the time its team spends on infrastructure maintenance by half after adopting Pulumi for Bitbucket. And [Spear AI](/case-studies/spear-ai/) used Pulumi's built-in policy and compliance tooling to reach Authority to Operate six times faster, cutting an 18-month certification process down to three months.
+
+## Pulumi vs. HCP Terraform, feature by feature
+
+| | Pulumi | HCP Terraform |
+| --- | --- | --- |
+| Language | Python, TypeScript, Go, C#, Java, and YAML---general-purpose languages with native testing, IDE support, and package management | HCL, a configuration-focused DSL; `terraform test` covers native unit testing, but reuse and abstraction are limited to the module system |
+| Pricing model | Pulumi Cloud plans; cost is not driven by the number of resources under management | Resources Under Management (RUM)---billed by the count of resources tracked in state, in addition to plan tier |
+| Free tier | Individual tier is free with no resource cap for personal use | Enhanced Free tier caps out at 500 managed resources per organization |
+| Policy as code | [Pulumi Policies](/docs/insights/policy/), written in Python, TypeScript, or OPA Rego, enforced on every `pulumi up` as part of the same platform | Sentinel or OPA policy checks, run as a distinct step in the HCP Terraform run pipeline |
+| Secrets and configuration | [Pulumi ESC](/docs/esc/) centralizes secrets and config across infrastructure and applications | Workspace variables plus a separate HashiCorp Vault integration for centralized secrets |
+| Estate visibility | [Pulumi Insights](/docs/insights/) inventories every resource across every provider, however it was provisioned | No equivalent; visibility is scoped to what's tracked in HCP Terraform workspaces |
+| AI and agent readiness | [Pulumi Neo](/docs/ai/) and general-purpose AI coding agents operate directly on real, familiar code | Agents must generate and reason about HCL, a narrower and less common training target |
+| Multi-cloud coverage | 180+ providers, one state model, one policy framework across every cloud | Large, mature provider ecosystem; state and policy are scoped per workspace, so multi-cloud governance is assembled by the platform team |
+| Migration path | `pulumi convert` and `pulumi import` bring existing HCL and already-provisioned resources under Pulumi management incrementally | N/A |
+| Ecosystem maturity | Fast-growing registry, with any existing Terraform provider or module usable from Pulumi | The largest and most mature IaC provider and module ecosystem in the industry today |
+
+Terraform's ecosystem maturity and community size are real advantages, and they're worth naming plainly: more public modules exist for Terraform than for any single alternative, Pulumi included. Pulumi closes that gap in two ways---by adapting [any existing Terraform provider](/docs/iac/concepts/providers/any-terraform-provider/) into a Pulumi provider, and by letting Pulumi programs [consume existing Terraform modules directly](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/)---so adopting Pulumi doesn't mean starting the provider and module ecosystem over from zero.
+
+## Migrating off HCP Terraform without a rewrite
+
+Moving off HCP Terraform doesn't require a rewrite. [`pulumi convert --from terraform`](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/) translates existing HCL into Pulumi programs in your language of choice as a starting point for review. [`pulumi import`](/docs/iac/guides/migration/import/) brings already-provisioned resources under Pulumi management without recreating them. And Pulumi can coexist with an existing `.tfstate` file so both tools can run side by side during a gradual cutover, with Neo available to help scaffold the conversion and interpret the resulting `pulumi preview` output along the way.
+
+## Frequently asked questions
+
+### Is HCP Terraform (Terraform Cloud) still free?
+
+HCP Terraform's enhanced Free tier remains available, but it's capped at 500 managed resources per organization, with the legacy user-based Free plan being phased out. For a large multi-cloud estate, that ceiling is typically reached well before the team's infrastructure footprint stabilizes, which forces a move to a paid, resource-metered plan.
+
+### How does Pulumi's pricing compare to HCP Terraform's Resources Under Management model?
+
+HCP Terraform bills primarily by Resources Under Management, so cost rises directly with the size of your infrastructure footprint. Pulumi Cloud's plans are not driven by a per-resource count, which means a large multi-cloud estate doesn't see its platform bill climb in lockstep with the number of subnets, security group rules, and managed services it operates.
+
+### How do I migrate my existing Terraform state and code to Pulumi?
+
+Three options, usable independently or together: convert HCL to a Pulumi program with `pulumi convert --from terraform`, bring already-provisioned resources under Pulumi management with `pulumi import`, or reference your existing Terraform state directly from Pulumi and run both tools side by side until you're ready to cut over. See the [migration guide](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/) for the full walkthrough.
+
+### Can Pulumi manage multiple clouds in a single project?
+
+Yes. Pulumi supports [180+ providers](/registry/) across AWS, Azure, Google Cloud, Kubernetes, and hundreds of SaaS platforms from the same program, in the same state, under the same policy framework, which is what large organizations with genuinely multi-cloud estates use it for today.
+
+### Does Pulumi work with AI coding agents?
+
+Yes, in two ways. General-purpose AI coding agents like Claude Code, Codex, and Cursor already understand Pulumi's real programming languages, so they can read, write, and reason about your infrastructure code directly. Pulumi also offers [Neo](/docs/ai/), a purpose-built infrastructure agent that runs previews, responds to failures, and opens pull requests inside your existing workflows.
+
+### Do I have to rewrite everything to switch from Terraform Cloud to Pulumi?
+
+No. `pulumi convert` handles the initial translation of your HCL, `pulumi import` brings existing resources under management without recreating them, and Pulumi can read your current Terraform state so you can migrate incrementally, project by project, rather than all at once.
+
+## Next steps
+
+* [Get started with Pulumi](/docs/get-started/)
+* [Migrating from Terraform to Pulumi](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/)
+* [Pulumi vs. Terraform](/docs/iac/comparisons/terraform/)
+* [Pulumi vs. OpenTofu](/docs/iac/comparisons/opentofu/)

--- a/data/team/team/content-team.toml
+++ b/data/team/team/content-team.toml
@@ -1,0 +1,4 @@
+id = "content-team"
+name = "Pulumi Content Team"
+title = "Product Team"
+status = "active"


### PR DESCRIPTION
## Summary

Adds a bottom-funnel comparison page targeting "best Terraform Cloud alternative for large multi-cloud teams" — a high-intent, evaluative query where large platform teams are actively comparing HCP Terraform against alternatives.

## What's in this page

- **Timely, sourced hook**: HashiCorp's shift to Resources Under Management (RUM) pricing, the Free tier's 500-resource cap, and the February 2025 IBM acquisition — framed factually, not as FUD.
- **Fair treatment of Terraform's limits at scale**: HCL's reuse/testing ceiling and workspace/state sprawl, while explicitly acknowledging `terraform test` and OPA support exist (no overclaiming).
- **Pulumi Cloud presented as one unified platform** — Neo, ESC, Insights, and Pulumi Policies all operating on the same resource graph, not siloed products. All CrossGuard references use the current "Pulumi Policies" name and canonical `/docs/insights/policy/` URL.
- **One comparison table** (feature-by-feature) and one **FAQ section** (`## Frequently asked questions` with `###` question headings) — structured for both readability and FAQ schema auto-detection.
- **Public proof points only**, verified against the live case studies: Mercedes-Benz (multi-cloud/multi-team framing), Wiz (1M+ resources, hundreds of thousands of daily updates), BMW (20,000+ resources, Python IaC), Supabase (80K resources across 16 regions), Atlassian (50% less maintenance time), Spear AI (6x faster Authority to Operate).
- **Migration path** via `pulumi convert --from terraform` / `pulumi import`, removing the lock-in objection for an evaluation-ready audience.

## Files changed

- `content/docs/iac/comparisons/terraform-cloud.md` — new comparison page
- `content/docs/iac/comparisons/_index.md` — added link to the new page from the comparisons hub
- `data/team/team/content-team.toml` — new "Pulumi Content Team" author profile (byline for this page)

## Notes for reviewers

- No RUM dollar figures are quoted — third-party estimates of HCP Terraform's per-resource pricing weren't verifiable against a primary HashiCorp source at time of writing, so the pricing shift is described qualitatively (per-resource vs. per-seat, free-tier cap) rather than with a specific number I couldn't confirm.
- Slug `terraform-cloud` was open (no existing HCP Terraform / Terraform Cloud comparison page in the repo).

---
🧠 *This PR was created by [workprentice](https://github.com/workprentice) on behalf of @joeduffy.*
