### PR TITLE
blog: date-only publish date for kubernetes-agent-sandbox

### DIFF
--- a/content/blog/kubernetes-agent-sandbox/index.md
+++ b/content/blog/kubernetes-agent-sandbox/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Kubernetes Agent Sandbox: What It Is and How to Deploy It with Pulumi"
-date: 2026-07-21T08:00:00-05:00
+date: 2026-07-21
 draft: false
 meta_desc: "Agent Sandbox gives AI agents kernel-isolated, disposable environments as Kubernetes resources. Here's what it is and how to deploy it on GKE with Pulumi."
 meta_image: feature.png


### PR DESCRIPTION
The post was future-dated 2026-07-21T08:00:00-05:00; the -05:00 offset means 9am EDT, which lands after both morning scheduled rebuilds, so the post wouldn't appear until the afternoon build. Date-only means it publishes on the next build.