### PR TITLE
blog: fix malformed figcaption in kubernetes-agent-sandbox

### DIFF
--- a/content/blog/kubernetes-agent-sandbox/index.md
+++ b/content/blog/kubernetes-agent-sandbox/index.md
@@ -73,7 +73,7 @@ spec:
           command: ["sleep", "infinity"]
 ```
 
-{{< figcaption >}}The `Sandbox` CRD, the whole idea in one manifest.{{< /figcaption >}}
+{{< figcaption >}}The <code>Sandbox</code> CRD, the whole idea in one manifest.{{< /figcaption >}}
 
 There are two common patterns for using it. In the first, every coding agent session in the organization maps to its own pod with a persistent volume, basically Claude Code running across a whole fleet of pods, each one an individual user's session.
 


### PR DESCRIPTION
Follow-up to #20383, addressing @janetkuo's review nit: the `Sandbox` in the figure caption didn't render as code.

The `figcaption` shortcode outputs `.Inner` raw (no markdownify), so the backticks showed up literally. Switched to `<code>Sandbox</code>`.