### PR TITLE
Add changed-page links to PR preview comments

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -35,6 +35,30 @@ post_github_pr_comment() {
          $pr_comment_api_url > /dev/null
 }
 
+# Converts a Hugo content file path to its published, root-relative URL, following
+# the same rules the site uses: strip the leading "content/", strip the ".md"
+# extension, collapse section landing pages ("/_index") and leaf-bundle pages
+# ("/index") to their directory, and guarantee a leading and trailing slash.
+# Usage:
+#   content_path_to_url content/docs/foo/bar.md          # => /docs/foo/bar/
+#   content_path_to_url content/blog/my-post/index.md    # => /blog/my-post/
+#   content_path_to_url content/_index.md                # => /
+content_path_to_url() {
+    local path=$1
+
+    path="${path#content/}"     # Strip the leading content/ prefix.
+    path="${path%.md}"          # Strip the trailing .md extension.
+
+    if [[ "$path" == "_index" || "$path" == "index" ]]; then
+        path=""                 # Site root (content/_index.md).
+    else
+        path="${path%/_index}"  # Collapse section landing pages (_index.md).
+        path="${path%/index}"   # Collapse leaf-bundle pages (index.md).
+    fi
+
+    echo "/${path}/" | sed 's#//*#/#g'
+}
+
 # Returns the Git SHA of the HEAD commit. For pull requests, we take this from GitHub event metadata, since in that case, the HEAD commit will contain the SHA of the merge commit with the base branch.
 git_sha() {
     if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; then

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -123,7 +123,48 @@ aws s3api put-bucket-cors --bucket "$destination_bucket" --cors-configuration "f
 if [[ "$1" == "preview" ]]; then
     pr_comment_api_url="$(cat "$GITHUB_EVENT_PATH" | jq -r ".pull_request._links.comments.href")"
     repo_api_url="$(cat "$GITHUB_EVENT_PATH" | jq -r ".pull_request.base.repo.url")"
-    preview_body="<!-- preview-link -->"$'\n'"Your site preview for commit $(git_sha_short) is ready! :tada:"$'\n\n'"${s3_website_url}"
+    pr_number="$(cat "$GITHUB_EVENT_PATH" | jq -r ".number")"
+
+    # Build a list of direct links to the pages this PR changed, to make reviewing
+    # easier. The base branch isn't available locally (CI does a shallow checkout),
+    # so we ask the GitHub API which files changed rather than diffing. We then map
+    # each changed content file to its published URL and keep only those that
+    # actually rendered to a page in this build (guards against removed files,
+    # non-page content, and url:/permalinks overrides — anything that doesn't
+    # resolve to a real page is simply left out rather than linked as a dead URL).
+    max_listed_pages=50         # Cap the rendered list so huge PRs stay readable.
+    max_files_pages=10          # Cap API pagination (10 * 100 = up to 1000 files).
+    changed_pages=()
+    for page in $(seq 1 "$max_files_pages"); do
+        files_json=$(curl -s \
+            -H "Authorization: token ${PULUMI_BOT_TOKEN}" \
+            "${repo_api_url}/pulls/${pr_number}/files?per_page=100&page=${page}")
+
+        # Collect non-removed content markdown files from this page.
+        while IFS= read -r filename; do
+            [[ -z "$filename" ]] && continue
+            url="$(content_path_to_url "$filename")"
+            if [[ -f "${build_dir}${url}index.html" ]]; then
+                changed_pages+=("- [${url}](${s3_website_url}${url})")
+            fi
+        done < <(echo "$files_json" | jq -r '.[] | select(.status != "removed") | select(.filename | startswith("content/") and endswith(".md")) | .filename')
+
+        # Stop once we hit a short (final) page, or if the response wasn't an
+        # array (e.g. a transient API error), which yields 0 and breaks cleanly.
+        page_count="$(echo "$files_json" | jq -r 'if type == "array" then length else 0 end')"
+        [[ "$page_count" -lt 100 ]] && break
+    done
+
+    changed_pages_section=""
+    if [[ "${#changed_pages[@]}" -gt 0 ]]; then
+        listed=$(printf '%s\n' "${changed_pages[@]:0:$max_listed_pages}")
+        changed_pages_section=$'\n\n'"**Changed pages:**"$'\n'"${listed}"
+        if [[ "${#changed_pages[@]}" -gt "$max_listed_pages" ]]; then
+            changed_pages_section+=$'\n'"- …and $(( ${#changed_pages[@]} - max_listed_pages )) more"
+        fi
+    fi
+
+    preview_body="<!-- preview-link -->"$'\n'"Your site preview for commit $(git_sha_short) is ready! :tada:"$'\n\n'"${s3_website_url}${changed_pages_section}"
     preview_payload=$(jq -n --arg body "$preview_body" '{"body": $body}')
 
     # Look for an existing preview comment to update (handles CI re-runs).


### PR DESCRIPTION
### Proposed changes

The PR preview comment that the build posts (via `scripts/sync-and-test-bucket.sh`) currently links only the site root, so reviewers have to hunt for the specific pages a PR touched. This adds a **Changed pages** list of direct, clickable links to those pages beneath the preview URL, to make reviewing easier.

How it works:

- **`scripts/common.sh`** — new `content_path_to_url()` helper that maps a Hugo content file path to its published root-relative URL (strips `content/` and `.md`, collapses `/_index` section pages and `/index` leaf bundles, guarantees a trailing slash).
- **`scripts/sync-and-test-bucket.sh`** — in the existing `preview` block, fetches the PR's changed files from the GitHub PR files API (the base ref isn't available locally under CI's shallow checkout, so we can't `git diff`), maps each changed `content/**.md` file to its URL, and keeps only those that **actually rendered to a page in this build** (`public/…/index.html` exists). This filters out removed files, non-page content, and `url:`/permalinks overrides so we never link a dead URL. The rendered list is capped for very large PRs.

The `<!-- preview-link -->` marker and the existing find-and-update (PATCH/POST) logic are unchanged, so re-pushes keep updating the same comment in place. No workflow changes are needed — `PULUMI_BOT_TOKEN` is already passed to the build step.

Resulting comment shape:

```
<!-- preview-link -->
Your site preview for commit abc12345 is ready! :tada:

http://…s3-website.us-west-2.amazonaws.com

**Changed pages:**
- [/docs/iac/concepts/stacks/](http://…/docs/iac/concepts/stacks/)
- [/blog/my-post/](http://…/blog/my-post/)
```

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5t6WDZXg5DHTiwaJ6kwGS)_