### PR TITLE
Fix errant "Navigation" item in the on-this-page nav

### DIFF
--- a/theme/src/ts/misc.ts
+++ b/theme/src/ts/misc.ts
@@ -108,7 +108,11 @@ export function generateOnThisPage() {
     let found = false;
     const headingItems: { element: HTMLElement, listItems: HTMLElement[] }[] = [];
 
-    document.querySelectorAll("h2, h3").forEach((el: HTMLElement) => {
+    // Scope to the main content region so headings in page chrome (e.g. the
+    // screen-reader-only "Navigation" heading in the mobile nav sheet, which
+    // renders in the header, outside #main) don't leak into the TOC.
+    const content = document.querySelector("#main") || document;
+    content.querySelectorAll("h2, h3").forEach((el: HTMLElement) => {
         if (el.closest('.hidden')) {
             return;
         }


### PR DESCRIPTION
The client-side "On this page" generator collects every h2/h3 in the document, which causes a "Navigation" heading to appear as the first TOC entry on every docs page: 

<img width="388" height="454" alt="image" src="https://github.com/user-attachments/assets/f890e742-0f3b-4cb8-bfe2-8a85ee2ff141" />

This scopes the heading query to `#main` so page chrome no longer leaks into the table of contents.