### PR TITLE
ci: allow workprentice bot through claude-code-action's actor gate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -955,7 +955,15 @@ jobs:
           # (workflow_run after triage) is gated by claude-triage.yml's
           # own access checks, so opening this door doesn't widen the
           # trust surface.
-          allowed_bots: 'github-actions[bot]'
+          #
+          # workprentice is also listed: it's a whitelisted PR author (see
+          # the has_write_access step above), and on the auto-fire path a
+          # push by the bot makes it the workflow_run's triggering actor,
+          # which claude-code-action@v1 checks independently of our own
+          # gate. Both the bare and `[bot]`-suffixed forms are listed
+          # because the action reports the actor as bare `workprentice`
+          # while github.actor renders it as `workprentice[bot]`.
+          allowed_bots: 'github-actions[bot],workprentice,workprentice[bot]'
           # Initial review uses Opus; re-entrant updates (via @claude mentions)
           # use Sonnet — see .github/workflows/claude.yml.
           # The CI prompt lives at .claude/commands/docs-review/ci.md and is


### PR DESCRIPTION
### Proposed changes

Today's PRs from workprentice[bot] (#20413, #20418) errored out of the Pre-merge Review workflow with the `review:error` label. The Actions logs show `claude-code-action@v1` aborting before doing any work:

```
Action failed with error: Workflow initiated by non-human actor: workprentice (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

There are two bot gates in the review pipeline, and #20368 only fixed the first:

1. The workflow's own `has_write_access` author whitelist — fixed by #20368, which is why the review step now launches for workprentice PRs instead of silently skipping.
2. `claude-code-action@v1`'s independent trigger-actor check, driven by the `allowed_bots` input — still only `github-actions[bot]`. On the auto-fire path (`workflow_run` after triage), a push by workprentice makes the bot the run's triggering actor, so the action exits 1 and the finalize steps mark the check-run failed and apply `review:error`.

(Yesterday's workprentice PRs #20367/#20375/#20380 reviewed fine only because those runs were re-triggered by a human right after #20368 landed, so the actor was human and the action's gate never fired.)

This PR adds workprentice to `allowed_bots`, listing both the bare and `[bot]`-suffixed forms since the action reports the actor as bare `workprentice` while `github.actor` renders `workprentice[bot]`. Once merged, the two stuck PRs can be retried by flipping draft → ready or commenting `@claude #update-review`.

### Unreleased product version (optional)

N/A

### Related issues (optional)

Follow-up to #20368. Unblocks reviews on #20413 and #20418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fVzfkjx4HnUEfn9NiP6by

---
_Generated by [Claude Code](https://claude.ai/code/session_017fVzfkjx4HnUEfn9NiP6by)_