### PR TITLE
Document the maintainer rubber-stamp sweep, blog adjudication policy, and needs-product-review label

### DIFF
--- a/.github/labels-pr-review.md
+++ b/.github/labels-pr-review.md
@@ -33,6 +33,7 @@ Load-bearing — these gate workflow execution.
 | `review:stale` | `ededed` | New commits landed since the last Claude review; refresh on next ready-transition or `@claude` mention. |
 | `review:error` | `e11d21` | Workflow failed before publishing a review. See the Actions logs. |
 | `needs-author-response` | `f7c6c7` | Review surfaced unverifiable claims; author needs to provide sources or fix. Applied by `pr-review`. |
+| `needs-product-review` | `d876e3` | Blog post needs a named product/launch/security sign-off (pricing, security claims, embargoed launches, case studies). Applied by the author or a maintainer; the maintainer rubber-stamp sweep skips labeled PRs — the requested human owns the approval. |
 
 The six `review:*` state labels are **mutually exclusive**. Setting one removes the others. `set-review-label.sh` (under `.claude/commands/docs-review/scripts/`) enforces this atomically and supports a `--clear` mode that strips any state label without adding a new one (used by claude-triage.yml's `if: always()` cleanup).
 
@@ -57,6 +58,7 @@ gh label create "review:no-blockers"     --color 0e8a16 --description "Claude re
 gh label create "review:stale"           --color ededed --description "New commits since last Claude review; refresh on next ready-transition or @claude mention"
 gh label create "review:error"           --color e11d21 --description "Workflow failed before publishing a review; see Actions logs"
 gh label create "needs-author-response"  --color f7c6c7 --description "Review surfaced unverifiable claims; author owes a response"
+gh label create "needs-product-review"   --color d876e3 --description "Blog post needs a named product/launch/security sign-off; the rubber-stamp sweep skips it"
 ```
 
 ## Migrate from the old two-label scheme

--- a/BLOGGING.md
+++ b/BLOGGING.md
@@ -335,6 +335,15 @@ Before submitting your post:
 
 Once merged to master, your post will go live on <https://www.pulumi.com/> (after its publish date).
 
+### Getting approved
+
+You merge your own PR once a maintainer approves. For most posts, approval comes to you: when your PR is ready for review, the automated review shows `review:no-blockers`, and CI is green, a scheduled maintainer sweep approves it with a one-line rubber-stamp comment — usually within a business day, no reviewer request needed. If the review flags outstanding findings, resolve them (see `CONTRIBUTING.md` § After review) and the sweep picks the PR up on a later pass.
+
+Two cases where a human approval is the point:
+
+- **Needs a product/launch/security sign-off** (pricing announcements, security feature claims, embargoed launches, case studies): apply the **`needs-product-review`** label and request the person who owns that sign-off. The sweep skips the PR entirely and leaves it to them.
+- **You requested a specific reviewer**: the sweep defers to them — it never approves around a human you asked for.
+
 ## A Note on Dates and Scheduling for Future Publishing
 
 ### How `draft` and `date` behave across environments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,17 @@ For both categories, triage runs a focused spelling/grammar pass on the relevant
 
 Classification is deterministic and lives in `.claude/commands/docs-review/scripts/triage-classify.py` — domain (path-precedence), triviality, and frontmatter-only detection are all path/grep rules. The model is invoked only for the prose check, only when the shell pre-classifies as trivial or frontmatter-only.
 
+### Adjudication and merge
+
+Pulumi convention: **authors merge their own PRs** after a maintainer approves. Approval is driven by the pinned review, and for clean PRs it usually arrives without you asking: a scheduled maintainer sweep approves ready PRs that are `review:no-blockers` with green CI — docs, infra, **and blog posts** — leaving a fixed one-line rubber-stamp comment. You don't need to request a reviewer to get unblocked; mark the PR ready, get the review green, and the sweep will find it. (The sweep is deliberately cautious: it punts anything oversized, sensitive, or resting on claims it can't confirm to a human instead of approving.)
+
+Two blog-specific carve-outs:
+
+- **`needs-product-review`** — apply this label (and request the reviewer you have in mind) when a post needs a named product, launch, or security sign-off before publishing: pricing/packaging announcements, security feature claims, embargoed launches, case studies. The sweep skips labeled PRs entirely; the human you asked owns the approval.
+- If you've **requested any human reviewer** on a blog PR, the sweep defers to them and won't approve around them.
+
+A ready PR with **no `review:*` label at all** fell through the pipeline (this predates the current tooling, or triage errored). The sweep flags these for manual triage rather than reviewing them — comment `@claude #new-review` to generate a fresh review and rejoin the normal flow.
+
 ## Documentation structure
 
 The mapping from documentation page to section and table-of-contents (TOC) is stored largely in each page's front matter, leveraging [Hugo Menus](https://gohugo.io/content-management/menus/). Menus for the CLI commands and API reference are specified in `./config.toml`.


### PR DESCRIPTION
### Proposed changes

Green blog PRs with no requested reviewer currently have no path to approval: CODEOWNERS is disabled, nothing requests reviewers at ready-for-review, and the scheduled maintainer sweep deliberately excluded `domain:blog` from its no-blockers lane -- so posts sat green and unapproved for weeks (e.g. #20085, and #18864 since May). The sweep now covers blog posts (companion change in CamSoper/claude-plugins#58); this PR documents the policy on the repo side:

- **CONTRIBUTING.md** -- new "Adjudication and merge" section under AI-assisted contributions: authors merge their own PRs after approval; a scheduled maintainer sweep approves ready `review:no-blockers` + green-CI PRs (docs, infra, and blog) with a fixed rubber-stamp comment; `needs-product-review` opts a post into a named human sign-off; a requested human reviewer is always deferred to; unlabeled orphan PRs get flagged for manual triage (`@claude #new-review`) instead of approved.
- **BLOGGING.md** -- author-facing "Getting approved" section with the same rules.
- **.github/labels-pr-review.md** -- `needs-product-review` label definition and its `gh label create` line. (The label itself still needs creating on the repo -- it's in the doc's one-liner block; the sweep degrades safely until then.)

### Unreleased product version (optional)

n/a

### Related issues (optional)

Companion: CamSoper/claude-plugins#58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TT5AckhrqGwMb3MnNPt8Hb

---
_Generated by [Claude Code](https://claude.ai/code/session_01TT5AckhrqGwMb3MnNPt8Hb)_