### PR TITLE
docs(gads/aws): remove obsolete Native provider and Crosswalk branding

### DIFF
--- a/content/gads/aws/index.md
+++ b/content/gads/aws/index.md
@@ -37,9 +37,9 @@ key_features_above:
                     Full API coverage for EC2, EKS, Lambda, S3, RDS, DynamoDB, and every other AWS service. Same-day updates when new services and features launch.
                 icon: global
                 color: yellow
-              - title: AWSx
+              - title: Component libraries
                 description: |
-                    Deploy production-ready VPCs, ECS Fargate services, and EKS clusters in just a few lines of code using Pulumi's AWSx component library.
+                    Deploy production-ready VPCs, ECS Fargate services, and EKS clusters in just a few lines of code using Pulumi's component libraries, like AWSx.
                 icon: code
                 color: yellow
               - title: AI-powered infrastructure
@@ -52,9 +52,9 @@ key_features:
     title: Key features
     items:
         - title: "Production-ready AWS in minutes"
-          sub_title: "Pulumi AWSx"
+          sub_title: "Pulumi component libraries"
           description: |
-            Stop writing hundreds of lines of boilerplate for VPCs, subnets, and security groups. AWSx gives you production-ready architectures with built-in best practices for ECS, EKS, API Gateway, and more — in just a few lines of code.
+            Stop writing hundreds of lines of boilerplate for VPCs, subnets, and security groups. Pulumi's component libraries, like AWSx, give you production-ready architectures with built-in best practices for ECS, EKS, API Gateway, and more — in just a few lines of code.
           ide:
             - title: index.ts
               language: typescript
@@ -179,10 +179,10 @@ key_features:
                 icon: cloud
                 description: |
                     Full API coverage for every AWS service with same-day updates when new features launch. No waiting for third-party support.
-              - title: AWSx
+              - title: Component libraries
                 icon: abstract-shapes
                 description: |
-                    Adopt well-architected best practices for VPC, ECS, EKS, API Gateway, and more with pre-built high-level components.
+                    Adopt well-architected best practices for VPC, ECS, EKS, API Gateway, and more with pre-built high-level components like AWSx.
               - title: Migrate from CloudFormation
                 icon: exchange
                 description: |

--- a/content/gads/aws/index.md
+++ b/content/gads/aws/index.md
@@ -1,13 +1,13 @@
 ---
 title: "AWS Infrastructure as Code | Pulumi"
-meta_desc: "Manage AWS with Python, TypeScript, Go, or C#. Full API coverage, same-day updates, built-in best practices with Crosswalk. Free tier, no resource caps."
+meta_desc: "Manage AWS with Python, TypeScript, Go, or C#. Full API coverage, same-day updates, built-in best practices with AWSx. Free tier, no resource caps."
 layout: gads-template
 block_external_search_index: true
 
 heading: "AWS Infrastructure as Code"
 subheading: |
     Manage any AWS service with real programming languages. Pulumi's AWS provider offers
-    full API coverage with same-day updates, plus higher-level Crosswalk components
+    full API coverage with same-day updates, plus higher-level AWSx components
     for production-ready architectures out of the box.
 
 hide_platform_details: true
@@ -30,16 +30,16 @@ key_features_above:
         - title: "Author in any language, deploy to AWS"
           sub_title: "Pulumi AWS Provider"
           description:
-            Manage any AWS resource using programming languages you already know. Pulumi's AWS provider covers every service and updates the same day AWS releases new features. Use Crosswalk for AWS to adopt well-architected best practices instantly.
+            Manage any AWS resource using programming languages you already know. Pulumi's AWS provider covers every service and updates the same day AWS releases new features. Use Pulumi's AWSx component library to adopt well-architected best practices instantly.
           features:
               - title: Every AWS service, day one
                 description: |
                     Full API coverage for EC2, EKS, Lambda, S3, RDS, DynamoDB, and every other AWS service. Same-day updates when new services and features launch.
                 icon: global
                 color: yellow
-              - title: Crosswalk for AWS
+              - title: AWSx
                 description: |
-                    Deploy production-ready VPCs, ECS Fargate services, and EKS clusters in just a few lines of code using Pulumi's Crosswalk library.
+                    Deploy production-ready VPCs, ECS Fargate services, and EKS clusters in just a few lines of code using Pulumi's AWSx component library.
                 icon: code
                 color: yellow
               - title: AI-powered infrastructure
@@ -52,9 +52,9 @@ key_features:
     title: Key features
     items:
         - title: "Production-ready AWS in minutes"
-          sub_title: "Pulumi Crosswalk for AWS"
+          sub_title: "Pulumi AWSx"
           description: |
-            Stop writing hundreds of lines of boilerplate for VPCs, subnets, and security groups. Crosswalk for AWS gives you production-ready architectures with built-in best practices for ECS, EKS, API Gateway, and more — in just a few lines of code.
+            Stop writing hundreds of lines of boilerplate for VPCs, subnets, and security groups. AWSx gives you production-ready architectures with built-in best practices for ECS, EKS, API Gateway, and more — in just a few lines of code.
           ide:
             - title: index.ts
               language: typescript
@@ -175,11 +175,11 @@ key_features:
                 outputs:
                   vpcId: ${my-vpc.vpcId}
           features:
-              - title: Native AWS provider
+              - title: Pulumi AWS provider
                 icon: cloud
                 description: |
                     Full API coverage for every AWS service with same-day updates when new features launch. No waiting for third-party support.
-              - title: Crosswalk for AWS
+              - title: AWSx
                 icon: abstract-shapes
                 description: |
                     Adopt well-architected best practices for VPC, ECS, EKS, API Gateway, and more with pre-built high-level components.


### PR DESCRIPTION
This fixes the three obsolete-content items called out in #20171 on the AWS Google Ads landing page (`content/gads/aws/index.md`, https://www.pulumi.com/gads/aws/).

**1. "Native AWS provider" branding**

The feature bullet titled "Native AWS provider" described full API coverage and same-day updates for AWS services — that's the standard Pulumi AWS provider (`@pulumi/aws`), but the title reads as a reference to the separate AWS Native provider (`@pulumi/aws-native`, Cloud Control API-backed), which is a distinct package with narrower resource coverage. Retitled to "Pulumi AWS provider" so the title matches the description and doesn't imply the wrong package.

**2. "Crosswalk" branding**

"Crosswalk" and "Crosswalk for AWS" are retired branding — the AWS guides today (`content/docs/iac/guides/clouds/aws/`) describe these higher-level, well-architected components as **AWSx** (`@pulumi/awsx`), and the old `/docs/reference/crosswalk/...` URLs redirect there. I replaced every "Crosswalk" reference on the page (meta description, subheading, feature titles and descriptions, and the "Key features" sub_title) with AWSx, while keeping the underlying value proposition and code samples unchanged — they already import `@pulumi/awsx` / `pulumi_awsx`, etc.

**3. cf2pulumi**

Confirmed this page has no reference to cf2pulumi already; no change needed.

No structural changes: headings, code-tabs, customer quote, and page layout are untouched, only wording that was inaccurate or out of date.

Fixes #20171

---
🧠 *This PR was created by [workprentice](https://github.com/workprentice) on behalf of @joeduffy.*
