### PR TITLE
Remove on-page tables of contents from blog series posts

### DIFF
--- a/content/blog/day-2-operations-drift-detection-and-remediation/index.md
+++ b/content/blog/day-2-operations-drift-detection-and-remediation/index.md
@@ -64,15 +64,6 @@ You've built a beautiful platform with robust guardrails, comprehensive template
 
 This post continues our journey through the IDP Best Practices series. We've covered strategy and self-service infrastructure, built golden paths with components and templates, and established deployment guardrails through policy as code. Now we're tackling what happens after deployment when the real world starts making changes to your carefully crafted infrastructure.
 
-Series roadmap:
-
-* [How to Build an Internal Developer Platform: Strategy, Best Practices, and Self-Service Infrastructure](/blog/idp-strategy-planning-self-service-infrastructure-that-balances-developer-autonomy-with-operational-control)
-* [Build Golden Paths with Infrastructure Components and Templates](/blog/golden-paths-infrastructure-components-and-templates)
-* [Deployment Guardrails with Policy as Code](/blog/deployment-guardrails-with-policy-as-code)
-* **Day 2 Operations: Drift Detection and Remediation** (you are here)
-* Extend Your IDP for AI Applications: GPUs, Models, and Cost Controls
-* Next-Gen IDPs: How to Modernize Legacy Infrastructure with Pulumi
-
 ## The Reality of Infrastructure Drift
 
 Let me paint you a picture that might feel uncomfortably familiar. It's Saturday afternoon, and you're enjoying a barbecue with friends when your phone buzzes with that dreaded alert: production is down. You rush to your laptop, but you're not on the corporate VPN. The AWS console is accessible, but you can't reach the application itself to properly diagnose the issue.

--- a/content/blog/deployment-guardrails-with-policy-as-code/index.md
+++ b/content/blog/deployment-guardrails-with-policy-as-code/index.md
@@ -26,15 +26,6 @@ Platform engineering presents a fundamental tension: we want to enable developer
 
 <!--more-->
 
-This post is part of our IDP Best Practices series:
-
-* [How to Build an Internal Developer Platform: Strategy, Best Practices, and Self-Service Infrastructure](/blog/idp-strategy-planning-self-service-infrastructure-that-balances-developer-autonomy-with-operational-control)
-* [Build Golden Paths with Infrastructure Components and Templates](/blog/golden-paths-infrastructure-components-and-templates)
-* **Deployment Guardrails with Policy as Code** (you are here)
-* [Day 2 Operations: Drift Detection and Remediation](/blog/day-2-operations-drift-detection-and-remediation)
-* Extend Your IDP for AI Applications: GPUs, Models, and Cost Controls
-* Next-Gen IDPs: How to Modernize Legacy Infrastructure with Pulumi
-
 {{% notes type="tip" %}}
 **Want hands-on experience?** Access the [complete demo code](https://github.com/pulumi/workshops/tree/main/idp-component-policies) and [policy examples](https://github.com/pulumi/workshops/tree/main/idp-component-policies/demo-policies) from this workshop.
 {{% /notes %}}

--- a/content/blog/getting-started-with-k8s-part3/index.md
+++ b/content/blog/getting-started-with-k8s-part3/index.md
@@ -15,15 +15,6 @@ Welcome to the third article in a series using infrastructure as code to deploy 
 
 <!--more-->
 
-This series walks you through:
-
-- [Building a Kubernetes cluster on cloud providers](/blog/getting-started-with-k8s-part1/)
-- [Basic application deployment](/blog/getting-started-with-k8s-part2/)
-- Advance application deployment and Helm charts
-- Stateful applications
-- Networking
-- “Day 2” activities such as migrating node groups.
-
 This article reviews three types of application deployment scenarios with commonly used examples. The first scenario is a [12-factor](https://12factor.net/) microservices multi-tier application consisting of multiple frontend and backend services backed by databases and a messaging queue to handle requests. The second scenario takes the Kubernetes guestbook and turns the Service and Deployment into a single component, demonstrating another pattern for organizing your stack. The third scenario shows how to deploy a popular web application using a [Helm](https://helm.sh/), the package manager for Kubernetes.
 
 In this article, we’ll assume that we already have a Kubernetes cluster available. You will have to set the [context](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/#kubernetes-configuration) with *kubectl* to deploy the examples in this article. Because of Kubernetes’ OpenAPI, we can use the same Typescript application code on any compliant instance.

--- a/content/blog/getting-started-with-k8s-part4/index.md
+++ b/content/blog/getting-started-with-k8s-part4/index.md
@@ -11,14 +11,7 @@ category: tutorials
 series: kubernetes-getting-started
 ---
 
-This article is the fourth in a series using infrastructure as code to deploy applications with Kubernetes. This series walks you through:
-
-- [Building a Kubernetes cluster on cloud providers](/blog/getting-started-with-k8s-part1/)
-- [Basic application deployment](/blog/getting-started-with-k8s-part2/)
-- [Advance application deployment and Helm charts](/blog/getting-started-with-k8s-part3/)
-- Stateful applications
-- Networking
-- “Day 2” activities such as migrating node groups.
+This article is the fourth in a series using infrastructure as code to deploy applications with Kubernetes.
 
 In the previous post, we examined different methods for deploying applications. We worked through examples of a boilerplate deployment, to one using `ComponentResources` to automate deployment further, and deploying with Helm charts. In this installment, we’ll look at how to deploy stateful applications, such as databases, in Kubernetes. Unlike stateless applications, stateful apps require persistent storage, which presents scaling and availability challenges.
 

--- a/content/blog/getting-started-with-k8s-part5/index.md
+++ b/content/blog/getting-started-with-k8s-part5/index.md
@@ -169,9 +169,4 @@ frontendIp = frontend.status.loadBalancer.ingress[0].ip;
 
 The goal of this article is to provide an overview of the Kubernetes Networking model. The implementation of the Container Network Interface (CNI) varies from provider to provider. You can read more about [CNI implementations](https://kubernetes.io/docs/concepts/cluster-administration/networking/) on the Kubernetes documentation site.
 
-Each article in this series is intended to be independent of each other. However, we build upon concepts introduced in previous articles. If some concepts or terminology are unfamiliar, I encourage reading the earlier articles:
-
-- [Building a Kubernetes cluster on cloud providers](/blog/getting-started-with-k8s-part1/)
-- [Basic application deployment](/blog/getting-started-with-k8s-part2/)
-- [Advance application deployment and Helm charts](/blog/getting-started-with-k8s-part3/)
-- [Stateful applications](/blog/getting-started-with-k8s-part4/)
+Each article in this series is intended to be independent of each other. However, we build upon concepts introduced in previous articles.

--- a/content/blog/getting-started-with-k8s-part6/index.md
+++ b/content/blog/getting-started-with-k8s-part6/index.md
@@ -43,10 +43,4 @@ Kubernetes Cluster Services provide logging and monitoring at the cluster level 
 
 Maintaining a Kubernetes cluster and modern applications can be varied and complex. However, infrastructure as code lets developers and operators use a common language to manage the cluster and resources. Pulumi has a rich toolset to help you accomplish Day 2 tasks, whether managing cluster components such as secrets, changing cluster components to scale applications, or logging and monitoring your cluster and resources.
 
-Each article in this series is intended to be independent of each other. However, we build upon concepts introduced in previous articles. If some concepts or terminology are unfamiliar, I encourage reading the earlier articles:
-
-- [Building a Kubernetes cluster on cloud providers](/blog/getting-started-with-k8s-part1/)
-- [Basic application deployment](/blog/getting-started-with-k8s-part2/)
-- [Advance application deployment and Helm charts](/blog/getting-started-with-k8s-part3/)
-- [Stateful applications](/blog/getting-started-with-k8s-part4/)
-- [Networking](/blog/getting-started-with-k8s-part5/)
+Each article in this series is intended to be independent of each other. However, we build upon concepts introduced in previous articles.

--- a/content/blog/golden-paths-infrastructure-components-and-templates/index.md
+++ b/content/blog/golden-paths-infrastructure-components-and-templates/index.md
@@ -31,15 +31,6 @@ In this guide, you'll learn how to build golden paths for your Internal Develope
 
 <!--more-->
 
-This post is part of our IDP Best Practices series:
-
-- [How to Build an Internal Developer Platform: Strategy, Best Practices, and Self-Service Infrastructure](/blog/idp-strategy-planning-self-service-infrastructure-that-balances-developer-autonomy-with-operational-control/)
-- **Build Golden Paths: Guide to Reusable Infrastructure with Pulumi Components and Templates** (you are here)
-- [Policy as Code for Safer IDPs: Enabling Developer Self-Service with Guardrails](/blog/deployment-guardrails-with-policy-as-code)
-- [Day 2 Operations: Drift Detection and Remediation](/blog/day-2-operations-drift-detection-and-remediation)
-- Extend Your IDP for AI Applications: GPUs, Models, and Cost Controls
-- Next-Gen IDPs: How to Modernize Legacy Infrastructure with Pulumi
-
 {{% notes type="tip" %}}
 The complete code examples from this post are available on [GitHub](https://github.com/pulumi/workshops/tree/main/golden-paths-infrastructure-components-and-templates).
 {{% /notes %}}

--- a/content/blog/iac-best-practices-applying-stack-references/index.md
+++ b/content/blog/iac-best-practices-applying-stack-references/index.md
@@ -20,16 +20,6 @@ This is the fourth post in a series of blog posts focused on Zephyr Archaeotech 
 
 As you may have read in earlier Zephyr posts, the ultimate goal of the Zephyr series is to share best practices on the use of Pulumi to manage your infrastructure and application resources (using a fictional company and a somewhat complex containerized application as the use case). The series exposes those practices over time---not all right away, and not without also discussing the context for the recommendations. This is deliberate, demonstrating how "point-in-time" recommendations change based on the needs of the company and its requirements.
 
-Here are links to all the blog posts in the series:
-
-* [IaC Best Practices: Understanding Code Organization and Stacks](/blog/iac-best-practices-understanding-code-organization-stacks/)
-* [IaC Best Practices: Enabling Developer Stacks and Git Branches](/blog/iac-best-practices-enabling-developer-stacks-git-branches/)
-* [IaC Best Practices: Structuring Pulumi Projects](/blog/iac-best-practices-structuring-pulumi-projects/)
-* **IaC Best Practices: Applying Stack References** (you are here)
-* [IaC Best Practices: Implementing RBAC and Security](/blog/iac-best-practices-implementing-rbac-and-security/)
-* [IaC Best Practices: Using Automation API](/blog/iac-best-practices-using-automation-api/)
-* [IaC Best Practices: Summarizing Key Learnings](/blog/iac-best-practices-summarizing-key-learnings)
-
 ## Reviewing Zephyr's Current Status
 
 This post continues the previous post in the series. Zephyr's infrastructure footprint and Pulumi codebase is the same; that is, Zephyr now has _three_ Pulumi projects (zephyr-infra, zephyr-k8s, and zephyr-app). Each of these projects handles a different aspect of Zephyr's online store:

--- a/content/blog/iac-best-practices-enabling-developer-stacks-git-branches/index.md
+++ b/content/blog/iac-best-practices-enabling-developer-stacks-git-branches/index.md
@@ -22,16 +22,6 @@ In the first post about [code organization and stacks](/blog/iac-best-practices-
 
 The ultimate goal of this series is to discuss best practices for using Pulumi to manage a fairly complex containerized application. However, it's important to note that these practices will emerge over the course of the series --- not all immediately, and not all in the beginning. This is a deliberate decision to allow you to see how Zephyr's use of Pulumi evolves as the company grows and its retail application changes to accommodate its growth.
 
-Here are links to all of the posts in the series:
-
-* [IaC Best Practices: Understanding Code Organization and Stacks](/blog/iac-best-practices-understanding-code-organization-stacks/)
-* **IaC Best Practices: Enabling Developer Stacks and Git Branches** (this post)
-* [IaC Best Practices: Structuring Pulumi Projects](/blog/iac-best-practices-structuring-pulumi-projects/)
-* [IaC Best Practices: Applying Stack References](/blog/iac-best-practices-applying-stack-references/)
-* [IaC Best Practices: Implementing RBAC and Security](/blog/iac-best-practices-implementing-rbac-and-security/)
-* [IaC Best Practices: Using Automation API](/blog/iac-best-practices-using-automation-api/)
-* [IaC Best Practices: Summarizing Key Learnings](/blog/iac-best-practices-summarizing-key-learnings)
-
 ## Existing IaC Workflow
 
 When we last met up with the Zephyr team, they were off and running, managing their newly refactored online store, Zephyr Archaeotech Emporium, with a single [Pulumi project](/docs/concepts/projects/) and two [Pulumi stacks](/docs/concepts/stack/) --- one for development (`dev`) and another for production (`prod`). The team had chosen to use one Git repository (a monorepo) to manage the code for the online store and its infrastructure after refactoring the store into a set of containerized microservices deployed with Kubernetes on [Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html).

--- a/content/blog/iac-best-practices-implementing-rbac-and-security/index.md
+++ b/content/blog/iac-best-practices-implementing-rbac-and-security/index.md
@@ -20,16 +20,6 @@ This post continues our series of blog posts focused on IaC best practices. In e
 
 The ultimate goal of this series is to discuss best practices for using Pulumi to manage a fairly complex containerized application. You've seen these practices emerge over the course of the series---not all immediately, and not all right away. Structuring the blog series in this way is a deliberate decision; many best practices are "point in time" recommendations: they are context-dependent and the recommendations for any given company, like Zephyr, may change as the company and its needs change.
 
-For ease of navigation, here are links to all the blog posts in the series:
-
-* [IaC Best Practices: Understanding Code Organization and Stacks](/blog/iac-best-practices-understanding-code-organization-stacks/)
-* [IaC Best Practices: Enabling Developer Stacks and Git Branches](/blog/iac-best-practices-enabling-developer-stacks-git-branches/)
-* [IaC Best Practices: Structuring Pulumi Projects](/blog/iac-best-practices-structuring-pulumi-projects/)
-* [IaC Best Practices: Applying Stack References](/blog/iac-best-practices-applying-stack-references/)
-* **IaC Best Practices: Implementing RBAC and Security (the post you're reading)**
-* [IaC Best Practices: Using Automation API](/blog/iac-best-practices-using-automation-api/)
-* [IaC Best Practices: Summarizing Key Learnings](/blog/iac-best-practices-summarizing-key-learnings)
-
 ## Evolving Project Structure to Enhance Security and Scalability
 
 So far, you've read about how Zephyr started out with a single project and a single Git repository. Adding short-lived per-developer stacks, as described in the post on [best practices for developer stacks and Git branches](/blog/iac-best-practices-enabling-developer-stacks-git-branches/), didn't really impact this structure. However, as the company grew, Zephyr's project and Git repository structure evolved into its current form:

--- a/content/blog/iac-best-practices-structuring-pulumi-projects/index.md
+++ b/content/blog/iac-best-practices-structuring-pulumi-projects/index.md
@@ -20,16 +20,6 @@ This is the third post in a series of blog posts focused on Zephyr Archaeotech E
 
 The first post about [organizing code and stacks](/blog/iac-best-practices-understanding-code-organization-stacks/) specifically mentions that the series will show "how Zephyr's use of Pulumi evolves as the company grows and their online retail store application changes to accommodate their growth." While the ultimate goal of this series is to discuss best practices for using Pulumi to manage a fairly complex containerized application, it's important to note that many best practices are "point in time" recommendations: best practices are context-dependent and the recommended practices for a given organization will change as the company and its infrastructure needs also change. This blog post is an example of that evolution in action: the practices that worked well for Zephyr while they were smaller and had smaller infrastructure and less teams working on that infrastructure are no longer ideal as the company has grown.
 
-Here are links to all the blog posts in the series:
-
-* [IaC Best Practices: Code Organization and Stacks](/blog/iac-best-practices-understanding-code-organization-stacks/)
-* [IaC Best Practices: Enabling Developer Stacks and Git Branches](/blog/iac-best-practices-enabling-developer-stacks-git-branches/)
-* **IaC Best Practices: Structuring Pulumi Projects** (this post)
-* [IaC Best Practices: Applying Stack References](/blog/iac-best-practices-applying-stack-references/)
-* [IaC Best Practices: Implementing RBAC and Security](/blog/iac-best-practices-implementing-rbac-and-security/)
-* [IaC Best Practices: Using Automation API](/blog/iac-best-practices-using-automation-api/)
-* [IaC Best Practices: Summarizing Key Learnings](/blog/iac-best-practices-summarizing-key-learnings)
-
 ## Growing Development Teams
 
 As a result of launching its online presence, Zephyr saw amazing success. The market for arcane artifacts and novel curiosities is booming, and Zephyr is becoming a leader in this market. Funded by this success, Zephyr has grown rapidly. Along with this growth, Zephyr's software engineering and IT teams also grew and expanded. Fortunately, Zephyr's [use of per-developer stacks with short-lived ephemeral Git branches](/blog/iac-best-practices-enabling-developer-stacks-git-branches/) positioned the development teams well for this growth.

--- a/content/blog/iac-best-practices-summarizing-key-learnings/index.md
+++ b/content/blog/iac-best-practices-summarizing-key-learnings/index.md
@@ -17,16 +17,6 @@ aliases:
 
 Welcome to the final post in our series of articles focused on Infrastructure as Code best practices. In this post, we'll wrap up our recommendations for [IaC with Pulumi](/product/infrastructure-as-code/), summarizing the best practices from previous posts as well as highlighting some areas of potential future growth for the team at Zephyr Archaeotech Emporium---the fictional company at the center of the story throughout this series.<!--more-->
 
-For ease of navigation, here are links to all the blog posts in the series:
-
-* [IaC Best Practices: Understanding Code Organization and Stacks](/blog/iac-best-practices-understanding-code-organization-stacks/)
-* [IaC Best Practices: Enabling Developer Stacks and Git Branches](/blog/iac-best-practices-enabling-developer-stacks-git-branches/)
-* [IaC Best Practices: Structuring Pulumi Projects](/blog/iac-best-practices-structuring-pulumi-projects/)
-* [IaC Best Practices: Applying Stack References](/blog/iac-best-practices-applying-stack-references/)
-* [IaC Best Practices: Implementing RBAC and Security](/blog/iac-best-practices-implementing-rbac-and-security/)
-* [IaC Best Practices: Using Automation API](/blog/iac-best-practices-using-automation-api/)
-* **IaC Best Practices: Summarizing Key Learnings** (this post)
-
 ## Recapping IaC Best Practices
 
 As this series has progressed, we've been showing you how Zephyr's use of Pulumi has changed in response to how the organization, the team, and the application has changed. In case you haven't been following along---or in case you need a refresher---here's a brief summary of what's happened in the series:

--- a/content/blog/iac-best-practices-understanding-code-organization-stacks/index.md
+++ b/content/blog/iac-best-practices-understanding-code-organization-stacks/index.md
@@ -24,16 +24,6 @@ This is the first in a series of blog posts that explores how a fictional compan
 
 The ultimate goal of this series is to discuss recommended practices for using Pulumi to manage a fairly complex containerized application. However, it's important to note that these practices will emerge over the course of the series---not all immediately, and not all in the beginning. This is a deliberate decision to allow you to see how Zephyr's use of Pulumi evolves as the company grows and their online retail store application changes to accommodate their growth.
 
-Here are links to all the blog posts in the series:
-
-* **IaC Best Practices: Understanding Code Organization and Stacks** (this post)
-* [IaC Best Practices: Enabling Developer Stacks and Git Branches](/blog/iac-best-practices-enabling-developer-stacks-git-branches/)
-* [IaC Best Practices: Structuring Pulumi Projects](/blog/iac-best-practices-structuring-pulumi-projects/)
-* [IaC Best Practices: Applying Stack References](/blog/iac-best-practices-applying-stack-references/)
-* [IaC Best Practices: Implementing RBAC and Security](/blog/iac-best-practices-implementing-rbac-and-security/)
-* [IaC Best Practices: Using Automation API](/blog/iac-best-practices-using-automation-api/)
-* [IaC Best Practices: Summarizing Key Learnings](/blog/iac-best-practices-summarizing-key-learnings)
-
 ## Setting Up the Scenario
 
 Zephyr is short for Zephyr Archaeotech Emporium, the fictional company in our scenario. Zephyr is an online retailer that specializes in the sale of "rare arcane artifacts and replicas." Over the past few years, the company has experienced a significant increase in its online presence, making it easier for customers to purchase unique and mysterious items. Zephyr's collection includes a variety of rare and unusual objects that are difficult to find elsewhere, making it a popular destination for collectors, enthusiasts, and adventurers.

--- a/content/blog/iac-best-practices-using-automation-api/index.md
+++ b/content/blog/iac-best-practices-using-automation-api/index.md
@@ -20,16 +20,6 @@ Welcome to the sixth post in our series of blog posts focused on Infrastructure 
 
 The ultimate goal of this series is to discuss best practices for using Pulumi to manage a fairly complex containerized application. These practices have unfolded organically, as a direct response to Zephyr's evolving needs. The aim is to demonstrate that best practices are not set in stone, but are rather "point in time" recommendations that adapt as your company grows.
 
-For ease of navigation, here are links to all the posts in the series:
-
-* [IaC Best Practices: Understanding Code Organization and Stacks](/blog/iac-best-practices-understanding-code-organization-stacks/)
-* [IaC Best Practices: Enabling Developer Stacks and Git Branches](/blog/iac-best-practices-enabling-developer-stacks-git-branches/)
-* [IaC Best Practices: Structuring Pulumi Projects](/blog/iac-best-practices-structuring-pulumi-projects/)
-* [IaC Best Practices: Applying Stack References](/blog/iac-best-practices-applying-stack-references/)
-* [IaC Best Practices: Implementing RBAC and Security](/blog/iac-best-practices-implementing-rbac-and-security/)
-* **IaC Best Practices: Using Automation API** (you are here)
-* [IaC Best Practices: Summarizing Key Learnings](/blog/iac-best-practices-summarizing-key-learnings)
-
 ## Managing Complexity in a Multi-Project Pulumi Setup
 
 Over the course of this series, you've seen how Zephyr's use of Pulumi has grown and changed. For the sake of completeness, here's a quick recap:

--- a/content/blog/idp-strategy-planning-self-service-infrastructure-that-balances-developer-autonomy-with-operational-control/index.md
+++ b/content/blog/idp-strategy-planning-self-service-infrastructure-that-balances-developer-autonomy-with-operational-control/index.md
@@ -77,15 +77,6 @@ The good news? You can do both, with a clear strategy and the right approach. Th
 
 These lessons come from real-world implementations across industries and company sizes—and are built to grow with you.
 
-This post is part of our IDP Best Practices series. You can explore the full series below:
-
-- **How to Build an Internal Developer Platform: Strategy, Best Practices, and Self-Service Infrastructure** (you are here)
-- [Build Golden Paths: Guide to Reusable Infrastructure with Pulumi Components and Templates](/blog/golden-paths-infrastructure-components-and-templates/)
-- [Policy as Code for Safer IDPs: Enabling Developer Self-Service with Guardrails](/blog/deployment-guardrails-with-policy-as-code)
-- [Day 2 Operations: Drift Detection and Remediation](/blog/day-2-operations-drift-detection-and-remediation)
-- Extend Your IDP for AI Applications: GPUs, Models, and Cost Controls
-- Next-Gen IDPs: How to Modernize Legacy Infrastructure with Pulumi
-
 ## Understanding the Platform Engineering Layers in Your Internal Developer Platform
 
 ![internal-developer-platform-key-layers.png](internal-developer-platform-key-layers.png)

--- a/content/blog/managing-aws-credentials-on-cicd-part-1/index.md
+++ b/content/blog/managing-aws-credentials-on-cicd-part-1/index.md
@@ -42,16 +42,6 @@ The recommendations in this series describe a general "one-size fits most" appro
 management, which requires a minimal amount of work to configure and maintain. Depending on your
 specific environment, needs, and constraints, there may be a better alternative for your use case.
 
-Here's the full set of steps in our series, walking through the creation of a secure CI/CD environment
-to deploy AWS resources using Pulumi:
-
-- [Create a dedicated IAM User for your CI/CD](#create-new-iam-user)
-- [Provide the IAM User’s credentials to your CI/CD system](/blog/managing-aws-credentials-on-cicd-part-2#providing-iam-credentials)
-- [Comparison with using hosted secret managers](/blog/managing-aws-credentials-on-cicd-part-2#using-a-secrets-service)
-- [Automate Rotating and Revoking AWS Credentials](/blog/managing-aws-credentials-on-cicd-part-2#automating-key-rotation)
-- [Assuming IAM Roles for performing updates](/blog/managing-aws-credentials-on-cicd-part-3#assuming-iam-roles)
-- [Securing sensitive data using Pulumi](/blog/managing-aws-credentials-on-cicd-part-3#secrets-in-pulumi)
-
 ## Create a dedicated IAM User for your CI/CD {#create-new-iam-user}
 
 The first step for securely automating CI/CD is to create a dedicated IAM User for use in your CI/CD

--- a/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
+++ b/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
@@ -24,15 +24,6 @@ This article is the second part of a series on best practices for securely manag
 > [assume IAM Roles when running on an EC2 instance](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html)
 > instead.
 
-Posts in this series:
-
-- [Create a dedicated IAM User for your CI/CD](/blog/managing-aws-credentials-on-cicd-part-1#create-new-iam-user)
-- [Provide the IAM User’s credentials to your CI/CD system](/blog/managing-aws-credentials-on-cicd-part-2#providing-iam-credentials)
-- [Comparison with using hosted secret managers](/blog/managing-aws-credentials-on-cicd-part-2#using-a-secrets-service)
-- [Automate Rotating and Revoking AWS Credentials](/blog/managing-aws-credentials-on-cicd-part-2#automating-key-rotation)
-- [Assuming IAM Roles for performing updates](/blog/managing-aws-credentials-on-cicd-part-3#assuming-iam-roles)
-- [Securing sensitive data using Pulumi](/blog/managing-aws-credentials-on-cicd-part-3#secrets-in-pulumi)
-
 ## Provide IAM credentials to your CI/CD system {#providing-iam-credentials}
 
 In the [first post](/blog/managing-aws-credentials-on-cicd-part-1/) in our series, we created a dedicated IAM User to perform updates to AWS resources within your CI/CD system. The next step is to pass the AWS access keys for that user to your CI/CD system.

--- a/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
+++ b/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
@@ -18,15 +18,6 @@ This article is the third part of a series on best practices for securely managi
 last leg of the continuous delivery process to update your AWS resources and how to store sensitive data using Pulumi securely.
 <!--more-->
 
-Posts in this series:
-
-- [Create a dedicated IAM User for your CI/CD](/blog/managing-aws-credentials-on-cicd-part-1#create-new-iam-user)
-- [Provide the IAM User’s credentials to your CI/CD system](/blog/managing-aws-credentials-on-cicd-part-2#providing-iam-credentials)
-- [Comparison with using hosted secret managers](/blog/managing-aws-credentials-on-cicd-part-2#using-a-secrets-service)
-- [Automate Rotating and Revoking AWS Credentials](/blog/managing-aws-credentials-on-cicd-part-2#automating-key-rotation)
-- [Assuming IAM Roles for performing updates](#assuming-iam-roles)
-- [Securing sensitive data using Pulumi](#secrets-in-pulumi)
-
 ## Recap
 
 In [part 1](/blog/managing-aws-credentials-on-cicd-part-1/), we created a dedicated IAM User with


### PR DESCRIPTION
Several blog series carried a hand-maintained list of the other posts in the series near the top or bottom of each post body. This removes those redundant on-page tables of contents, leaving surrounding prose intact. Series navigation is still available on the auto-generated /blog/series/ pages.