### PR TITLE
Document context.pulumi.token properties for ESC

### DIFF
--- a/content/docs/esc/concepts/interpolations-and-references.md
+++ b/content/docs/esc/concepts/interpolations-and-references.md
@@ -107,12 +107,32 @@ In addition to referencing properties defined within an environment, references 
 
 ### context
 
-The `context` built-in property provides information about the user evaluating an ESC environment. It exposes the login of the requesting user at `context.pulumi.user.login` and the login of their organization at `context.pulumi.organization.login`.
+The `context` built-in property provides information about the user and the access token evaluating an ESC environment:
+
+* `context.pulumi.user.login`: the login of the requesting user
+* `context.pulumi.organization.login`: the login of their organization
+* `context.pulumi.token.type`: the type of the access token used to open the environment, such as `personal`, `team`, or `organization`
+* `context.pulumi.token.team`: the name of the team a team-scoped token belongs to
+* `context.pulumi.token.name`: the token's name
+
+Each `context.pulumi.token` property resolves to an empty string when it doesn't apply to the credential in use. `token.team` is empty for tokens that aren't team-scoped, and `token.name` is empty for personal and web tokens.
 
 ```yaml
 values:
   greeting: Hello, ${context.pulumi.organization.login}/${context.pulumi.user.login}!
 ```
+
+#### Differentiating callers by token
+
+For team and organization tokens, both `user.login` and `organization.login` resolve to the organization name, so neither one distinguishes a team token from an individual user. The `context.pulumi.token` properties are the way to tell those callers apart:
+
+```yaml
+values:
+  callerType: ${context.pulumi.token.type}
+  callerTeam: ${context.pulumi.token.team}
+```
+
+`token.type` and `token.team` are also available as OIDC subject attributes, which lets a cloud provider's trust policy scope an assumable role to a specific team. `token.name` is deliberately excluded from subject claims because token names are chosen by the user and could be crafted to forge a subject. See [Custom token claim](/docs/esc/guides/configuring-oidc/#custom-token-claim).
 
 ### environments
 

--- a/content/docs/esc/guides/configuring-oidc/_index.md
+++ b/content/docs/esc/guides/configuring-oidc/_index.md
@@ -87,10 +87,12 @@ The following attributes are available:
 * `currentEnvironment.name`: the full name (including the project) of the environment where the ESC login provider and `subjectAttributes` are defined
 * `pulumi.user.login`: the login identifier of the user opening the environment
 * `pulumi.organization.login`: the login identifier of the organization
+* `pulumi.token.type`: the type of the access token used to open the environment, such as `personal`, `team`, or `organization`
+* `pulumi.token.team`: the name of the team a team-scoped token belongs to, which lets a trust policy scope a role to one team
 
 {{< notes type="info" >}}
 
-The set of attributes that may be encoded into the subject claim is deliberately restricted to this fixed list. Because the subject is consumed by the cloud provider's trust policy to make authorization decisions, only values that are determined and attested by the Pulumi platform (rather than supplied by the requesting caller) are permitted. Admitting arbitrary or user-controllable values would allow a caller to forge a subject that satisfies a trust policy and thereby obtain credentials they are not entitled to. Each supported attribute therefore reflects a non-spoofable, platform-derived identity or environment value; attributes that a caller could influence are intentionally excluded.
+The set of attributes that may be encoded into the subject claim is deliberately restricted to this fixed list. Because the subject is consumed by the cloud provider's trust policy to make authorization decisions, only values that are determined and attested by the Pulumi platform (rather than supplied by the requesting caller) are permitted. Admitting arbitrary or user-controllable values would allow a caller to forge a subject that satisfies a trust policy and thereby obtain credentials they are not entitled to. Each supported attribute therefore reflects a non-spoofable, platform-derived identity or environment value; attributes that a caller could influence are intentionally excluded. `pulumi.token.name` is one such exclusion: unlike the token's type and team, which the platform determines, a token's name is chosen by whoever creates it and could be set to a value that forges a subject.
 
 {{< /notes >}}
 


### PR DESCRIPTION
## What

Documents the `context.pulumi.token` properties in ESC environments, and the two new OIDC subject attributes that came with them.

[pulumi/pulumi-service#45097](https://github.com/pulumi/pulumi-service/pull/45097) exposes the authenticating access token's `type`, `team`, and `name` under `context.pulumi.token`, and adds `pulumi.token.type` / `pulumi.token.team` to the subject attribute allowlist. None of it was documented.

Two pages change:

- **`content/docs/esc/concepts/interpolations-and-references.md`** — the `context` built-in property reference now lists all five properties, notes when each token property resolves to an empty string, and adds a short subsection on differentiating callers by token.
- **`content/docs/esc/guides/configuring-oidc/_index.md`** — the custom token claim attribute list gains the two new attributes, and the adjacent security note explains why `pulumi.token.name` is excluded.

## Why

For team and organization tokens, both `user.login` and `organization.login` resolve to the organization name, so neither distinguishes a team token from an individual user. This came up as a customer question about scoping AWS access per team over OIDC, and the token properties are the answer, but there was nothing to point at.

## Verification

- `make lint` passes.
- Wording was taken from the merged implementation in `cmd/service/services/environments/environments.go` rather than the PR summary, so the empty-value behavior described here matches the code (`token.name` empty for personal/web tokens, `token.team` empty for non-team tokens).
- Confirmed live against a real org: `${context.pulumi.token.type}` resolves to `personal` with a personal token, where it previously failed with `unknown property "token"`.

## Note for reviewers

I verified the personal-token path directly. I did **not** exercise a team-scoped token, so the `token.team` behavior described here comes from reading the implementation rather than from a live test. Worth a second look if you have a team token handy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)