### PR TITLE
docs: fix and complete ESC context object documentation

### DIFF
--- a/content/blog/esc-editor-enhancements/index.md
+++ b/content/blog/esc-editor-enhancements/index.md
@@ -2,6 +2,7 @@
 title: "Introducing the Latest ESC Editor Enhancements for Improved Authoring"
 allow_long_title: true
 date: 2024-02-22T00:00:00-07:00
+updated: 2026-07-21
 draft: false
 meta_desc: "The new enhancements to Pulumi ESC Editor streamlines the authoring experience of environments for developers"
 authors:
@@ -34,14 +35,16 @@ We have also added support for accessing contextual information from within an E
 
 - `context.rootEnvironment.name`: the name of the root environment being evaluated
 - `context.currentEnvironment.name`: the name of the current environment being evaluated
-- `context.user.login`: the login of the user evaluating the environment
-- `context.organization.login`: the name of the user's organization
+- `context.pulumi.user.login`: the login of the user evaluating the environment
+- `context.pulumi.organization.login`: the name of the user's organization
 
 ```yaml
 values:
   rootEnv: ${context.rootEnvironment.name}
-  currentUser: ${context.user.login}
+  currentUser: ${context.pulumi.user.login}
 ```
+
+For the current, complete list of `context` properties, see [Built-in properties](/docs/esc/concepts/interpolations-and-references/#context).
 
 ## A Seamless Authoring Experience Awaits
 

--- a/content/docs/esc/concepts/interpolations-and-references.md
+++ b/content/docs/esc/concepts/interpolations-and-references.md
@@ -107,7 +107,18 @@ In addition to referencing properties defined within an environment, references 
 
 ### context
 
-The `context` built-in property provides information about the user and the access token evaluating an ESC environment:
+The `context` built-in property provides information about the environment being evaluated, the user requesting it, and the access token they used.
+
+#### Environment identity
+
+* `context.currentEnvironment.name`: the name of the environment in which the reference is written, including its project
+* `context.rootEnvironment.name`: the name of the environment that was opened, including its project
+
+These two differ only inside imported environments. A reference written in an imported environment sees its own name in `currentEnvironment.name`, but the name of the environment that started the evaluation in `rootEnvironment.name`. For a worked example, see [How attributes resolve across imported environments](/docs/esc/guides/configuring-oidc/#how-attributes-resolve-across-imported-environments).
+
+For environments in the legacy `default` project, both properties resolve to the environment name alone, without a project prefix.
+
+#### Caller identity
 
 * `context.pulumi.user.login`: the login of the requesting user
 * `context.pulumi.organization.login`: the login of their organization
@@ -121,6 +132,12 @@ Each `context.pulumi.token` property resolves to an empty string when it doesn't
 values:
   greeting: Hello, ${context.pulumi.organization.login}/${context.pulumi.user.login}!
 ```
+
+#### Open duration
+
+* `context.pulumi.openDuration`: how long the opened environment's values remain valid, as a [Go duration](https://pkg.go.dev/time#ParseDuration) string such as `2h0m0s`
+
+This reflects the lifetime requested for this particular open, so the same environment can evaluate it differently from one open to the next. Opening with `esc env open <environment> --lifetime 30m` resolves it to `30m0s`; opening without a lifetime resolves it to the default of `2h0m0s`. Use it to align a credential's own expiry with the lifetime of the environment that issued it.
 
 #### Differentiating callers by token
 

--- a/content/docs/esc/guides/configuring-oidc/_index.md
+++ b/content/docs/esc/guides/configuring-oidc/_index.md
@@ -81,7 +81,7 @@ By default (when `subjectAttributes` is not set), the subject claim has the form
 
 When you set `subjectAttributes`, the subject instead begins with the fixed prefix `pulumi:environments:pulumi.organization.login:{ORGANIZATION_NAME}`, and each configured attribute is appended to it as a `:<attribute>:<value>` pair, in the order listed.
 
-The following attributes are available:
+The following attributes are available. This is a deliberately restricted subset of the `context` built-in property — see [Built-in properties](/docs/esc/concepts/interpolations-and-references/#context) for the full set of values you can interpolate anywhere in an environment.
 
 * `rootEnvironment.name`: the name of the environment that is opened first. This root environment in turn opens other imported environments
 * `currentEnvironment.name`: the full name (including the project) of the environment where the ESC login provider and `subjectAttributes` are defined


### PR DESCRIPTION
Fixes #20393

The hand-written docs for the ESC built-in `context` object had drifted from the engine in three places. I verified every claim below against live ESC environments (created, probed, and cleaned up).

## Changes

**1. `currentEnvironment` / `rootEnvironment` are now on the canonical reference**

Both are injected into every evaluation and are interpolable, but `content/docs/esc/concepts/interpolations-and-references.md` had zero occurrences of either. They were only documented in the OIDC guide, under the narrow `subjectAttributes` framing — so a reader asking "what can I interpolate?" could not find them.

Verified the import semantics directly. Opening a parent that imports a child:

```json
{
  "parentView": { "current": "scratch/ctx-parent", "root": "scratch/ctx-parent" },
  "whoAmI":     { "current": "scratch/ctx-child",  "root": "scratch/ctx-parent" }
}
```

Rather than duplicate the OIDC guide's worked example, the new section states the rule and links to it.

I also confirmed the legacy-`default`-project behavior applies to **both** properties, not just `currentEnvironment.name` as the OIDC page implies — an env in `default` resolves both to the bare name with no project prefix.

**2. `context.pulumi.openDuration` is documented**

It is real and interpolable. Confirmed it reflects the lifetime requested per-open rather than a fixed environment property:

| open | resolves to |
|---|---|
| `esc env open <env>` | `2h0m0s` |
| `esc env open <env> --lifetime 30m` | `30m0s` |
| `esc env open <env> --lifetime 90m` | `1h30m0s` |

Since it is user-visible, interpolable, and has a legitimate use (aligning a credential's expiry with the environment that issued it), I documented it rather than proposing removal.

**3. The OIDC guide is cross-linked, not merged**

The issue flags the guide as a second copy of the field list. On reading, it is not quite duplication — it is the *restricted subset* permitted in subject claims, which deliberately excludes `token.name` and `openDuration`. Collapsing the two would lose that distinction. Instead the list now says it is a subset and links to the canonical reference. The security rationale for excluding `pulumi.token.name` is untouched.

**4. Blog post paths fixed**

`content/blog/esc-editor-enhancements/index.md` showed `context.user.login` and `context.organization.login`, both missing the `pulumi.` infix — neither works if copied. Fixed, plus a pointer to the canonical list so the post ages better. Stamped `updated:` per AGENTS.md since the snippet was broken for readers.

## On `context.pulumi.user.id`

The issue asks whether it is supported. **It is not** — the engine rejects it at edit time:

```
Error: updating environment definition: [0]
Diags: unknown property "id"
```

So despite its appearance in pulumi/pulumi's eval fixtures, it is not a valid public path and I left it undocumented.

## Notes

- `make lint` passes.
- All probe environments were deleted; `esc env ls` confirms none remain.
- No org-specific names appear in the diff.
- ⚠️ `pulumi/docs-private` mirrors these three files at identical paths and needs the same fixes — not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)