### PR TITLE
Add cloud-agnostic getting-started overview and connect-cloud page

### DIFF
--- a/content/docs/get-started/_index.md
+++ b/content/docs/get-started/_index.md
@@ -1,6 +1,6 @@
 ---
 title_tag: Get Started with Pulumi
-meta_desc: Step-by-step guides for creating, deploying, and managing infrastructure with Pulumi on the cloud using your favorite language.
+meta_desc: Learn the five steps to get started with Pulumi — install the CLI, connect your cloud account, write a program, deploy, and iterate — then pick your cloud.
 title: Get Started #Breadcrumb
 h1: Get Started with Pulumi # Page title
 no_on_this_page: true
@@ -22,7 +22,32 @@ Pulumi is a modern [infrastructure as code](/what-is/what-is-infrastructure-as-c
 
 Pulumi IaC is free, [open source](https://github.com/pulumi/pulumi), and optionally pairs with [Pulumi Cloud](/docs/iac/guides/basics/pulumi-cloud-vs-oss/) to make managing infrastructure secure, reliable, and hassle-free.
 
-Choose a cloud provider to get started:
+## Why Pulumi
+
+- **Use a real programming language.** Define infrastructure in TypeScript, Python, Go, C#, Java, or YAML — with loops, functions, testing, and full IDE support instead of a domain-specific language.
+- **See every change before it happens.** Pulumi previews exactly what will be created, updated, or deleted before anything touches your cloud account.
+- **Keep your existing credentials.** Pulumi has no credential system of its own — it uses the cloud access you already have, so there's nothing new to set up or secure.
+
+For the full story, see [What is Pulumi?](/what-is/what-is-pulumi/).
+
+## How getting started works
+
+Getting started follows the same five steps on every cloud; only the provider details differ.
+
+```mermaid
+flowchart LR
+    A["1. Install the CLI"] --> B["2. Connect your cloud account"] --> C["3. Write a program"] --> D["4. Deploy"] --> E["5. Iterate and evolve"]
+```
+
+1. **Install the Pulumi CLI.** [Install Pulumi](/docs/install/) with your operating system's package manager or a one-line installer script. One CLI covers every cloud and every language.
+1. **Connect your cloud account.** Pulumi authenticates to your cloud the same way your cloud provider's own CLI does — if that already works on your machine, you're done. See [Connect your cloud account](/docs/get-started/connect-cloud/) for how this works and how to set it up.
+1. **Write a program.** Run `pulumi new` to scaffold a project from a template in your language of choice, then declare cloud resources as code.
+1. **Deploy.** Run `pulumi up` to preview the planned changes and then apply them. Pulumi records what it created in a [stack](/docs/iac/concepts/stacks/), an isolated, configurable instance of your program — see [How Pulumi Works](/docs/iac/guides/basics/how-pulumi-works/) for the details.
+1. **Iterate and evolve.** Change your code and run `pulumi up` again — Pulumi computes the difference and applies only what changed. When you're done experimenting, `pulumi destroy` tears everything down cleanly.
+
+## Choose your cloud
+
+Ready to begin? Choose a cloud provider and complete the full tutorial:
 
 <section class="docs-home mt-4 mb-12">
     <div class="docs-home-section">
@@ -63,6 +88,8 @@ Choose a cloud provider to get started:
     </div>
 </section>
 
+Coming from Terraform? See [Pulumi for Terraform Users](/docs/iac/get-started/terraform/) to use Pulumi alongside your existing Terraform infrastructure.
+
 ## Learn more
 
 The following sections are also useful when first learning how to use Pulumi:
@@ -77,3 +104,5 @@ The following sections are also useful when first learning how to use Pulumi:
         <p>Learn how to support, migrate, or convert existing cloud infrastructure with Pulumi.</p>
     </div>
 </div>
+
+Beyond IaC, the Pulumi platform also includes [Pulumi ESC](/docs/esc/get-started/) for centralized secrets and configuration and [Pulumi Deployments](/docs/deployments/get-started/) for git-driven deployment workflows.

--- a/content/docs/get-started/connect-cloud.md
+++ b/content/docs/get-started/connect-cloud.md
@@ -32,7 +32,7 @@ Run your cloud's identity check. If it prints your account, identity, or cluster
 
 ## Set up access for your cloud
 
-If the check above didn't succeed — or you'd like to review the details — each getting started guide has a configuration page for its cloud. These pages are part of the full tutorial flow, so the Previous and Next buttons on each page take you back to installing Pulumi or onward to creating and deploying your first project.
+If the check above didn't succeed — or you'd like to review the details — each getting started guide has a configuration page for its cloud. Each of those pages is part of its cloud's full tutorial flow, and its Previous and Next buttons take you back to installing Pulumi or onward to creating and deploying your first project.
 
 <section class="docs-home mt-4 mb-12">
     <div class="docs-home-section">
@@ -79,5 +79,5 @@ Long-lived static keys are the most common source of credential leaks. [Pulumi E
 
 ## Next steps
 
-1. Pick your cloud above and continue its getting started flow — configuration is step 3 of the tutorial.
+1. Pick your cloud above to configure access, then continue that cloud's tutorial to create and deploy your first project.
 1. New to Pulumi entirely? Start from the [getting started overview](/docs/get-started/).

--- a/content/docs/get-started/connect-cloud.md
+++ b/content/docs/get-started/connect-cloud.md
@@ -1,0 +1,83 @@
+---
+title_tag: Connect Pulumi to Your Cloud Account
+meta_desc: Pulumi uses your existing AWS, Azure, Google Cloud, or Kubernetes credentials — no separate credential system. Learn how to check and configure cloud access.
+title: Connect Your Cloud Account
+h1: Connect Your Cloud Account
+menu:
+    get-started:
+        name: Connect Your Cloud Account
+        parent: get-started-home
+        weight: 2
+        identifier: get-started-connect-cloud
+---
+
+Pulumi has no credential system of its own. It authenticates to your cloud the same way your cloud provider's own CLI and SDKs do — using the same environment variables, configuration files, and identity mechanisms. If your cloud provider's CLI already works on your machine, Pulumi already has everything it needs.
+
+## How Pulumi authenticates
+
+Each Pulumi provider uses the cloud vendor's official SDK and its standard credential chain, so any authentication method your cloud supports — CLI login, environment variables, instance profiles, workload identity — works with Pulumi unchanged. You can also set credentials explicitly for an individual [stack](/docs/iac/concepts/stacks/) using [provider configuration](/docs/iac/concepts/config/).
+
+For the full range of options per provider, see the setup pages for [AWS](/registry/packages/aws/installation-configuration/), [Azure](/registry/packages/azure-native/installation-configuration/), [Google Cloud](/registry/packages/gcp/installation-configuration/), and [Kubernetes](/registry/packages/kubernetes/installation-configuration/).
+
+## Check whether you're already connected
+
+Run your cloud's identity check. If it prints your account, identity, or cluster details, Pulumi can already manage resources there and you can continue straight to writing your program.
+
+| Cloud | Command | Success looks like |
+| --- | --- | --- |
+| AWS | `aws sts get-caller-identity` | Your user ID, account, and ARN are printed |
+| Azure | `az account show` | Your subscription and tenant details are printed |
+| Google Cloud | `gcloud config list` | Your active account and project are printed |
+| Kubernetes | `kubectl cluster-info` | Your cluster's control plane address is printed |
+
+## Set up access for your cloud
+
+If the check above didn't succeed — or you'd like to review the details — each getting started guide has a configuration page for its cloud. These pages are part of the full tutorial flow, so the Previous and Next buttons on each page take you back to installing Pulumi or onward to creating and deploying your first project.
+
+<section class="docs-home mt-4 mb-12">
+    <div class="docs-home-section">
+        <div class="cards-logo-label-link clouds">
+            <a data-track="connect-aws-configure" href="/docs/iac/get-started/aws/configure/">
+                <div class="card-icon">
+                    <div class="icon aws-40"></div>
+                </div>
+                <div class="label">
+                    <span class="text-sm text-gray-800 dark:text-gray-300">Configure access to AWS &rarr;</span>
+                </div>
+            </a>
+            <a data-track="connect-azure-configure" href="/docs/iac/get-started/azure/configure/">
+                <div class="card-icon">
+                    <div class="icon azure-40"></div>
+                </div>
+                <div class="label">
+                    <span class="text-sm text-gray-800 dark:text-gray-300">Configure access to Azure &rarr;</span>
+                </div>
+            </a>
+            <a data-track="connect-google-configure" href="/docs/iac/get-started/gcp/configure/">
+                <div class="card-icon">
+                    <div class="icon google-cloud-40"></div>
+                </div>
+                <div class="label">
+                    <span class="text-sm text-gray-800 dark:text-gray-300">Configure access to Google Cloud &rarr;</span>
+                </div>
+            </a>
+            <a data-track="connect-kubernetes-configure" href="/docs/iac/get-started/kubernetes/configure/">
+                <div class="card-icon">
+                    <div class="icon kubernetes-40"></div>
+                </div>
+                <div class="label">
+                    <span class="text-sm text-gray-800 dark:text-gray-300">Configure access to Kubernetes &rarr;</span>
+                </div>
+            </a>
+        </div>
+    </div>
+</section>
+
+## Best practice: short-lived credentials with Pulumi ESC
+
+Long-lived static keys are the most common source of credential leaks. [Pulumi ESC](/docs/esc/) can mint short-lived cloud credentials on demand via OpenID Connect (OIDC), so nothing sensitive lives on your workstation or in CI. See the ESC login providers for [AWS](/docs/esc/providers/login/aws-login/), [Azure](/docs/esc/providers/login/azure-login/), and [Google Cloud](/docs/esc/providers/login/gcp-login/).
+
+## Next steps
+
+1. Pick your cloud above and continue its getting started flow — configuration is step 3 of the tutorial.
+1. New to Pulumi entirely? Start from the [getting started overview](/docs/get-started/).


### PR DESCRIPTION
### Proposed changes

Out of a UX-crit discussion ([Slack thread](https://pulumi.slack.com/archives/C0A84RUU2SH/p1784653681631779)): the getting-started funnel had no cloud-agnostic end-to-end explanation, and the "configure credentials" step is our biggest dropoff with only cloud-specific pages.

**1. Rebuilt `/docs/get-started/` landing page** (`content/docs/get-started/_index.md`)

- Light "Why Pulumi" value-prop section (3 bullets + link to `/what-is/what-is-pulumi/`)
- New "How getting started works" section: a Mermaid flowchart plus a numbered five-step journey (install → connect your cloud account → write a program → deploy → iterate), each step cloud-agnostic with links into the relevant docs
- Existing four cloud fan-out cards preserved verbatim (same `data-track` values, icons, and markup)
- Added a link to the previously orphaned [Pulumi for Terraform Users](https://www.pulumi.com/docs/iac/get-started/terraform/) flow and links to ESC/Deployments get-starteds under Additional resources
- Frontmatter, menu, and all six aliases unchanged (sharpened `meta_desc` only)

**2. New `/docs/get-started/connect-cloud/` page** (`content/docs/get-started/connect-cloud.md`)

A generic credentials explainer targeting the dropoff step. Leads with the key reassurance — Pulumi has no credential system of its own; it uses your cloud CLI's existing credentials — then:

- How authentication works (official SDK credential chains, per-stack provider config)
- An identity-check command table (`aws sts get-caller-identity`, `az account show`, `gcloud config list`, `kubectl cluster-info`) matching the commands the per-cloud configure pages use
- Card fan-out into each cloud's existing `configure` step, with **new** `data-track` values (`connect-*-configure`) so landing-page analytics stay clean
- ESC OIDC short-lived credentials best-practice pointer, mirroring the notes already on the per-cloud pages

Joins the left nav under Getting Started via frontmatter only — no `layouts/` or `data/` changes, no changes to the per-cloud flows. A follow-up PR will consolidate the near-identical per-cloud flow steps into shortcodes.

Verification: markdown lint passes (0 errors), prettier clean; per-cloud configure targets and stepper untouched.
