### PR TITLE
Name the models that power Neo on the AI overview page

### DIFF
--- a/content/docs/ai/_index.md
+++ b/content/docs/ai/_index.md
@@ -29,7 +29,7 @@ sections:
   description_md: |
     Pulumi is built to be driven by AI agents, including the coding agents your team already uses. Because Pulumi infrastructure is real code with a verifiable plan for every change, agents like Claude Code, Codex, Cursor, and GitHub Copilot can write, preview, and deploy it directly. The [Pulumi CLI](/docs/iac/cli/) is designed for them: run any command with `npx pulumi`, perform one-shot resource operations with [`pulumi do`](/docs/iac/cli/direct-resource-operations/), and parse structured `--json` output. [Pulumi Agent Skills](/docs/ai/skills/) teach agents proven Pulumi workflows, the [Pulumi MCP server](/docs/ai/mcp-server/) offers the same reach over MCP, and [agent accounts](/docs/administration/organizations-teams/agent-accounts/) remove signup friction entirely.
 
-    Pulumi Neo is Pulumi's own infrastructure agent. It ships with these skills built in, and adds organizational context, policy guardrails, human-in-the-loop approvals, and scheduled autonomous work. Use your favorite agent, use Neo, or use both together: Neo for long-running, governed infrastructure tasks, and your coding agent for interactive development.
+    Pulumi Neo is Pulumi's own infrastructure agent, powered by Anthropic's Claude family of models accessed via Amazon Bedrock. It ships with these skills built in, and adds organizational context, policy guardrails, human-in-the-loop approvals, and scheduled autonomous work. Use your favorite agent, use Neo, or use both together: Neo for long-running, governed infrastructure tasks, and your coding agent for interactive development.
 
 - type: button-cards
   heading: Bring your own agent


### PR DESCRIPTION
Customers ask which models power Neo during security reviews, and the public docs never said (#20391). This adds the answer to the Neo overview paragraph on `/docs/ai/`: Neo is powered by Anthropic's Claude family of models accessed via Amazon Bedrock.

Both claims were verified against the pulumi-service source: the agent's model constants and default are Claude models (`cmd/agents/src/agents_py/constants.py`), and production inference goes through the Bedrock client (`cmd/agents/src/agents_py/llm_client.py`, with Bedrock inference-profile IDs normalized in `cmd/service/product/metering/neo.go`).