### PR TITLE
docs: add "When to Build a Component" guide

### DIFF
--- a/content/docs/iac/concepts/components/_index.md
+++ b/content/docs/iac/concepts/components/_index.md
@@ -118,7 +118,7 @@ Components distributed as Pulumi packages can be consumed in any language using 
 pulumi package add github.com/my-org/my-component@v1.0.0
 ```
 
-This pattern is common for components your organization publishes for internal consumption via a Git repository or the [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/). It is also how components from a [source-based plugin package](#authoring-components) are consumed across languages — the SDK is generated in your program's language regardless of the language the component was authored in.
+This pattern is common for components your organization publishes for internal consumption via a Git repository or the [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/). It is also how components from a [source-based plugin package](/docs/iac/guides/building-extending/components/packaging-components/#source-based-plugin-packages) are consumed across languages — the SDK is generated in your program's language regardless of the language the component was authored in.
 
 Under the hood, Pulumi fetches the package source (e.g. from GitHub), generates a [local SDK](/docs/iac/guides/building-extending/packages/local-sdks/) from the component's schema, and makes the generated SDK available for import in your program.
 

--- a/content/docs/iac/guides/building-extending/_index.md
+++ b/content/docs/iac/guides/building-extending/_index.md
@@ -23,6 +23,8 @@ These guides show you how to create custom components that encapsulate best prac
 
 Build reusable infrastructure components to encapsulate and share infrastructure patterns.
 
+**[When to Build a Component](/docs/iac/guides/building-extending/components/when-to-build-a-component/)** - Understand what a component gives you that a plain function cannot, and when a function is the better choice.
+
 **[Build a Component](/docs/iac/guides/building-extending/components/build-a-component/)** - Learn the process for creating custom Pulumi components that bundle multiple resources into reusable abstractions with built-in best practices.
 
 **[Testing Components](/docs/iac/guides/building-extending/components/testing-components/)** - Write automated tests for your components to ensure they work correctly and maintain quality as they evolve.

--- a/content/docs/iac/guides/building-extending/components/build-a-component.md
+++ b/content/docs/iac/guides/building-extending/components/build-a-component.md
@@ -27,11 +27,9 @@ This guide will walk you through the steps of making a [Pulumi Component](/docs/
 
 ## Why Write a Component?
 
-Pulumi Components provide a way to encapsulate best practices, ensuring that security policies and deployment patterns remain consistent across projects. They also help reduce code duplication by allowing you to define reusable infrastructure patterns. By structuring infrastructure as components, maintainability improves, and teams can work more efficiently.
+Components encapsulate best practices, propagate resource options to every resource they create, appear as a single node in your stack, and can be shared across teams and languages.
 
-- **Sharing and Reusability**: Do more with less code. Don't repeat yourself.
-- **Best Practices and Policy**: Encode company standards and policy.
-- **Multi-language Support**: When packaged as a Pulumi plugin package, a component written in one language can be consumed from any other Pulumi-supported language via a generated SDK.
+For the full case — including when a plain function is the better choice — see [When to Build a Component](/docs/iac/guides/building-extending/components/when-to-build-a-component/).
 
 ## How It Works
 

--- a/content/docs/iac/guides/building-extending/components/packaging-components.md
+++ b/content/docs/iac/guides/building-extending/components/packaging-components.md
@@ -12,11 +12,13 @@ aliases:
 - /docs/iac/guides/building-extending/components/packaging-a-component/
 ---
 
-Once you've authored a Pulumi component, you will probably want to package and distribute it so others can use it. This guide covers three ways of packaging a component, each with different trade-offs for distribution, versioning, and discoverability.
+Once you've authored a Pulumi component, you may want to package and distribute it so others can use it. This guide covers three ways of packaging a component, each with different trade-offs for distribution, versioning, and discoverability.
 
 ## Choosing a packaging approach
 
-The three options differ in whether the component ships as a [Pulumi package](/docs/iac/concepts/packages/) and, if so, which kind of [plugin](/docs/iac/concepts/plugins/) carries it:
+Start by deciding whether you need to package the component at all. A component defined in the same project as the program that uses it needs no packaging: consumers reference the class with your language's normal import mechanism, and there is nothing to version or publish. While a component has exactly one consumer, this is the right answer, and it costs nothing to package it later — consumers keep constructing it the same way.
+
+Once a component has a second consumer — another project, another team, or another language — package it. The three options differ in whether the component ships as a [Pulumi package](/docs/iac/concepts/packages/) and, if so, which kind of [plugin](/docs/iac/concepts/plugins/) carries it:
 
 1. **Native language package** — a plain language-ecosystem package (npm, PyPI, Go module, etc.) containing a component class. Not a Pulumi package; no Pulumi plugin involved. A good fit for smaller organizations where all Pulumi code is written in the same language.
 1. **Source-based plugin package** — a Pulumi package distributed as source. Pulumi generates per-language SDKs on-the-fly when a consumer adds the package, so the components can be consumed from any Pulumi language. A good fit for platform teams providing reusable abstractions and self-service. For more information, see [Authoring a source-based plugin package](/docs/iac/guides/building-extending/packages/source-based-plugin/).
@@ -101,6 +103,8 @@ Consuming an executable-based plugin package whose plugin is written in a non-Go
 {{% /notes %}}
 
 ## Packaging summary
+
+This table compares the three packaging approaches. A component that stays local to a single project uses none of them — see [Choosing a packaging approach](#choosing-a-packaging-approach) above.
 
 | Feature | Native language package | Source-based plugin package | Executable-based plugin package |
 |---------|--------------------------|-------------------------------------------|--------------------------|

--- a/content/docs/iac/guides/building-extending/components/when-to-build-a-component.md
+++ b/content/docs/iac/guides/building-extending/components/when-to-build-a-component.md
@@ -1,0 +1,92 @@
+---
+title_tag: "When to Build a Component"
+meta_desc: "Understand when to encapsulate resources in a Pulumi component instead of a plain function, and what a component gives you that a function cannot."
+title: When to Build a Component
+h1: When to Build a Component
+menu:
+    iac:
+        name: When to Build a Component
+        parent: iac-guides-components
+        weight: 5
+---
+
+A [component](/docs/iac/concepts/components/) groups related resources behind a single, well-defined interface. But a plain function can also create a group of resources and return them, which raises a fair question: why write a component at all?
+
+The answer comes down to one difference. A component is a resource: it gets its own node in your [stack's](/docs/iac/concepts/stacks/) state, with a [URN](/docs/iac/concepts/resources/names/#urns) and a parent-child relationship to everything it creates. A function is code that runs. The resources it creates land in your stack as loose, unrelated children, and the grouping exists only in your head. Everything below follows from that.
+
+## Resource options propagate to children
+
+Set a [resource option](/docs/iac/concepts/resources/options/) on a component and it applies to every resource the component creates:
+
+```typescript
+const network = new AcmeVpc("prod", {
+    cidrBlock: "10.0.0.0/16",
+}, {
+    protect: true,
+});
+```
+
+Every subnet, route table, and gateway inside `AcmeVpc` is now protected. The same holds for [`providers`](/docs/iac/concepts/resources/options/providers/), [`transforms`](/docs/iac/concepts/resources/options/transforms/), [`retainOnDelete`](/docs/iac/concepts/resources/options/retainondelete/), and [`deletedWith`](/docs/iac/concepts/resources/options/deletedwith/). Not every option is inherited — see [Options inherited from a component to its children](/docs/iac/concepts/resources/options/#options-inherited-from-a-component-to-its-children) for the full list.
+
+With a function, you have to thread each option through to each resource by hand. That works until someone adds a new resource to the function and forgets to pass the option along, a mistake that produces no error, only an unprotected resource.
+
+## Other resources can depend on the whole group
+
+Because a component is a resource, other resources can depend on it directly:
+
+```typescript
+const cluster = new AcmeCluster("prod", {
+    nodeCount: 3,
+});
+
+const app = new k8s.apps.v1.Deployment("app", {
+    /* ... */
+}, {
+    dependsOn: [cluster],
+});
+```
+
+Pulumi expands the component into the resources it transitively reaches, including those inside nested components, so the deployment waits for every one of them. A function returns a bag of resources, so callers have to know which ones matter and list them individually, then update that list whenever the function's internals change.
+
+## The component appears as one node
+
+A component appears as a single node in `pulumi preview` and `pulumi up`, with its children nested underneath:
+
+```output
+Updating (dev):
+     Type                                Name          Status
+ +   pulumi:pulumi:Stack                 website-dev   created
+ +   └─ acme:index:StaticWebsite         site          created
+ +      ├─ aws:s3:Bucket                 site-bucket   created
+ +      ├─ aws:s3:BucketPolicy           site-policy   created
+ +      └─ aws:cloudfront:Distribution   site-cdn      created
+```
+
+That grouping is real, not cosmetic. The component's URN means you can target it with [`pulumi up --target`](/docs/iac/cli/commands/pulumi_up/), and you can restructure its internals later without replacing resources by adding an [alias](/docs/iac/concepts/resources/options/aliases/). Resources created by a function have no shared parent to target or alias.
+
+## Components match the declarative style of your program
+
+Pulumi programs are declarative: you describe the infrastructure you want and Pulumi works out how to get there. `new VirtualMachine("web", { size: "large" })` matches the shape of every other resource declaration in the file. `createVirtualMachine("web", "large")` is an imperative call that looks like an exception to the pattern.
+
+This is more than style. When every abstraction in your codebase is declared the same way, readers don't have to work out which helpers create infrastructure and which merely compute values.
+
+## A component can graduate to a shared package
+
+A component that starts as a class in a single program can later be published as a [native language package](/docs/iac/guides/building-extending/components/packaging-components/#native-language-packages), packaged as a [plugin package](/docs/iac/guides/building-extending/components/packaging-components/#source-based-plugin-packages) consumable from any Pulumi language, or listed in the [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/). Consumers keep calling it exactly the same way.
+
+A function has no such path. Making it available to another language or another team means rewriting it as a component first.
+
+## When a function is the right call
+
+Components are for creating infrastructure. If your helper doesn't create resources, it should stay a function:
+
+- **Computing values**: deriving a CIDR block, building a connection string, calculating a size from an environment name.
+- **Naming and tagging**: assembling the standard tag map your organization stamps on every resource.
+- **Assembling arguments**: building the argument object you then pass to a resource or component constructor.
+
+A function is also reasonable for a small group of resources used exactly once, in one program, that you're confident will never need shared resource options, a dependency edge, or reuse elsewhere. Be aware that converting it to a component later means replacing resources unless you add aliases, so the cost of guessing wrong grows over time.
+
+## Next steps
+
+- [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/) — write your first component.
+- [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/) — decide how to distribute it once you have one.

--- a/content/docs/iac/guides/building-extending/components/when-to-build-a-component.md
+++ b/content/docs/iac/guides/building-extending/components/when-to-build-a-component.md
@@ -10,7 +10,7 @@ menu:
         weight: 5
 ---
 
-A [component](/docs/iac/concepts/components/) groups related resources behind a single, well-defined interface. But in every language Pulumi supports for authoring, which is TypeScript, Python, Go, .NET, and Java, you can also create a group of resources by writing a plain function. So why write a component instead of just a function?
+A [component](/docs/iac/concepts/components/) groups related resources behind a single, well-defined interface. But in every language Pulumi supports for authoring, which is TypeScript, Python, Go, .NET, and Java, you can also create a group of resources by writing a plain function, so why write a component instead?
 
 Both take about the same effort. In TypeScript, Python, .NET, and Java, a component is a class that subclasses a base `ComponentResource` type and creates its resources in the constructor. Go has no inheritance, so a component there is a struct that embeds `pulumi.ResourceState`, paired with a `NewX` constructor function that does the same work. In each case the base call, whether `super`, `base`, or `ctx.RegisterComponentResource`, **registers the grouping with Pulumi**. The engine records that these resources belong together and that the component owns them. A function creates the same resources without registering anything, so Pulumi holds no record of the grouping. The sections below cover what that record makes possible.
 

--- a/content/docs/iac/guides/building-extending/components/when-to-build-a-component.md
+++ b/content/docs/iac/guides/building-extending/components/when-to-build-a-component.md
@@ -10,17 +10,17 @@ menu:
         weight: 5
 ---
 
-A [component](/docs/iac/concepts/components/) groups related resources behind a single, well-defined interface. But a function can do that too: take some arguments, create five resources, return the useful outputs. Why write a component?
+A [component](/docs/iac/concepts/components/) groups related resources behind a single, well-defined interface. But in every language Pulumi supports for authoring, which is TypeScript, Python, Go, .NET, and Java, you can also create a group of resources by writing a plain function. So why write a component instead of just a function?
 
-The call site isn't the answer. A constructor is a function, and `new Vpc("main", args)` and `createVpc("main", args)` cost about the same to write. The difference is that a component **registers the grouping with Pulumi**. The engine learns that these resources belong together and that this one owns them, and that registration buys you concrete things a function cannot offer.
+Both take about the same effort. In TypeScript, Python, .NET, and Java, a component is a class that subclasses a base `ComponentResource` type and creates its resources in the constructor. Go has no inheritance, so a component there is a struct that embeds `pulumi.ResourceState`, paired with a `NewX` constructor function that does the same work. In each case the base call, whether `super`, `base`, or `ctx.RegisterComponentResource`, **registers the grouping with Pulumi**. The engine records that these resources belong together and that the component owns them. A function creates the same resources without registering anything, so Pulumi holds no record of the grouping. The sections below cover what that record makes possible.
 
-## You keep the option to consume it from another language
+## A component can be packaged for other languages later
 
-A component authored in one language can be [packaged as a plugin package](/docs/iac/guides/building-extending/components/packaging-components/#source-based-plugin-packages) and consumed from any Pulumi language, including YAML, or published to the [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/) for other teams to discover. Consumers keep constructing it the same way they always did.
+A component authored in one language can be [packaged as a plugin package](/docs/iac/guides/building-extending/components/packaging-components/#source-based-plugin-packages) and consumed from any Pulumi language, including YAML, or published to the [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/) for other teams to discover. Consumers construct it the same way regardless of its authoring language.
 
-This matters most when you can't yet predict who needs the abstraction. A TypeScript component that turns out to be useful to a Python team is a packaging task. The same logic in a TypeScript function is a rewrite. Writing it as a component costs nothing extra up front and keeps the option open.
+If a TypeScript component later turns out to be useful to a team writing Python, packaging becomes a build-and-publish task and the component source does not change. The same logic in a TypeScript function has to be rewritten in Python, or converted to a component first. Authoring it as a component leaves that path open without requiring you to decide up front.
 
-## Resource options apply consistently to everything inside
+## Resource options are inherited by child resources
 
 Set a [resource option](/docs/iac/concepts/resources/options/) on a component and it applies to every resource the component creates:
 
@@ -34,15 +34,15 @@ const network = new AcmeVpc("prod", {
 
 Every subnet, route table, and gateway inside `AcmeVpc` is now protected. The same inheritance applies to [`providers`](/docs/iac/concepts/resources/options/providers/), [`transforms`](/docs/iac/concepts/resources/options/transforms/), [`retainOnDelete`](/docs/iac/concepts/resources/options/retainondelete/), and [`deletedWith`](/docs/iac/concepts/resources/options/deletedwith/). Not every option is inherited, so check [Options inherited from a component to its children](/docs/iac/concepts/resources/options/#options-inherited-from-a-component-to-its-children) for the full list.
 
-A function has to thread each option through to each resource by hand. That works until someone adds a new resource and forgets to pass the option along, which produces no error, only an unprotected resource. With a component, the guarantee holds for resources that didn't exist when you wrote the option.
+With a function, each option has to be passed to each resource explicitly. If someone later adds a resource and does not pass the option along, Pulumi reports no error and the resource is created without it. Inheritance from a component also covers resources added after the option was set.
 
-The same consistency applies to dependencies. Because a component is a resource, `dependsOn: [myComponent]` expands to the resources the component transitively reaches, including those inside nested components, so a consumer can wait on the whole group without knowing what's in it.
+Dependencies behave the same way. Because a component is a resource, `dependsOn: [myComponent]` expands to the resources the component transitively reaches, including those inside nested components, so a consumer can wait on the whole group without knowing its contents.
 
-## Refactoring stays cheap as the component evolves
+## Aliases are inherited when a component is refactored
 
-A [URN](/docs/iac/concepts/resources/names/#urns) encodes the chain of parent types above a resource, so a component's children are named relative to the component rather than sitting flat under the stack. Two instances of the same component don't collide, and the child names stay predictable as the program grows.
+A [URN](/docs/iac/concepts/resources/names/#urns) encodes the chain of parent types above a resource, so a component's children are named relative to the component rather than sitting directly under the stack. This keeps names from colliding when a program creates more than one instance of the same component.
 
-That parentage doesn't make a URN harder to change, but it does make the change cheap to absorb. [Aliases are inherited from a parent](/docs/iac/concepts/resources/options/aliases/), so renaming or re-typing a component carries its children along automatically, through any number of levels:
+Because the URN depends on that chain, renaming or re-typing a component changes the URNs of its children, and a changed URN means the resource is deleted and recreated rather than updated in place. [Aliases are inherited from a parent](/docs/iac/concepts/resources/options/aliases/), so a single alias on the component covers its children, through any number of levels:
 
 ```typescript
 const site = new StaticWebsite("site", args, {
@@ -50,9 +50,9 @@ const site = new StaticWebsite("site", args, {
 });
 ```
 
-One alias on the component preserves the identity of every resource beneath it. Refactoring the equivalent function means writing an alias for each resource it created, and missing one replaces that resource. See [Refactoring with aliases](/docs/iac/operations/stack-management/refactoring-with-aliases/) for the common workflows.
+Refactoring the equivalent function requires an alias on each resource it created, and any resource missed is deleted and recreated. See [Refactoring with aliases](/docs/iac/operations/stack-management/refactoring-with-aliases/) for the common workflows.
 
-## Operations treat it as one unit
+## The CLI treats the component as one resource
 
 A component appears as a single node in `pulumi preview` and `pulumi up`, with its children nested underneath:
 
@@ -66,17 +66,17 @@ Updating (dev):
  +      └─ aws:cloudfront:Distribution   site-cdn      created
 ```
 
-The grouping is operational, not cosmetic. The component's URN is addressable, so you can target the whole group with [`pulumi up --target`](/docs/iac/cli/commands/pulumi_up/). Resources created by a function have no shared parent to address.
+Because the component has its own URN, commands that accept a URN can refer to it directly, and the wildcard forms that [`pulumi up --target`](/docs/iac/cli/commands/pulumi_up/) accepts can select its children by URN prefix. Resources created by a function share no parent, so each one has to be named individually.
 
-## When a function is the right call
+## When a function is the better choice
 
-Components are for creating infrastructure. If your helper doesn't create resources, it should stay a function:
+Components are for creating infrastructure. If your helper does not create resources, it should stay a function:
 
 - **Computing values**: deriving a CIDR block, building a connection string, calculating a size from an environment name.
 - **Naming and tagging**: assembling the standard tag map your organization stamps on every resource.
 - **Assembling arguments**: building the argument object you then pass to a resource or component constructor.
 
-A function is also reasonable for a small group of resources used exactly once, in one program, that will never need shared resource options, a dependency edge, or reuse elsewhere. Converting it to a component later means writing per-resource aliases to avoid replacement, so the cost of guessing wrong grows as the stack ages.
+A function is also reasonable for a small group of resources used exactly once, in one program, that will never need shared resource options, a dependency edge, or reuse elsewhere. Converting it to a component later requires a per-resource alias to avoid deleting and recreating each resource, so the cost of that conversion grows as the stack does.
 
 ## Next steps
 

--- a/content/docs/iac/guides/building-extending/components/when-to-build-a-component.md
+++ b/content/docs/iac/guides/building-extending/components/when-to-build-a-component.md
@@ -1,6 +1,6 @@
 ---
 title_tag: "When to Build a Component"
-meta_desc: "Understand when to encapsulate resources in a Pulumi component instead of a plain function, and what a component gives you that a function cannot."
+meta_desc: "Understand what a Pulumi component gives you that a plain function creating the same resources cannot, and when a function is the better choice."
 title: When to Build a Component
 h1: When to Build a Component
 menu:
@@ -10,11 +10,17 @@ menu:
         weight: 5
 ---
 
-A [component](/docs/iac/concepts/components/) groups related resources behind a single, well-defined interface. But a plain function can also create a group of resources and return them, which raises a fair question: why write a component at all?
+A [component](/docs/iac/concepts/components/) groups related resources behind a single, well-defined interface. But a function can do that too: take some arguments, create five resources, return the useful outputs. Why write a component?
 
-The answer comes down to one difference. A component is a resource: it gets its own node in your [stack's](/docs/iac/concepts/stacks/) state, with a [URN](/docs/iac/concepts/resources/names/#urns) and a parent-child relationship to everything it creates. A function is code that runs. The resources it creates land in your stack as loose, unrelated children, and the grouping exists only in your head. Everything below follows from that.
+The call site isn't the answer. A constructor is a function, and `new Vpc("main", args)` and `createVpc("main", args)` cost about the same to write. The difference is that a component **registers the grouping with Pulumi**. The engine learns that these resources belong together and that this one owns them, and that registration buys you concrete things a function cannot offer.
 
-## Resource options propagate to children
+## You keep the option to consume it from another language
+
+A component authored in one language can be [packaged as a plugin package](/docs/iac/guides/building-extending/components/packaging-components/#source-based-plugin-packages) and consumed from any Pulumi language, including YAML, or published to the [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/) for other teams to discover. Consumers keep constructing it the same way they always did.
+
+This matters most when you can't yet predict who needs the abstraction. A TypeScript component that turns out to be useful to a Python team is a packaging task. The same logic in a TypeScript function is a rewrite. Writing it as a component costs nothing extra up front and keeps the option open.
+
+## Resource options apply consistently to everything inside
 
 Set a [resource option](/docs/iac/concepts/resources/options/) on a component and it applies to every resource the component creates:
 
@@ -26,29 +32,27 @@ const network = new AcmeVpc("prod", {
 });
 ```
 
-Every subnet, route table, and gateway inside `AcmeVpc` is now protected. The same holds for [`providers`](/docs/iac/concepts/resources/options/providers/), [`transforms`](/docs/iac/concepts/resources/options/transforms/), [`retainOnDelete`](/docs/iac/concepts/resources/options/retainondelete/), and [`deletedWith`](/docs/iac/concepts/resources/options/deletedwith/). Not every option is inherited — see [Options inherited from a component to its children](/docs/iac/concepts/resources/options/#options-inherited-from-a-component-to-its-children) for the full list.
+Every subnet, route table, and gateway inside `AcmeVpc` is now protected. The same inheritance applies to [`providers`](/docs/iac/concepts/resources/options/providers/), [`transforms`](/docs/iac/concepts/resources/options/transforms/), [`retainOnDelete`](/docs/iac/concepts/resources/options/retainondelete/), and [`deletedWith`](/docs/iac/concepts/resources/options/deletedwith/). Not every option is inherited, so check [Options inherited from a component to its children](/docs/iac/concepts/resources/options/#options-inherited-from-a-component-to-its-children) for the full list.
 
-With a function, you have to thread each option through to each resource by hand. That works until someone adds a new resource to the function and forgets to pass the option along, a mistake that produces no error, only an unprotected resource.
+A function has to thread each option through to each resource by hand. That works until someone adds a new resource and forgets to pass the option along, which produces no error, only an unprotected resource. With a component, the guarantee holds for resources that didn't exist when you wrote the option.
 
-## Other resources can depend on the whole group
+The same consistency applies to dependencies. Because a component is a resource, `dependsOn: [myComponent]` expands to the resources the component transitively reaches, including those inside nested components, so a consumer can wait on the whole group without knowing what's in it.
 
-Because a component is a resource, other resources can depend on it directly:
+## Refactoring stays cheap as the component evolves
+
+A [URN](/docs/iac/concepts/resources/names/#urns) encodes the chain of parent types above a resource, so a component's children are named relative to the component rather than sitting flat under the stack. Two instances of the same component don't collide, and the child names stay predictable as the program grows.
+
+That parentage doesn't make a URN harder to change, but it does make the change cheap to absorb. [Aliases are inherited from a parent](/docs/iac/concepts/resources/options/aliases/), so renaming or re-typing a component carries its children along automatically, through any number of levels:
 
 ```typescript
-const cluster = new AcmeCluster("prod", {
-    nodeCount: 3,
-});
-
-const app = new k8s.apps.v1.Deployment("app", {
-    /* ... */
-}, {
-    dependsOn: [cluster],
+const site = new StaticWebsite("site", args, {
+    aliases: [{ type: "acme:index:StaticSite" }],
 });
 ```
 
-Pulumi expands the component into the resources it transitively reaches, including those inside nested components, so the deployment waits for every one of them. A function returns a bag of resources, so callers have to know which ones matter and list them individually, then update that list whenever the function's internals change.
+One alias on the component preserves the identity of every resource beneath it. Refactoring the equivalent function means writing an alias for each resource it created, and missing one replaces that resource. See [Refactoring with aliases](/docs/iac/operations/stack-management/refactoring-with-aliases/) for the common workflows.
 
-## The component appears as one node
+## Operations treat it as one unit
 
 A component appears as a single node in `pulumi preview` and `pulumi up`, with its children nested underneath:
 
@@ -62,19 +66,7 @@ Updating (dev):
  +      └─ aws:cloudfront:Distribution   site-cdn      created
 ```
 
-That grouping is real, not cosmetic. The component's URN means you can target it with [`pulumi up --target`](/docs/iac/cli/commands/pulumi_up/), and you can restructure its internals later without replacing resources by adding an [alias](/docs/iac/concepts/resources/options/aliases/). Resources created by a function have no shared parent to target or alias.
-
-## Components match the declarative style of your program
-
-Pulumi programs are declarative: you describe the infrastructure you want and Pulumi works out how to get there. `new VirtualMachine("web", { size: "large" })` matches the shape of every other resource declaration in the file. `createVirtualMachine("web", "large")` is an imperative call that looks like an exception to the pattern.
-
-This is more than style. When every abstraction in your codebase is declared the same way, readers don't have to work out which helpers create infrastructure and which merely compute values.
-
-## A component can graduate to a shared package
-
-A component that starts as a class in a single program can later be published as a [native language package](/docs/iac/guides/building-extending/components/packaging-components/#native-language-packages), packaged as a [plugin package](/docs/iac/guides/building-extending/components/packaging-components/#source-based-plugin-packages) consumable from any Pulumi language, or listed in the [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/). Consumers keep calling it exactly the same way.
-
-A function has no such path. Making it available to another language or another team means rewriting it as a component first.
+The grouping is operational, not cosmetic. The component's URN is addressable, so you can target the whole group with [`pulumi up --target`](/docs/iac/cli/commands/pulumi_up/). Resources created by a function have no shared parent to address.
 
 ## When a function is the right call
 
@@ -84,7 +76,7 @@ Components are for creating infrastructure. If your helper doesn't create resour
 - **Naming and tagging**: assembling the standard tag map your organization stamps on every resource.
 - **Assembling arguments**: building the argument object you then pass to a resource or component constructor.
 
-A function is also reasonable for a small group of resources used exactly once, in one program, that you're confident will never need shared resource options, a dependency edge, or reuse elsewhere. Be aware that converting it to a component later means replacing resources unless you add aliases, so the cost of guessing wrong grows over time.
+A function is also reasonable for a small group of resources used exactly once, in one program, that will never need shared resource options, a dependency edge, or reuse elsewhere. Converting it to a component later means writing per-resource aliases to avoid replacement, so the cost of guessing wrong grows as the stack ages.
 
 ## Next steps
 

--- a/content/docs/idp/concepts/private-registry.md
+++ b/content/docs/idp/concepts/private-registry.md
@@ -12,7 +12,7 @@ menu:
     weight: 10
 ---
 
-Pulumi Private Registry is the source of truth for an organization's infrastructure building blocks like [components](/docs/iac/concepts/resources/components/) and [templates](/docs/idp/concepts/organization-templates/). Platform engineers publish components to the private registry so that developers can discover them, browse auto-generated API documentation, and use them in their Pulumi programs.
+Pulumi Private Registry is the source of truth for an organization's infrastructure building blocks like [components](/docs/iac/concepts/components/) and [templates](/docs/idp/concepts/organization-templates/). Platform engineers publish components to the private registry so that developers can discover them, browse auto-generated API documentation, and use them in their Pulumi programs.
 
 For detailed information about different component packaging approaches, see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/).
 


### PR DESCRIPTION
## Why

From [this thread in #product-questions](https://pulumi.slack.com/archives/C010K803WCA/p1783974772397919): *why should a customer use a proper component resource instead of a function that produces the same result?*

The docs couldn't answer it. The only rationale content was `build-a-component.md`'s "Why Write a Component?" — reuse, best practices, multi-language support — and two of those three are equally true of a plain helper function. Nothing named what registering the grouping with the engine actually buys you.

## What

Keeps two questions separate that were previously tangled:

**A. Component or function?** — a new guide, [When to Build a Component](/docs/iac/guides/building-extending/components/when-to-build-a-component/), at weight 5 so it sits ahead of "Build a Component". Sections:

- A component can be packaged for other languages later
- Resource options are inherited by child resources
- Aliases are inherited when a component is refactored
- The CLI treats the component as one resource
- **When a function is the better choice** — so it reads as guidance, not a pitch

**B. How do I distribute it?** — `packaging-components.md` opened with "you will probably want to package and distribute it," skipping past the local option. Adds "keep it local" as the zeroth option in the decision list, plus a note above the summary table so table and prose agree.

The components *concept* page is organized around consuming components, so it gets no rationale content — only the anchor fix below.

Reasons sourced from the Slack thread (Mitch, James, Levi) plus `data/resource_options.yaml`.

## Drive-by fixes

- `concepts/components/_index.md` — "source-based plugin package" linked to `#authoring-components`, the wrong section. Now points at `packaging-components/#source-based-plugin-packages`.
- `idp/concepts/private-registry.md` — components linked via the stale `/docs/iac/concepts/resources/components/` alias.

## Verification

- `make lint` and Prettier clean. `make lint-prose` reports one finding on the new page, a false-positive Oxford-comma nag on a two-item list.
- Every added link checked against a local build (all 200), including the `#urns` and `#options-inherited-from-a-component-to-its-children` anchors.
- Sidebar order confirmed: When to Build → Build → Testing → Packaging.

### Claims corrected during review

Three things were wrong in my drafts and are worth a reviewer's attention:

1. **`ignoreChanges` is not inherited** by component children (`data/resource_options.yaml:159`). Swapped for `deletedWith`.
2. **`dependsOn` on a component expands to *transitively reachable* resources**, not literally everything inside — the SDK walk stops at custom resources.
3. **`pulumi up --target` is not documented to cascade** from a component to its children. That claim was removed; the text now says only what the CLI help supports (URNs accepted directly, wildcards can select children by URN prefix). **If someone knows the cascade behavior is real and documented elsewhere, this is worth restoring.**

Also note the intro distinguishes Go (struct embedding `pulumi.ResourceState` + a `NewX` function) from the subclassing model used by TypeScript, Python, .NET, and Java.

## Follow-ups not in this PR

- `dependson.md` doesn't mention components at all, so "you can depend on a whole component" is documented only on this new page.
- Engin suggested a part 8 of the [IaC best practices series](https://www.pulumi.com/blog/series/iac-best-practices/) on this topic.