### PR TITLE
docs(ai): add canonical Neo permissions model page

### DIFF
--- a/content/docs/ai/neo/automations/_index.md
+++ b/content/docs/ai/neo/automations/_index.md
@@ -21,7 +21,7 @@ Provider freshness checks, encryption audits, backup audits, and activity digest
 
 ## Defaults that fit recurring work
 
-Scheduled tasks default to two settings. Approval mode is [**auto**](/docs/ai/neo/tasks/#task-modes), so the task proceeds without waiting for human confirmation at each step. Permission mode is [**read-only**](/docs/ai/neo/tasks/#task-modes), so the task can read state and propose changes through pull requests, but it can't write directly to your infrastructure. Settings apply in this order:
+Scheduled tasks default to two settings. Approval mode is [**auto**](/docs/ai/neo/tasks/#task-modes), so the task proceeds without waiting for human confirmation at each step. Permission mode is [**read-only**](/docs/ai/neo/permissions/#permission-mode-and-approval-mode), so the task can read state and propose changes through pull requests, but it can't write directly to your infrastructure. Settings apply in this order:
 
 1. The per-automation setting, if set
 1. The org-level default

--- a/content/docs/ai/neo/get-started/_index.md
+++ b/content/docs/ai/neo/get-started/_index.md
@@ -21,7 +21,7 @@ Neo is enabled by default. To disable Neo for your organization, navigate to **S
 
 ## VCS integration
 
-Connecting a [version control integration](/docs/integrations/version-control/) significantly enhances Neo's capabilities, though it is not required. Pulumi supports [GitHub](/docs/integrations/version-control/github-app/), [Azure DevOps](/docs/integrations/version-control/azure-devops-integration/), and [GitLab](/docs/integrations/version-control/gitlab/). A VCS integration:
+Connecting a [version control integration](/docs/integrations/version-control/) significantly enhances Neo's capabilities, though it is not required. Pulumi supports [GitHub](/docs/integrations/version-control/github-app/), [Azure DevOps](/docs/integrations/version-control/azure-devops-integration/), [GitLab](/docs/integrations/version-control/gitlab/), [Bitbucket](/docs/integrations/version-control/bitbucket/), and [Custom VCS](/docs/integrations/version-control/custom-vcs/). A VCS integration:
 
 - Allows Neo to read repository content for better context
 - Enables pull request creation
@@ -33,23 +33,13 @@ To set up a VCS integration, see the [version control docs](/docs/integrations/v
 
 ## Neo's permission model
 
-Neo operates within the conversing user's [RBAC entitlements](/docs/pulumi-cloud/access-management/rbac/) and cannot perform actions that the user couldn't perform themselves. This means:
-
-- There's no privilege escalation risk or special administrative access required
-- Each user's Neo conversations are isolated from other users
+Neo operates within the conversing user's [RBAC entitlements](/docs/administration/access-identity/rbac/) and cannot perform actions that the user couldn't perform themselves — there's no privilege escalation, and each user's Neo conversations are isolated from other users. For the full picture of which identity Neo acts as on each surface, how permission and approval modes constrain it, and how to scope its access, see [Neo's permissions model](/docs/ai/neo/permissions/).
 
 ### Read-only mode
 
-When you create a Neo task, you can choose between two permission levels:
+When you create a task, you can run Neo with your full permissions ("Use my permissions", the default) or in read-only mode. Read-only mode takes your existing permissions and removes the ability to trigger writes in Pulumi Cloud: Neo can still read state, run previews, write and refactor code, and open pull requests, but it can't trigger deployments or other Pulumi Cloud write operations directly. Neo never gets more access than you have, only less.
 
-| Option | What Neo can do |
-| :--- | :--- |
-| **Use my permissions** | Full access (default behavior) |
-| **Read-only** | Read, preview, and create PRs. No infrastructure mutations. |
-
-Read-only mode takes your existing permissions and removes the ability to make changes. Neo never gets more access than you have, only less. If you can view a stack but not a particular environment, Neo in read-only mode also cannot see that environment.
-
-In read-only mode, Neo can still read your infrastructure state, run previews, write and refactor code, create branches, and open pull requests. The only difference is that Neo cannot trigger deployments or other write operations in Pulumi Cloud directly.
+Read-only is scoped to Pulumi Cloud. It does not, on its own, prevent Neo from opening [ESC](/docs/esc/) environments you can open or reaching the cloud accounts those environments unlock — see [ESC, secrets, and downstream cloud access](/docs/ai/neo/permissions/#esc-secrets-and-downstream-cloud-access).
 
 ## Quick Start Guide
 
@@ -94,6 +84,6 @@ Let's run a simple infrastructure [task](/docs/ai/neo/tasks/) to see Neo in acti
 
 ## Considerations and Limitations
 
-- Code Changes Only - Neo can only modify infrastructure through code. It cannot perform API or UI actions like configure deployments, updating stack configurations, or managing environments in Pulumi Cloud.
-- Cannot Create Repos - Neo cannot create new repositories or initialize new Git repos. It only works within existing repositories.
+- Changes go through code, deployments, and APIs - Where your Pulumi Cloud configuration (deployment settings, stack configuration, environment definitions) is managed in IaC, Neo changes it through code and pull requests. Where it isn't, Neo can edit it directly through the Pulumi Cloud APIs. Neo can also run deployments (`pulumi up`) and, where it has access, cloud CLI operations, so its effects reach beyond code. See [Neo's permissions model](/docs/ai/neo/permissions/) for the full picture.
+- Creating repositories requires individual access - Neo creates repositories as your own connected version control account, not as the shared Pulumi app, so you must [grant individual access](/docs/integrations/version-control/github-app/#individual-user-setup) to your provider first. Custom VCS servers do not support repository creation at all.
 - Cannot Create New Projects - Neo cannot initialize new Pulumi projects. It can only work within existing projects that are already set up.

--- a/content/docs/ai/neo/get-started/_index.md
+++ b/content/docs/ai/neo/get-started/_index.md
@@ -21,7 +21,7 @@ Neo is enabled by default. To disable Neo for your organization, navigate to **S
 
 ## VCS integration
 
-Connecting a [version control integration](/docs/integrations/version-control/) significantly enhances Neo's capabilities, though it is not required. Pulumi supports [GitHub](/docs/integrations/version-control/github-app/), [Azure DevOps](/docs/integrations/version-control/azure-devops-integration/), [GitLab](/docs/integrations/version-control/gitlab/), [Bitbucket](/docs/integrations/version-control/bitbucket/), and [Custom VCS](/docs/integrations/version-control/custom-vcs/). A VCS integration:
+A [version control integration](/docs/integrations/version-control/) is optional. With one connected, Neo can read your code and open pull requests. Pulumi supports [GitHub](/docs/integrations/version-control/github-app/), [Azure DevOps](/docs/integrations/version-control/azure-devops-integration/), [GitLab](/docs/integrations/version-control/gitlab/), [Bitbucket](/docs/integrations/version-control/bitbucket/), and [Custom VCS](/docs/integrations/version-control/custom-vcs/). A VCS integration:
 
 - Allows Neo to read repository content for better context
 - Enables pull request creation
@@ -33,7 +33,7 @@ To set up a VCS integration, see the [version control docs](/docs/integrations/v
 
 ## Neo's permission model
 
-Neo operates within the conversing user's [RBAC entitlements](/docs/administration/access-identity/rbac/) and cannot perform actions that the user couldn't perform themselves — there's no privilege escalation, and each user's Neo conversations are isolated from other users. For the full picture of which identity Neo acts as on each surface, how permission and approval modes constrain it, and how to scope its access, see [Neo's permissions model](/docs/ai/neo/permissions/).
+Neo operates within the conversing user's [RBAC entitlements](/docs/administration/access-identity/rbac/) and cannot perform actions that the user couldn't perform themselves — there's no privilege escalation, and tasks are private to the user who created them unless they [share one](/docs/ai/neo/tasks/#ownership-and-sharing). For the full picture of which identity Neo acts as on each surface, how permission and approval modes constrain it, and how to scope its access, see [Neo's permissions model](/docs/ai/neo/permissions/).
 
 ### Read-only mode
 
@@ -45,7 +45,7 @@ Read-only is scoped to Pulumi Cloud. It does not, on its own, prevent Neo from o
 
 ### Enable Neo for Your Organization
 
-Neo is automatically enabled for eligible organizations. To access Neo:
+Neo is included on every current Pulumi plan and is on by default, so there is nothing to turn on. (Organizations still on the legacy Starter, Pro, or per-stack plans need to move to a current plan first — see [pricing](/pricing/).) To access Neo:
 
 1. Navigate to [Pulumi Cloud](https://app.pulumi.com/signin)
 2. Click on **Agent Tasks** within the **Neo** section in the left navigation menu

--- a/content/docs/ai/neo/integrations/cli/_index.md
+++ b/content/docs/ai/neo/integrations/cli/_index.md
@@ -71,7 +71,7 @@ The [Kubernetes Cluster Access](/docs/esc/guides/integrate-with/kubernetes-clust
 
 ## Setting up a CLI integration
 
-CLI integrations are configured by an organization administrator and are available to every Neo task in the organization once enabled.
+CLI integrations are configured by an organization administrator and are offered to every Neo task in the organization once enabled. Using one still takes the acting user's own access: Neo invokes the CLI with `pulumi env run`, as that user, so an integration works only for users who can open the backing ESC environment. Connecting an integration doesn't grant anyone access they didn't already have — see [Neo's permissions model](/docs/ai/neo/permissions/).
 
 ### 1. Create the ESC environment
 
@@ -123,7 +123,7 @@ Individual CLI invocations made by Neo during a task are visible in the task tra
 
 ## Troubleshooting
 
-**Neo says it can't run the CLI.** Most often the linked ESC environment is missing a required environment variable, or the credentials it produces aren't authorized for the action Neo attempted. Open the ESC environment in Pulumi Cloud and use **Open environment** to check what variables are emitted, then re-run the failing command locally with `pulumi env run <ref> -- <cli> <args>` to reproduce the error.
+**Neo says it can't run the CLI.** Most often the linked ESC environment is missing a required environment variable, or the credentials it produces aren't authorized for the action Neo attempted. If the failure is a Pulumi permission error rather than a cloud one, check that the user running the task can open the environment themselves — Neo opens it as them. Open the ESC environment in Pulumi Cloud and use **Open environment** to check what variables are emitted, then re-run the failing command locally with `pulumi env run <ref> -- <cli> <args>` to reproduce the error.
 
 **Neo picked the wrong account.** If you have several connected instances of the same CLI (for example, both `production-aws` and `staging-aws`), give them clearly distinguishable names and mention the name in your task prompt. You can also use [per-task selection](#per-task-selection) to limit the task to a single instance.
 

--- a/content/docs/ai/neo/permissions/_index.md
+++ b/content/docs/ai/neo/permissions/_index.md
@@ -1,0 +1,141 @@
+---
+title: Neo's permissions model
+title_tag: Neo's permissions model | Pulumi Neo
+h1: Neo's permissions model
+meta_desc: What Pulumi Neo can do, which identity it acts as on each surface, how permission and approval modes constrain it, and how to scope its access.
+menu:
+    ai:
+        name: Permissions model
+        parent: ai-neo
+        identifier: ai-permissions
+        weight: 12
+---
+
+This page is the canonical reference for Neo's permissions model: what Neo can do, which identity it acts as on each surface, what constrains it, and how to scope it down. If you are a security reviewer or platform admin answering "what can Neo do, as whom, and how do I constrain it?", start here.
+
+## The core invariant
+
+Neo acts on behalf of the user invoking it, and Neo can only do what that user could do themselves.
+
+- Neo operates within the acting user's [role-based access control (RBAC)](/docs/administration/access-identity/rbac/) entitlements and cannot perform actions that user couldn't perform.
+- There is no privilege escalation: Neo never gets more access than the user has, only the same or less.
+- Tasks are private to the user who created them. That user can [share a task](/docs/ai/neo/tasks/#ownership-and-sharing) with the rest of the organization as a read-only link: viewers see the conversation but cannot act through it, and any stack or resource it links to still enforces the viewer's own RBAC.
+
+The rest of this page describes which user Neo acts as on each surface, the ceiling that user's RBAC sets, and the controls that narrow it further.
+
+{{% notes type="info" %}}
+Today, Neo has no role of its own — it inherits the acting user's role. Fine-grained access control to scope Neo's access independently of the user is in development and will be an Enterprise and Business Critical capability. Until then, the lever for constraining Neo is the acting user's RBAC and the ESC environments they can open.
+{{% /notes %}}
+
+## Execution identity per surface
+
+Neo is one agent reachable from several places. Whichever surface starts a task, the task runs as a specific Pulumi identity:
+
+| Surface | Runs as | Notes |
+| :--- | :--- | :--- |
+| Pulumi Cloud console | The signed-in user | The main home for tasks, automations, and settings. |
+| [`pulumi neo`](/docs/ai/neo/pulumi-cli/) (CLI) | Your Pulumi user, via `pulumi login` | Also inherits your local setup: authenticated CLIs, environment variables, and kubeconfigs. |
+| [Slack](/docs/ai/neo/integrations/slack/) | The Pulumi user linked to your Slack identity | Requires connecting your Slack identity in Neo settings first. |
+| PR mentions / [code reviews](/docs/ai/neo/code-reviews/) | The Pulumi user matched to your VCS identity | Neo matches your GitHub identity to your Pulumi user. |
+| [Scheduled automations](/docs/ai/neo/automations/) | The user who scheduled the automation | RBAC is evaluated at execution time — if that user's permissions change, the new permissions apply. |
+| API / [MCP](/docs/ai/neo/integrations/mcp/)-created tasks | The Pulumi user whose token created the task | The task runs with that user's RBAC, exactly as if they had started it in the console. |
+
+These identities govern what Neo does in Pulumi Cloud. Writes to your version control provider are a separate matter: Neo authenticates as the shared app installation for its VCS interactions no matter which surface started the task (see [VCS identity per provider](#vcs-identity-per-provider)).
+
+Because a task's Pulumi RBAC is evaluated at execution time, it never runs with stale permissions: if the acting user is deactivated or loses access, the task loses that access immediately, including in the middle of a running task.
+
+## What Neo can access, per Pulumi Cloud area
+
+Neo's access ceiling is the acting user's RBAC. Within that ceiling, Neo reads broadly — it leans on the Pulumi Cloud APIs heavily to retrieve and search your infrastructure — and it makes changes two ways: through code and pull requests for anything you manage in IaC, and directly through the Pulumi Cloud APIs for anything you don't. Managing your Pulumi estate in IaC is therefore what routes Neo's changes through code review.
+
+| Area | What Neo can read | How Neo changes it |
+| :--- | :--- | :--- |
+| IaC stacks and state | Stack state, resources, and outputs for stacks the user can read | Proposes IaC code changes via [pull requests](/docs/ai/neo/pull-requests/) and runs `pulumi preview` / `pulumi up` (gated by [approval mode](#permission-mode-and-approval-mode)). It does not edit state directly. |
+| Environments and secrets ([ESC](/docs/esc/)) | Any environment the user can open — including decrypting secrets and minting dynamic cloud credentials | Through ESC code changes where the environment is managed in IaC; otherwise Neo edits the environment definition directly. |
+| Deployment settings | Settings the user can read | Through code and pull requests where the settings are managed in IaC; otherwise Neo edits them directly through the API. |
+| Policy packs | Packs and results the user can read | No direct management of policy packs. |
+| Insights / discovery (cloud) accounts | Accounts and scan results the user can read | No direct management of accounts. |
+| Audit logs | Logs, if the user holds an audit-log read permission (typically Admin) | Read-only resource. |
+
+### ESC, secrets, and downstream cloud access
+
+Neo inherits the acting user's ESC access. If the user can [open](/docs/administration/access-identity/rbac/) an environment (the `environment:open` permission), so can Neo — which means Neo can decrypt that environment's secrets and use any dynamic cloud credentials it mints. If an environment brokers OIDC credentials to an AWS, Azure, or Google Cloud account, Neo can assume those roles and operate in that cloud account, exactly as the user could.
+
+This has two consequences worth stating plainly:
+
+- **"Read-only" is scoped to Pulumi Cloud, not to your cloud accounts.** Read-only mode blocks writes in Pulumi Cloud and instructs Neo not to make modifications, but it does not technically prevent Neo from opening ESC environments or reaching the cloud accounts those environments unlock. Treat read-only as "no Pulumi Cloud mutations," not "no side effects anywhere."
+- **Handling of secret values.** Pulumi redacts secret values on the service side, so they are not stored in task history and are not visible to task viewers or Pulumi operators. This is a weaker guarantee than [MCP integration credentials](/docs/ai/neo/integrations/mcp/), which are never exposed to the language model at all: an ESC-sourced secret value *can* reach the model if a task reads it directly. The model is instructed to handle secrets with care, the model provider performs no retention of these values, and the value leaves the task context after the task idles. Where possible, Neo moves secret values without reading them into context — for example, redirecting a cloud CLI's output straight to a file.
+
+To constrain what Neo can reach, scope the acting user's RBAC and the ESC environments they can open. Prefer read-only cloud roles in ESC environments and broaden them deliberately.
+
+## Permission mode and approval mode
+
+Neo has two independent axes of control. Do not conflate them:
+
+| Axis | Values | Governs |
+| :--- | :--- | :--- |
+| **Permission mode** | `default` ("Use my permissions") / `read-only` | *What Neo can change.* Read-only removes the ability to trigger Pulumi Cloud writes while keeping read, preview, code, and PR abilities. |
+| **Approval mode** (also called task mode) | Review / Balanced / Auto | *When Neo pauses for your approval.* See the gates below. |
+
+Approval-mode gates:
+
+- **Review mode**: Neo requires approval before running `pulumi preview`, running `pulumi up`, and opening a pull request.
+- **Balanced mode**: Neo requires approval only before running `pulumi up`.
+- **Auto mode**: Neo does not require any approvals.
+
+{{% notes type="info" %}}
+In the `pulumi neo` CLI and the API, the strictest approval mode is named **`manual`**, which is the same mode the console calls **Review**. The permission-mode values (`default`, `read-only`) are the same in both places.
+{{% /notes %}}
+
+[Plan Mode](/docs/ai/neo/tasks/#plan-mode) is a separate, pre-execution control: it makes Neo research and agree on a plan with you before it acts, and it composes with any permission or approval mode.
+
+## What triggers an approval prompt
+
+Approval mode gates the Pulumi actions above — `pulumi preview`, `pulumi up`, and opening a pull request. It's important to understand what it does *not* gate.
+
+By design, Neo investigates autonomously. During the investigation phase it reads state, opens ESC environments, and reaches the cloud accounts, clusters, and integrations it has access to **without prompting for each action** — an explicit tradeoff to avoid approval fatigue on the many small reads a real investigation requires. Approval prompts apply to the Pulumi write actions listed above (and to sensitive writes Neo surfaces for confirmation), not to bare read access.
+
+The practical implication: if you need Neo to stay within a boundary, set that boundary with permissions (the user's RBAC and the ESC environments they can open), not by relying on approval prompts to catch every access.
+
+## The control inventory
+
+Every lever that shapes what a Neo task can do, and who sets it:
+
+| Control | Values | Configured by | Where |
+| :--- | :--- | :--- | :--- |
+| Permission mode | `default` / `read-only` | User, per task | Task creation; `--permission-mode` in the CLI |
+| Approval (task) mode | Review-`manual` / Balanced / Auto | User per task; org admin sets the default | Task UI; `--approval-mode` in the CLI; org default in [Settings](/docs/ai/neo/settings/#task-modes) |
+| Plan Mode | On / off | User, per task | Task UI; **Shift+Tab** in the CLI |
+| Per-automation overrides | Permission and approval mode | User who owns the automation | [Automations](/docs/ai/neo/automations/) |
+| Disable integrations for a task | On / off | User, per task | `--disable-integrations` in the CLI |
+| Neo master switch and per-feature toggles | On / off | Org admin | [Settings > Neo access](/docs/ai/neo/settings/#neo-access) |
+| Integration enablement and credentials | Per integration | Org admin | [Integrations](/docs/ai/neo/integrations/) |
+
+For scheduled automations, settings resolve in this order: the per-automation setting, then the org-level default, then the built-in fallback (auto approval and read-only permissions).
+
+Org-level defaults for permission and approval mode set the starting point for new tasks; a user can override them per task.
+
+[CLI integrations](/docs/ai/neo/integrations/cli/) are a distinct, admin-controlled capability: an organization admin configures them, and they are available to tasks run by users who can open the backing ESC environment, with whatever permissions that environment grants. Scope each integration's ESC environment to what Neo needs — prefer a read-only cloud role and broaden it deliberately.
+
+## VCS identity per provider
+
+Neo's version control writes do not run as you. Neo authenticates as the shared app installation for its VCS interactions — opening pull requests, pushing commits, commenting, posting checks. Creating a repository is the exception: that runs as your connected individual account, which is why it needs individual access.
+
+| Provider | Neo writes as | Individual access | Notes |
+| :--- | :--- | :--- | :--- |
+| GitHub.com | The shared Pulumi GitHub App for all VCS interactions (opening PRs, pushing commits, PR comments, checks); your connected GitHub account for creating repositories | **Required** to create repositories and to trigger [Neo code reviews](/docs/ai/neo/code-reviews/); optional otherwise | When a task needs individual access you don't have connected, Neo posts a nudge prompting you to grant it. |
+| GitHub Enterprise Server | The shared app installation by default; your connected account when individual user authentication is enabled | Enabled per integration by an admin, then connected per user | Business Critical edition. Scheduled Neo tasks and API-created operations always use the shared installation. |
+| Azure DevOps | The org integration handles PR comments and deployments; individual access lets Neo create repositories | Optional | Neo posts PR reviews when enabled (the default). |
+| GitLab | The org integration handles MR comments and deployments; individual access lets Neo create repositories | Optional | Neo posts MR reviews when enabled (the default). |
+| Bitbucket | The org integration handles PR comments and deployments; individual access lets Neo create repositories | Optional | Neo posts PR reviews when enabled (the default). |
+| [Custom VCS](/docs/integrations/version-control/custom-vcs/) | The credentials from the integration's ESC environment — a shared identity belonging to whoever configured the integration | N/A | Neo can clone and push (Git and Mercurial) but cannot open pull requests or create repositories on Custom VCS servers. |
+
+## Related resources
+
+- [Role-based access control](/docs/administration/access-identity/rbac/) — the permission model Neo inherits
+- [Least-privilege access](/docs/administration/security-compliance/least-privilege/) — scoping down what a user (and therefore Neo) can do
+- [Pulumi ESC](/docs/esc/) — environments, secrets, and dynamic credentials
+- [Tasks](/docs/ai/neo/tasks/) — Plan Mode and approval modes in depth
+- [Automations](/docs/ai/neo/automations/) — scheduled tasks and their defaults
+- [Integrations](/docs/ai/neo/integrations/) — MCP and CLI integration credentials
+- [Version control](/docs/integrations/version-control/) — per-provider VCS setup

--- a/content/docs/ai/neo/permissions/_index.md
+++ b/content/docs/ai/neo/permissions/_index.md
@@ -11,25 +11,25 @@ menu:
         weight: 12
 ---
 
-This page is the canonical reference for Neo's permissions model: what Neo can do, which identity it acts as on each surface, what constrains it, and how to scope it down. If you are a security reviewer or platform admin answering "what can Neo do, as whom, and how do I constrain it?", start here.
+This page is the canonical reference for Neo's permissions model: what Neo can do, which identity it acts as on each surface, what constrains it, and how to scope it down. If you are a security reviewer or platform admin working out what Neo can do, as whom, and how to constrain it, start here.
 
 ## The core invariant
 
 Neo acts on behalf of the user invoking it, and Neo can only do what that user could do themselves.
 
 - Neo operates within the acting user's [role-based access control (RBAC)](/docs/administration/access-identity/rbac/) entitlements and cannot perform actions that user couldn't perform.
-- There is no privilege escalation: Neo never gets more access than the user has, only the same or less.
+- No privilege escalation: Neo never gets more access than the user has, only the same or less.
 - Tasks are private to the user who created them. That user can [share a task](/docs/ai/neo/tasks/#ownership-and-sharing) with the rest of the organization as a read-only link: viewers see the conversation but cannot act through it, and any stack or resource it links to still enforces the viewer's own RBAC.
 
 The rest of this page describes which user Neo acts as on each surface, the ceiling that user's RBAC sets, and the controls that narrow it further.
 
 {{% notes type="info" %}}
-Today, Neo has no role of its own — it inherits the acting user's role. Fine-grained access control to scope Neo's access independently of the user is in development and will be an Enterprise and Business Critical capability. Until then, the lever for constraining Neo is the acting user's RBAC and the ESC environments they can open.
+Neo has no identity of its own: by default a task carries the acting user's full set of [role](/docs/administration/access-identity/rbac/) assignments. On Enterprise and Business Critical editions, a task can instead assume a single role, and then runs with that role's permissions in place of the user's own assignments. You can only assume a role you already hold, so this narrows Neo's access and never widens it. Per-task roles are still rolling out; if your organization doesn't have them yet, the levers for constraining Neo are the acting user's RBAC and the ESC environments they can open.
 {{% /notes %}}
 
 ## Execution identity per surface
 
-Neo is one agent reachable from several places. Whichever surface starts a task, the task runs as a specific Pulumi identity:
+Neo is one agent reachable from the surfaces below. Whichever surface starts a task, the task runs as a specific Pulumi identity:
 
 | Surface | Runs as | Notes |
 | :--- | :--- | :--- |
@@ -46,12 +46,12 @@ Because a task's Pulumi RBAC is evaluated at execution time, it never runs with 
 
 ## What Neo can access, per Pulumi Cloud area
 
-Neo's access ceiling is the acting user's RBAC. Within that ceiling, Neo reads broadly — it leans on the Pulumi Cloud APIs heavily to retrieve and search your infrastructure — and it makes changes two ways: through code and pull requests for anything you manage in IaC, and directly through the Pulumi Cloud APIs for anything you don't. Managing your Pulumi estate in IaC is therefore what routes Neo's changes through code review.
+Neo's access ceiling is the acting user's RBAC. Within that ceiling, Neo reads broadly — it leans on the Pulumi Cloud APIs heavily to retrieve and search your infrastructure — and it makes changes two ways: through code and pull requests for anything you manage in IaC, and directly through the Pulumi Cloud APIs for anything you don't. Managing your Pulumi estate in IaC is what routes Neo's changes through code review.
 
 | Area | What Neo can read | How Neo changes it |
 | :--- | :--- | :--- |
 | IaC stacks and state | Stack state, resources, and outputs for stacks the user can read | Proposes IaC code changes via [pull requests](/docs/ai/neo/pull-requests/) and runs `pulumi preview` / `pulumi up` (gated by [approval mode](#permission-mode-and-approval-mode)). It does not edit state directly. |
-| Environments and secrets ([ESC](/docs/esc/)) | Any environment the user can open — including decrypting secrets and minting dynamic cloud credentials | Through ESC code changes where the environment is managed in IaC; otherwise Neo edits the environment definition directly. |
+| Environments and secrets ([ESC](/docs/esc/)) | Any environment the user can open — including decrypting secrets and minting dynamic cloud credentials | Through ESC code changes where the environment is managed in IaC; otherwise Neo edits the environment definition directly. Environments with [update approvals](/docs/esc/concepts/approvals/) force those edits into a draft that a reviewer must approve. |
 | Deployment settings | Settings the user can read | Through code and pull requests where the settings are managed in IaC; otherwise Neo edits them directly through the API. |
 | Policy packs | Packs and results the user can read | No direct management of policy packs. |
 | Insights / discovery (cloud) accounts | Accounts and scan results the user can read | No direct management of accounts. |
@@ -64,9 +64,9 @@ Neo inherits the acting user's ESC access. If the user can [open](/docs/administ
 This has two consequences worth stating plainly:
 
 - **"Read-only" is scoped to Pulumi Cloud, not to your cloud accounts.** Read-only mode blocks writes in Pulumi Cloud and instructs Neo not to make modifications, but it does not technically prevent Neo from opening ESC environments or reaching the cloud accounts those environments unlock. Treat read-only as "no Pulumi Cloud mutations," not "no side effects anywhere."
-- **Handling of secret values.** Pulumi redacts secret values on the service side, so they are not stored in task history and are not visible to task viewers or Pulumi operators. This is a weaker guarantee than [MCP integration credentials](/docs/ai/neo/integrations/mcp/), which are never exposed to the language model at all: an ESC-sourced secret value *can* reach the model if a task reads it directly. The model is instructed to handle secrets with care, the model provider performs no retention of these values, and the value leaves the task context after the task idles. Where possible, Neo moves secret values without reading them into context — for example, redirecting a cloud CLI's output straight to a file.
+- **Handling of secret values.** ESC secrets carry a weaker guarantee than [MCP integration credentials](/docs/ai/neo/integrations/mcp/), which are never exposed to the language model at all: an ESC-sourced secret value *can* reach the model if a task reads it directly. Three things limit that exposure. Neo is instructed never to run `pulumi env open` or `pulumi env get --show-secrets`, and where possible it moves secret values without reading them into context — for example, redirecting a cloud CLI's output straight to a file. Pulumi then scans the events a task produces for credential patterns and replaces what it detects with `[REDACTED]` before storing them, so detected values stay out of task history, shared task views, and Slack and pull request output. Treat that scan as defense in depth rather than a guarantee: it matches known credential shapes, not every string a secret value could take. Neo's models run through Amazon Bedrock, which does not retain prompts or completions, and an idle task's runtime session is torn down — the next turn rebuilds context from the stored, redacted history.
 
-To constrain what Neo can reach, scope the acting user's RBAC and the ESC environments they can open. Prefer read-only cloud roles in ESC environments and broaden them deliberately.
+To constrain what Neo can reach, scope the acting user's RBAC and the ESC environments they can open. Prefer read-only cloud roles in ESC environments and broaden them deliberately. For the environments that unlock the most, [ESC open approvals](/docs/esc/concepts/approvals/) put a reviewer in front of every attempt to open them — including Neo's, since Neo opens them as you.
 
 ## Permission mode and approval mode
 
@@ -75,7 +75,7 @@ Neo has two independent axes of control. Do not conflate them:
 | Axis | Values | Governs |
 | :--- | :--- | :--- |
 | **Permission mode** | `default` ("Use my permissions") / `read-only` | *What Neo can change.* Read-only removes the ability to trigger Pulumi Cloud writes while keeping read, preview, code, and PR abilities. |
-| **Approval mode** (also called task mode) | Review / Balanced / Auto | *When Neo pauses for your approval.* See the gates below. |
+| **Approval mode** (also called task mode) | Review / Balanced / Auto | *When Neo pauses for your approval.* Review is strictest; Auto never pauses. |
 
 Approval-mode gates:
 
@@ -108,14 +108,14 @@ Every lever that shapes what a Neo task can do, and who sets it:
 | Plan Mode | On / off | User, per task | Task UI; **Shift+Tab** in the CLI |
 | Per-automation overrides | Permission and approval mode | User who owns the automation | [Automations](/docs/ai/neo/automations/) |
 | Disable integrations for a task | On / off | User, per task | `--disable-integrations` in the CLI |
-| Neo master switch and per-feature toggles | On / off | Org admin | [Settings > Neo access](/docs/ai/neo/settings/#neo-access) |
+| Neo on/off switch and per-feature toggles | On / off | Org admin | [Settings > Neo access](/docs/ai/neo/settings/#neo-access) |
 | Integration enablement and credentials | Per integration | Org admin | [Integrations](/docs/ai/neo/integrations/) |
 
 For scheduled automations, settings resolve in this order: the per-automation setting, then the org-level default, then the built-in fallback (auto approval and read-only permissions).
 
 Org-level defaults for permission and approval mode set the starting point for new tasks; a user can override them per task.
 
-[CLI integrations](/docs/ai/neo/integrations/cli/) are a distinct, admin-controlled capability: an organization admin configures them, and they are available to tasks run by users who can open the backing ESC environment, with whatever permissions that environment grants. Scope each integration's ESC environment to what Neo needs — prefer a read-only cloud role and broaden it deliberately.
+[CLI integrations](/docs/ai/neo/integrations/cli/) are a distinct, admin-controlled capability: an organization admin points a CLI at an ESC environment, and every task in the organization is then offered that integration unless the user turns it off for the task. Being offered an integration is not the same as being able to use it. Neo invokes the CLI with `pulumi env run`, as the acting user, so the integration only works for users who can open the backing environment — for anyone else, the call fails with a permission error rather than handing over the environment's credentials. Connecting an integration doesn't widen anyone's access; it makes an environment the user could already open convenient for Neo to reach. Scope each integration's ESC environment to what Neo needs — prefer a read-only cloud role and broaden it deliberately.
 
 ## VCS identity per provider
 
@@ -130,11 +130,12 @@ Neo's version control writes do not run as you. Neo authenticates as the shared 
 | Bitbucket | The org integration handles PR comments and deployments; individual access lets Neo create repositories | Optional | Neo posts PR reviews when enabled (the default). |
 | [Custom VCS](/docs/integrations/version-control/custom-vcs/) | The credentials from the integration's ESC environment — a shared identity belonging to whoever configured the integration | N/A | Neo can clone and push (Git and Mercurial) but cannot open pull requests or create repositories on Custom VCS servers. |
 
-## Related resources
+## Learn more
 
 - [Role-based access control](/docs/administration/access-identity/rbac/) — the permission model Neo inherits
-- [Least-privilege access](/docs/administration/security-compliance/least-privilege/) — scoping down what a user (and therefore Neo) can do
+- [Least-privilege access](/docs/administration/security-compliance/least-privilege/) — scoping down what a user, and so Neo, can do
 - [Pulumi ESC](/docs/esc/) — environments, secrets, and dynamic credentials
+- [ESC approvals](/docs/esc/concepts/approvals/) — review gates on opening and updating an environment
 - [Tasks](/docs/ai/neo/tasks/) — Plan Mode and approval modes in depth
 - [Automations](/docs/ai/neo/automations/) — scheduled tasks and their defaults
 - [Integrations](/docs/ai/neo/integrations/) — MCP and CLI integration credentials

--- a/content/docs/ai/neo/pull-requests/_index.md
+++ b/content/docs/ai/neo/pull-requests/_index.md
@@ -28,7 +28,7 @@ Neo also analyzes pull requests that your team opens and leaves its feedback rig
 
 ### VCS integration
 
-Neo requires a [version control integration](/docs/integrations/version-control/) to read code from and create pull requests. Pulumi supports [GitHub](/docs/integrations/version-control/github-app/), [Azure DevOps](/docs/integrations/version-control/azure-devops-integration/), [GitLab](/docs/integrations/version-control/gitlab/), and [Bitbucket](/docs/integrations/version-control/bitbucket/). [Custom VCS](/docs/integrations/version-control/custom-vcs/) integrations let Neo clone and push, but not open pull requests. Without a VCS integration, Neo will not be able to view the IaC code backing a stack. Neo can still propose code changes, but they will not be fully contextualized to your IaC code.
+Neo requires a [version control integration](/docs/integrations/version-control/) to read code from and create pull requests. Pulumi supports [GitHub](/docs/integrations/version-control/github-app/), [Azure DevOps](/docs/integrations/version-control/azure-devops-integration/), [GitLab](/docs/integrations/version-control/gitlab/), and [Bitbucket](/docs/integrations/version-control/bitbucket/). [Custom VCS](/docs/integrations/version-control/custom-vcs/) integrations let Neo clone and push, but not open pull requests. Without a VCS integration, Neo cannot view the IaC code backing a stack. Neo can still propose code changes, but they are not fully contextualized to your IaC code.
 
 ### Code Access
 

--- a/content/docs/ai/neo/pull-requests/_index.md
+++ b/content/docs/ai/neo/pull-requests/_index.md
@@ -28,7 +28,7 @@ Neo also analyzes pull requests that your team opens and leaves its feedback rig
 
 ### VCS integration
 
-Neo requires a [version control integration](/docs/integrations/version-control/) to read code from and create pull requests. Pulumi supports [GitHub](/docs/integrations/version-control/github-app/), [Azure DevOps](/docs/integrations/version-control/azure-devops-integration/), and [GitLab](/docs/integrations/version-control/gitlab/). Without a VCS integration, Neo will not be able to view the IaC code backing a stack. Neo can still propose code changes, but they will not be fully contextualized to your IaC code.
+Neo requires a [version control integration](/docs/integrations/version-control/) to read code from and create pull requests. Pulumi supports [GitHub](/docs/integrations/version-control/github-app/), [Azure DevOps](/docs/integrations/version-control/azure-devops-integration/), [GitLab](/docs/integrations/version-control/gitlab/), and [Bitbucket](/docs/integrations/version-control/bitbucket/). [Custom VCS](/docs/integrations/version-control/custom-vcs/) integrations let Neo clone and push, but not open pull requests. Without a VCS integration, Neo will not be able to view the IaC code backing a stack. Neo can still propose code changes, but they will not be fully contextualized to your IaC code.
 
 ### Code Access
 

--- a/content/docs/ai/neo/pulumi-cli/_index.md
+++ b/content/docs/ai/neo/pulumi-cli/_index.md
@@ -25,8 +25,8 @@ You can ask Neo to investigate a failed preview, make changes to your program an
 
 The controls you have in Pulumi Cloud apply in the terminal:
 
-- **[Approval modes](/docs/ai/neo/tasks/#task-modes)** (manual, balanced, auto) govern whether Neo asks before using tools
-- **[Permission modes](/docs/ai/neo/tasks/#task-modes)** (default, read-only) govern what Neo can change
+- **[Approval modes](/docs/ai/neo/tasks/#task-modes)** (manual, balanced, auto) govern whether Neo asks before using tools. `manual` is the same mode the console calls **Review**.
+- **[Permission modes](/docs/ai/neo/permissions/#permission-mode-and-approval-mode)** (default, read-only) govern what Neo can change
 - **[Plan mode](/docs/ai/neo/tasks/#plan-mode)** lets Neo research and plan before executing (toggle with **Shift+Tab** before sending your first message)
 
 ## Integrations

--- a/content/docs/ai/neo/tasks/_index.md
+++ b/content/docs/ai/neo/tasks/_index.md
@@ -87,7 +87,7 @@ Each task belongs to the user who created it. By default, tasks are private, but
 Sharing preserves security boundaries:
 
 - Viewers can see the conversation but cannot trigger any actions
-- Links to stacks or resources within the shared task still enforce the viewer's existing [RBAC](/docs/pulumi-cloud/access-management/rbac/) permissions
+- Links to stacks or resources within the shared task still enforce the viewer's existing [RBAC](/docs/administration/access-identity/rbac/) permissions
 - The original task owner retains full control
 
 ### Interruptions and resuming


### PR DESCRIPTION
## What

Creates `content/docs/ai/neo/permissions/_index.md` as the single canonical reference for Neo's permissions model, consolidating content previously scattered across get-started, tasks, settings, automations, integrations, and the version-control provider pages. Answers the security-reviewer question "what can Neo do, as whom, and how do I constrain it?"

Sections: the core invariant · execution identity per surface · per-Pulumi-Cloud-area access (stacks, ESC/secrets, deployments, policy packs, insights accounts, audit logs) · ESC/secret handling · permission mode vs approval mode · what triggers approvals · the full control inventory · VCS identity per provider.

## Cleanup this enables (same PR)

- Reduced get-started's permission section to a summary linking to the new page (preserved the `#read-only-mode` anchor).
- Fixed stale RBAC links → `/docs/administration/access-identity/rbac/` (get-started, tasks).
- Pointed permission-mode references at the new page instead of the approval-only `#task-modes` anchor (automations, pulumi-cli).
- Added Bitbucket and Custom VCS to the supported-VCS lists (get-started, pull-requests).
- Noted CLI `manual` == console `Review`.
- Corrected get-started's misleading "code changes only" limitation.

## Sourcing / accuracy note

Several claims (ESC access model, secret handling, read-only being scoped to Pulumi Cloud, scheduled-task/GitHub.com identity) originated in Neo-team answers in #pulumi-neo (Florian Stadler), reconciling a real support incident (customer-support#2976). A later pass verified the flagged ones directly against `pulumi-service`:

- **CLI integrations are not a privilege-escalation exception.** Integrations are offered to every task in the org, but the agent invokes them via `pulumi env run` under the acting user's OBO token, so ESC enforces that user's `environment:open`. Availability is org-wide; use requires the user's own access. Both this page and `integrations/cli` now say so.
- **Per-task roles exist.** `CreateAgentTaskRequest.role` is public API and runs the task with that role's permissions in place of the creator's assignments, gated to Enterprise and above. Replaced the stale "no role of its own, in development" note.
- **Secret redaction is a pattern scan over stored events**, not knowledge of which values are secret — now described as such, and marked defense in depth rather than a guarantee.
- **ESC approvals** were added as a control: update approvals push Neo's direct environment edits through a reviewed draft; open approvals gate the environment access read-only mode doesn't cover.

**Open for a human:** per-task roles are verified at the API and SKU level, but whether the console exposes a role picker today is unconfirmed.

Fixes #20451

🤖 Generated with [Claude Code](https://claude.com/claude-code)
