### PR TITLE
Add OpenAI ad pixel to site head

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -476,11 +476,19 @@
             });
         </script>
 
-        <!-- OpenAI ad pixel (deferred to window.load to avoid blocking first paint) -->
+        <!-- OpenAI ad pixel (deferred to window.load to avoid blocking first paint) — Marketing & Analytics
+             consent-gated: loads only after the consent-managed Segment analytics is ready
+             (window.analytics.ready), same as the Floqer integration below. Fail-closed: if
+             consent-managed analytics never loads, the pixel never loads. -->
         <script>
             window.addEventListener('load', function() {
-                !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
-                oaiq("init",{pixelId:"7KRuATZtZE3j5BSAZErZAb",debug:false});
+                function loadOaiq() {
+                    !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+                    oaiq("init",{pixelId:"7KRuATZtZE3j5BSAZErZAb",debug:false});
+                }
+                if (window.analytics && typeof window.analytics.ready === "function") {
+                    window.analytics.ready(loadOaiq);
+                }
             });
         </script>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,6 +19,8 @@
     {{- if eq hugo.Environment "production" }}
     <!-- Preconnect to Common Room (production only). -->
     <link rel="preconnect" href="https://cdn.cr-relay.com" crossorigin />
+    <!-- Preconnect to OpenAI ad pixel CDN (production only). -->
+    <link rel="preconnect" href="https://bzrcdn.openai.com" crossorigin />
     {{- end }}
 
     <!-- Preload critical fonts (skip monospace on the homepage — not used above the fold). -->
@@ -471,6 +473,14 @@
                     }, {})
                 );
                 document.head.appendChild(script);
+            });
+        </script>
+
+        <!-- OpenAI ad pixel (deferred to window.load to avoid blocking first paint) -->
+        <script>
+            window.addEventListener('load', function() {
+                !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+                oaiq("init",{pixelId:"7KRuATZtZE3j5BSAZErZAb",debug:false});
             });
         </script>
 


### PR DESCRIPTION
## What

Adds the OpenAI advertising pixel (`oaiq`) to the site.

## Where

Placed in the `production`-gated third-party script block in `layouts/partials/head.html`, alongside the existing Common Room and Floqer scripts. So it loads only in production, not in local/preview builds.

## Details

- **Deferred to `window.load`** to avoid blocking first paint, matching the Common Room pattern.
- Added a matching **`preconnect`** to `https://bzrcdn.openai.com` (production only), matching the Segment/Common Room preconnect pattern.
- **`debug:false`** — the snippet as supplied had `debug:true`, which would log to the console for every production visitor. Shipped with debug off; flip it if you actually want debug output live.

## Verification

- `npx prettier --check` passes on the changed file.
- Production Hugo build compiles the template cleanly (the two `make lint`/build errors present are pre-existing icon-sprite manifest issues, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)