### PR TITLE
Allow workprentice bot to run the social media review workflow

### DIFF
--- a/.github/workflows/claude-social-review.yml
+++ b/.github/workflows/claude-social-review.yml
@@ -255,6 +255,13 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # workprentice (Joe Duffy's bot) opens blog PRs, which surfaces the
+          # run's actor as a Bot; claude-code-action@v1 rejects Bot actors by
+          # default. Same allowance claude-code-review.yml makes. Both the bare
+          # and `[bot]`-suffixed forms are listed because the action reports the
+          # actor as bare `workprentice` while github.actor renders it as
+          # `workprentice[bot]`.
+          allowed_bots: 'github-actions[bot],workprentice,workprentice[bot]'
           prompt: |
             You are running in a CI environment.
 

--- a/.github/workflows/claude-social-review.yml
+++ b/.github/workflows/claude-social-review.yml
@@ -255,8 +255,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # workprentice (Joe Duffy's bot) opens blog PRs, which surfaces the
-          # run's actor as a Bot; claude-code-action@v1 rejects Bot actors by
+          # workprentice opens blog PRs, which surfaces the run's actor as a
+          # Bot; claude-code-action@v1 rejects Bot actors by
           # default. Same allowance claude-code-review.yml makes. Both the bare
           # and `[bot]`-suffixed forms are listed because the action reports the
           # actor as bare `workprentice` while github.actor renders it as


### PR DESCRIPTION
### Proposed changes

The `claude-social-review.yml` workflow runs `anthropics/claude-code-action@v1` without an `allowed_bots` input, so the action rejects Bot actors by default. `workprentice[bot]` (Joe Duffy's bot) opens blog PRs, which surfaces the run's actor as a Bot and fails the "Run Claude Social Media Review" step with:

> Workflow initiated by non-human actor: workprentice (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

This adds an `allowed_bots` input to that step listing `github-actions[bot]` plus both the bare `workprentice` and `[bot]`-suffixed forms — the action reports the actor as bare `workprentice` while `github.actor` renders it as `workprentice[bot]`, so both are listed. This mirrors the allowance already made for the same bot in `claude-code-review.yml`.

Example failing run: https://github.com/pulumi/docs/actions/runs/29871830767/job/88773492416 (PR #20413).

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMR7A25RmiypEmijzPcbDs)_