### PR TITLE
[docs] Clarify Add Stack regenerates the program from a referenced template

### DIFF
--- a/content/docs/idp/concepts/new-project-wizard.md
+++ b/content/docs/idp/concepts/new-project-wizard.md
@@ -23,7 +23,7 @@ The New Project Wizard supports three primary workflows:
 
 1. **Create a new project from a template**: Create a new project and its first stack by forking code from a Pulumi organization [template](/docs/idp/concepts/organization-templates/). This creates a copy of the template code in your repository, which you can then modify independently.
 1. **Add a no-code stack to a template**: Add a new stack to an organization template without forking the template code. The template code remains the single source of truth, and the stack references the template directly.
-1. **Add a stack to an existing project**: Add a new stack to any existing Pulumi project, whether or not it was originally created from a template.
+1. **Add a stack to an existing project**: Add a new stack to any existing Pulumi project. If the project references an upstream template (via `pulumi:template` in its `Pulumi.yaml`), the wizard regenerates the project's program from that template when it adds the stack, so local changes that have diverged from the template are not preserved. Projects without a template reference keep their existing program unchanged.
 
 ## Configuration options
 


### PR DESCRIPTION
The New Project Wizard page listed "Add a stack to an existing project" without noting that, when the project references an upstream template (`pulumi:template`), the wizard regenerates the program from that template and does not preserve local changes that have diverged from it. Reword the existing bullet to set that expectation.

Wording-only change to one bullet; documents current behavior.
