### PR TITLE
ci: trust workprentice bot; open content-review PRs ready on lint pass

### DIFF
--- a/.claude/commands/pr-review/scripts/contributor-detection.sh
+++ b/.claude/commands/pr-review/scripts/contributor-detection.sh
@@ -62,9 +62,9 @@ case "$CONTRIBUTOR_TYPE" in
     # Strip "app/" prefix that gh returns for GitHub Apps so the match works
     BOT_NAME="${AUTHOR#app/}"
     BOT_NAME="${BOT_NAME%\[bot\]}"
-    # Known good bots get high; unknown bots get low. `workprentice` is Joe
-    # Duffy's docs-automation identity (the Docs Groundskeeper agent), trusted
-    # like an internal author.
+    # Known good bots get high; unknown bots get low. `workprentice` is a
+    # trusted first-party docs-automation identity (the Docs Groundskeeper
+    # agent), treated like an internal author.
     case "$BOT_NAME" in
       dependabot*|pulumi-bot|renovate*|copilot*|github-actions*|workprentice*)
         ETIQUETTE_TRUST="high"

--- a/.claude/commands/pr-review/scripts/contributor-detection.sh
+++ b/.claude/commands/pr-review/scripts/contributor-detection.sh
@@ -62,9 +62,11 @@ case "$CONTRIBUTOR_TYPE" in
     # Strip "app/" prefix that gh returns for GitHub Apps so the match works
     BOT_NAME="${AUTHOR#app/}"
     BOT_NAME="${BOT_NAME%\[bot\]}"
-    # Known good bots get high; unknown bots get low
+    # Known good bots get high; unknown bots get low. `workprentice` is Joe
+    # Duffy's docs-automation identity (the Docs Groundskeeper agent), trusted
+    # like an internal author.
     case "$BOT_NAME" in
-      dependabot*|pulumi-bot|renovate*|copilot*|github-actions*)
+      dependabot*|pulumi-bot|renovate*|copilot*|github-actions*|workprentice*)
         ETIQUETTE_TRUST="high"
         ;;
       *)

--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -16,8 +16,9 @@ You run **unprivileged**: the review job holds no push token, so you edit the
 working tree only — never `git commit`, `git push`, or `gh pr create`. The
 workflow's publish job validates your changes against a deterministic gate
 (`scripts/content-review/publish-gate.py`: verdict shape, diff scope,
-`no_retire`), derives the branch name from the queue, and opens the draft PR
-with the body you edited. Changes outside the gate's scope are rejected
+`no_retire`), derives the branch name from the queue, and opens the PR
+(ready when the re-lint passes, draft only on lint failure) with the body you
+edited. Changes outside the gate's scope are rejected
 wholesale, so keep every edit inside the bounds each step names.
 
 ## Input
@@ -277,18 +278,18 @@ separate commands) before opening the PR.
 
 ### 7. PR body — only when you applied a fix
 
-You do not open the PR — the publish job creates a **draft** PR to `master`
-whose body is `.pr-body-draft.md`, exactly as you leave it. You do **not**
-write that body from scratch: the workflow composed it (via
-`compose-pr-body.py`, the assemble-then-judge model — the composer ASSEMBLES
-facts, you JUDGE) with every section present and each pre-found finding
-pre-bucketed under a `<TODO>`. **Edit that draft** in place, resolve every
-`<TODO>`, and strip the HTML-comment hints. After opening the PR the workflow
-re-runs `make lint` on the published branch and **promotes the PR to ready
-only if lint passes** — that ready transition is what triggers triage and the
-docs review (a clean lint means it flows through the normal pipeline; a
-trivial fix is short-circuited there). A lint failure leaves the PR a draft
-with a comment for a human; humans merge. The sections (each is checked for):
+You do not open the PR — the publish job creates the PR to `master` whose body
+is `.pr-body-draft.md`, exactly as you leave it. You do **not** write that body
+from scratch: the workflow composed it (via `compose-pr-body.py`, the
+assemble-then-judge model — the composer ASSEMBLES facts, you JUDGE) with every
+section present and each pre-found finding pre-bucketed under a `<TODO>`. **Edit
+that draft** in place, resolve every `<TODO>`, and strip the HTML-comment hints.
+Before opening the PR the workflow runs the authoritative `make lint` on the
+published branch and **opens the PR ready for review only if lint passes** —
+opening ready is what triggers triage and the docs review (a clean lint means it
+flows through the normal pipeline; a trivial fix is short-circuited there). A
+lint failure opens the PR as a draft instead, with a comment for a human; humans
+merge. The sections (each is checked for):
 
 - **Auto-merge notice** (top `> [!IMPORTANT]` block): the re-lint gate arms
   GitHub auto-merge on the PR, so the body flags that approving merges it.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -451,10 +451,16 @@ jobs:
           AUTHOR="${{ steps.pr-context.outputs.author }}"
 
           # GitHub App bots are not collaborators, so the permission API
-          # below returns "none" for them. Trusted agent bots that open
-          # PRs on this repo are whitelisted by name instead. Keep this
-          # list in sync with the matching check in claude-triage.yml.
-          if [[ "$AUTHOR" == "github-copilot[bot]" || "$AUTHOR" == "eon-pulumi-agent[bot]" ]]; then
+          # below returns "none" for them. Trusted bots that open PRs on this
+          # repo are whitelisted by name instead. `workprentice` is Joe Duffy's
+          # docs-automation identity (the Docs Groundskeeper agent) and is
+          # trusted like an internal author. The author string differs by source:
+          # this workflow reads `gh pr view --json author` (`app/workprentice`)
+          # while claude-triage.yml reads the REST webhook `user.login`
+          # (`workprentice[bot]`), so both forms are listed in both files. Keep
+          # this list in sync with the matching check in claude-triage.yml.
+          if [[ "$AUTHOR" == "github-copilot[bot]" || "$AUTHOR" == "eon-pulumi-agent[bot]" \
+             || "$AUTHOR" == "app/workprentice" || "$AUTHOR" == "workprentice[bot]" ]]; then
             echo "has_write_access=true" >> $GITHUB_OUTPUT
             echo "✓ Bot $AUTHOR is whitelisted for Claude reviews"
             exit 0

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -24,9 +24,10 @@ jobs:
     #
     # Exception: content-review/* PRs are bot-authored but are first-class
     # automated docs fixes we DO want triaged and reviewed like any human PR
-    # (the worker opens them draft and promotes to ready on a clean re-lint, so
-    # triage fires on that ready transition). They flow through the normal
-    # triage → review chain instead of being force-dispatched.
+    # (the worker opens them ready when the re-lint passes — falling back to
+    # draft only on lint failure — so triage fires on the non-draft `opened`
+    # event). They flow through the normal triage → review chain instead of
+    # being force-dispatched.
     if: >-
       !github.event.pull_request.draft
       && github.event.pull_request.user.login != 'dependabot[bot]'
@@ -109,10 +110,16 @@ jobs:
           AUTHOR="${{ github.event.pull_request.user.login }}"
 
           # GitHub App bots are not collaborators, so the permission API
-          # below returns "none" for them. Trusted agent bots that open
-          # PRs on this repo are whitelisted by name instead. Keep this
-          # list in sync with the matching check in claude-code-review.yml.
-          if [[ "$AUTHOR" == "github-copilot[bot]" || "$AUTHOR" == "eon-pulumi-agent[bot]" ]]; then
+          # below returns "none" for them. Trusted bots that open PRs on this
+          # repo are whitelisted by name instead. `workprentice` is Joe Duffy's
+          # docs-automation identity (the Docs Groundskeeper agent) and is
+          # trusted like an internal author. The author string differs by source:
+          # this workflow reads the REST webhook `user.login` (`workprentice[bot]`)
+          # while claude-code-review.yml reads `gh pr view` (`app/workprentice`),
+          # so both forms are listed in both files. Keep this list in sync with
+          # the matching check in claude-code-review.yml.
+          if [[ "$AUTHOR" == "github-copilot[bot]" || "$AUTHOR" == "eon-pulumi-agent[bot]" \
+             || "$AUTHOR" == "workprentice[bot]" || "$AUTHOR" == "app/workprentice" ]]; then
             echo "has_write_access=true" >> $GITHUB_OUTPUT
             echo "✓ Bot $AUTHOR is whitelisted for triage"
             exit 0

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -545,12 +545,23 @@ jobs:
               || { echo "::error::fix-scope gate failed; report follows"; cat .fix-scope-report.json; exit 1; }
           fi
 
-      # Branch, push, and draft PR — the write half of what used to be the
+      # Branch, push, and open the PR — the write half of what used to be the
       # model's SKILL.md steps 1 and 7. The branch name comes from the gate
       # (queue slug + verdict retirement), never from the model, and the
       # applied paths are re-checked against the gate's scope rules after
       # `git apply` — the staged tree, not the patch text, is what ships.
-      - name: Create branch and draft PR
+      #
+      # We run the authoritative `make lint` on the applied tree BEFORE opening
+      # the PR — we don't trust the model's self-report that lint passed. On
+      # PASS the PR opens READY for review, which fires triage → review
+      # (content-review/* PRs flow through the normal triage → review chain; see
+      # claude-triage.yml / claude-code-review.yml). On FAIL it opens as a DRAFT
+      # so triage never fires, and the next step comments the lint output for a
+      # human. Either way the next step stamps the authoritative result into the
+      # PR body. Deciding ready-vs-draft at creation time (rather than opening a
+      # draft and promoting it) means a passing PR is born ready and never
+      # depends on a separate promotion transition firing.
+      - name: Create branch and PR
         id: publish
         if: steps.gate.outputs.publish == 'true'
         env:
@@ -581,22 +592,30 @@ jobs:
           # `|| true` covers the common case where the branch doesn't exist.
           git fetch origin "$BRANCH" || true
           git push --force-with-lease -u origin "$BRANCH"
-          gh pr create --draft --title "$TITLE" --body-file .pr-body-draft.md \
-            --base master --head "$BRANCH"
+          # Authoritative lint gate: open ready on PASS, draft on FAIL. The
+          # result is recorded as a step output so the next step can stamp the
+          # body and arm auto-merge / comment without re-running lint.
+          if make lint > .lint.log 2>&1; then
+            echo "lint passed on $BRANCH; opening PR ready for review (fires triage → review)"
+            echo "lint_result=passed" >> "$GITHUB_OUTPUT"
+            gh pr create --title "$TITLE" --body-file .pr-body-draft.md \
+              --base master --head "$BRANCH"
+          else
+            echo "::warning::make lint failed on $BRANCH; opening PR as draft"
+            echo "lint_result=failed" >> "$GITHUB_OUTPUT"
+            gh pr create --draft --title "$TITLE" --body-file .pr-body-draft.md \
+              --base master --head "$BRANCH"
+          fi
 
-      # Lint re-gate + ready promotion. The PR opens as a DRAFT and we don't
-      # trust the model's self-report that `make lint` passed: re-run lint on
-      # the applied tree ourselves. On PASS, promote the PR to ready — that
-      # draft→ready transition is what fires triage and the docs review
-      # (content-review/* PRs flow through the normal triage → review chain; see
-      # claude-triage.yml / claude-code-review.yml). On FAIL, leave it draft (so
-      # triage never fires) and comment the output for a human. Either way, stamp
-      # the authoritative result into the PR body's `<!-- LINT-RESULT -->`
-      # placeholder — this gate is the authority on lint, not the model. The
-      # ledger still records `reviewed`. Build is left to the PR's normal CI.
-      # On a ready PR we also arm GitHub auto-merge (squash); `master` requires
-      # 1 approval + the build check, so it merges only after a human approves.
-      - name: Re-lint, promote, and arm auto-merge
+      # Post-publish bookkeeping. The authoritative `make lint` already ran in
+      # the publish step and decided whether the PR opened ready (PASS) or draft
+      # (FAIL); here we stamp that result into the PR body's `<!-- LINT-RESULT -->`
+      # placeholder — this gate is the authority on lint, not the model — and,
+      # on PASS, arm GitHub auto-merge (squash). On FAIL we comment the lint
+      # output for a human. The ledger still records `reviewed`. Build is left
+      # to the PR's normal CI. `master` requires 1 approval + the build check,
+      # so auto-merge never merges on its own.
+      - name: Stamp lint result and arm auto-merge
         id: lint
         if: steps.publish.outcome == 'success' && steps.gate.outputs.publish == 'true'
         continue-on-error: true
@@ -611,11 +630,9 @@ jobs:
             python3 scripts/content-review/stamp-lint-result.py \
               --branch "$BRANCH" --result "$1" --sha "$(git rev-parse --short HEAD)" || true
           }
-          if make lint > .lint.log 2>&1; then
-            echo "lint passed on $BRANCH; promoting draft → ready (fires triage → review)"
+          if [ "${{ steps.publish.outputs.lint_result }}" = "passed" ]; then
             stamp_body passed
-            gh pr ready "$BRANCH" || echo "::warning::could not promote $BRANCH to ready"
-            # Arm auto-merge (squash) on the now-ready PR. `master` requires 1
+            # Arm auto-merge (squash) on the ready PR. `master` requires 1
             # approving review AND the "Install deps and build site" check, so
             # this NEVER merges on its own — the PR merges only once a human
             # approves and the build is green, which just removes the manual
@@ -624,10 +641,9 @@ jobs:
             gh pr merge "$BRANCH" --auto --squash \
               || echo "::warning::could not enable auto-merge on $BRANCH"
           else
-            echo "::warning::make lint failed on $BRANCH; leaving PR as draft"
             stamp_body failed
             {
-              echo "Automated review note: \`make lint\` failed on this branch, so the PR was left as a draft and no review was triggered. Lint output:"
+              echo "Automated review note: \`make lint\` failed on this branch, so the PR was opened as a draft and no review was triggered. Lint output:"
               echo ""
               echo '```'
               tail -c 4000 .lint.log

--- a/.gitignore
+++ b/.gitignore
@@ -117,10 +117,14 @@ _vendor/
 /.lint.log
 /.lint-comment.md
 # Review→publish handoff (the unprivileged review job exports the model's
-# working-tree changes; the publish job re-checks the applied paths).
+# working-tree changes; the publish job re-checks the applied paths). The
+# publish job also downloads the pre-compute artifacts into `.review-snapshot/`
+# and writes the fix-scope report; keep both out of git (and prettier).
 /.review-changes.patch
 /.review-changes.paths
 /.applied.paths
+/.fix-scope-report.json
+/.review-snapshot/
 # docs-review pre-computation artifacts the worker generates before the
 # review (claim extraction/verification, Vale, frontmatter, cross-sibling,
 # readthrough).

--- a/.prettierignore
+++ b/.prettierignore
@@ -65,7 +65,10 @@ static/js
 # Content-review / docs-review pre-compute artifacts (gitignored, generated at
 # runtime). The content-review worker re-runs `make lint` on the fix branch in a
 # workspace that still holds these scratch files; without this, `prettier
-# --check .` flags them and the re-gate false-fails.
+# --check .` flags them and the re-gate false-fails. This must cover BOTH the
+# root-level artifacts AND the `.review-snapshot/` directory (which holds copies
+# of the same JSONs, downloaded as a workflow artifact into the publish job) plus
+# the fix-scope report — otherwise lint false-fails and the PR is stuck in draft.
 /.synthetic.patch
 /.fetched-urls.json
 /.candidate-claims*.json
@@ -76,6 +79,8 @@ static/js
 /.vale-raw.json
 /.vale-findings.json
 /.content-review-*.json
+/.fix-scope-report.json
+/.review-snapshot/
 /.pr-body-draft.md
 /.lint.log
 /.lint-comment.md

--- a/scripts/content-review/stamp-lint-result.py
+++ b/scripts/content-review/stamp-lint-result.py
@@ -38,7 +38,7 @@ def marker(result: str, sha: str) -> str:
     if result == "passed":
         return f"✅ `make lint` re-verified by the workflow on `{sha}`"
     return (
-        f"❌ `make lint` FAILED on `{sha}` — PR returned to draft; "
+        f"❌ `make lint` FAILED on `{sha}` — PR opened as a draft; "
         "see the automated lint comment on this PR"
     )
 


### PR DESCRIPTION
### Proposed changes

Two independent tweaks to the content and PR-review automation.

**1. Treat `workprentice[bot]` as a trusted internal author.**

`workprentice` is Joe Duffy's docs-automation identity (the Docs Groundskeeper backlog-burndown agent). Because it's a GitHub App, it isn't a repo *collaborator*, so the `has_write_access` collaborator-permission check returns `none` for it. Both `claude-triage.yml` and `claude-code-review.yml` whitelist trusted App bots **by author name** to work around this — but that whitelist only knew `github-copilot[bot]` and `eon-pulumi-agent[bot]`. When `workprentice` opened a PR, `has_write_access` resolved `false`, the Claude review/triage steps were silently skipped, and the "Pre-merge Review" check reported a generic failure with no path to green — permanently blocking otherwise-mergeable PRs on `REVIEW_REQUIRED`. (PRs the bot opens *as* `joeduffy` were unaffected; only directly bot-authored PRs stuck.)

- Added `workprentice` to the name-whitelist in both workflows. The two files read the author from different sources, so both observed forms are listed in each: `workprentice[bot]` (the REST webhook `user.login` that `claude-triage.yml` reads) and `app/workprentice` (what `gh pr view --json author` returns for App bots, which `claude-code-review.yml` reads). Listing both in both files keeps the two "keep in sync" lists identical and hedges the format difference.
- Added `workprentice*` to the high-trust bot list in the `/pr-review` skill's `contributor-detection.sh` so the interactive maintainer flow treats it as trusted too.
- No repo change is needed to make the *build* run — `workprentice` is an App installed on the repo, so it pushes in-repo branches and already clears `pull-request.yml`'s same-repo gate. The review/triage whitelist was the only blocker.

**2. Open content-review PRs ready for review on the success path.**

The automated existing-content review workflow (`content-review-article.yml`) created its PR as a draft and only promoted it to ready if a post-publish `make lint` re-check passed. That draft-first design risks leaving PRs stuck if the promotion transition doesn't fire. The publish job now runs the authoritative `make lint` on the applied tree **before** `gh pr create`:

- lint **pass** → PR opens **ready for review** (fires triage → review directly, no draft→promote step).
- lint **fail** → PR opens as a **draft** with a lint-output comment (unchanged safety fallback).

Auto-merge stays gated on lint pass, so a lint-failing PR can never auto-merge. The follow-on step now stamps the recorded lint result and arms auto-merge / comments without re-running lint or promoting. Stale draft-flow wording was updated in the workflow comments, the `review-existing-content` SKILL.md, and `stamp-lint-result.py`.

### Unreleased product version (optional)

N/A — CI workflow and agent-skill changes only; no product docs touched.

### Related issues (optional)

Addresses the `workprentice`-bot review-gate blocker also described in #20368 (that PR is the bot's own stuck attempt at the same fix).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MrPmnKsUpAKG5iwie3ceCr)_