### PR TITLE
ci(claude-update): whitelist trusted bots for #update-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -456,9 +456,10 @@ jobs:
           # docs-automation identity (the Docs Groundskeeper agent) and is
           # trusted like an internal author. The author string differs by source:
           # this workflow reads `gh pr view --json author` (`app/workprentice`)
-          # while claude-triage.yml reads the REST webhook `user.login`
-          # (`workprentice[bot]`), so both forms are listed in both files. Keep
-          # this list in sync with the matching check in claude-triage.yml.
+          # while claude-triage.yml and claude-update.yml read the REST webhook
+          # `user.login` (`workprentice[bot]`), so both forms are listed in
+          # every file. Keep this list in sync with the matching checks in
+          # claude-triage.yml and claude-update.yml.
           if [[ "$AUTHOR" == "github-copilot[bot]" || "$AUTHOR" == "eon-pulumi-agent[bot]" \
              || "$AUTHOR" == "app/workprentice" || "$AUTHOR" == "workprentice[bot]" ]]; then
             echo "has_write_access=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -116,8 +116,8 @@ jobs:
           # trusted like an internal author. The author string differs by source:
           # this workflow reads the REST webhook `user.login` (`workprentice[bot]`)
           # while claude-code-review.yml reads `gh pr view` (`app/workprentice`),
-          # so both forms are listed in both files. Keep this list in sync with
-          # the matching check in claude-code-review.yml.
+          # so both forms are listed in every file. Keep this list in sync with
+          # the matching checks in claude-code-review.yml and claude-update.yml.
           if [[ "$AUTHOR" == "github-copilot[bot]" || "$AUTHOR" == "eon-pulumi-agent[bot]" \
              || "$AUTHOR" == "workprentice[bot]" || "$AUTHOR" == "app/workprentice" ]]; then
             echo "has_write_access=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -194,6 +194,28 @@ jobs:
             AUTHOR="unknown"
           fi
 
+          # GitHub App bots are not collaborators, so the permission API
+          # below returns "none" for them. Trusted bots that drive review
+          # refreshes on this repo are whitelisted by name instead.
+          # `workprentice` is Joe Duffy's docs-automation identity (the Docs
+          # Groundskeeper agent) and is trusted like an internal author: it
+          # opens PRs, addresses the pinned-review findings, and then mentions
+          # `@claude #update-review` to re-verify them — which is exactly what
+          # this workflow does. Without this, that mention hits the
+          # collaborator lookup, resolves to "none", and the refresh silently
+          # no-ops. The author string differs by source: this workflow reads
+          # the comment/review/issue `user.login` (`workprentice[bot]`) while
+          # claude-code-review.yml reads `gh pr view` (`app/workprentice`), so
+          # both forms are listed. Keep this list in sync with the matching
+          # checks in claude-code-review.yml and claude-triage.yml.
+          if [[ "$AUTHOR" == "github-copilot[bot]" || "$AUTHOR" == "eon-pulumi-agent[bot]" \
+             || "$AUTHOR" == "workprentice[bot]" || "$AUTHOR" == "app/workprentice" ]]; then
+            echo "has_write_access=true" >> $GITHUB_OUTPUT
+            echo "author=$AUTHOR" >> $GITHUB_OUTPUT
+            echo "✓ Bot $AUTHOR is whitelisted for review refreshes"
+            exit 0
+          fi
+
           # Get user's permission level (admin, write, read, or none)
           PERMISSION=$(curl -s \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
### Proposed changes

`workprentice[bot]` cannot trigger `@claude #update-review` — the mention is accepted by the workflow's trigger filter, but the **Check repository write access** step then runs a `collaborators/{login}/permission` lookup, which returns `"none"` for GitHub App bots (they aren't collaborators). The refresh silently no-ops. This is exactly what happened on #20413, where `workprentice[bot]`'s two `#update-review` mentions produced a `SKIPPED` `claude-review` check and no refreshed review, forcing a fall back to `#new-review`.

`claude-code-review.yml` and `claude-triage.yml` already solve this: they short-circuit the same trusted bots (`github-copilot[bot]`, `eon-pulumi-agent[bot]`, `workprentice`/`workprentice[bot]`) by name **before** the collaborator lookup. `claude-update.yml` was the only one of the three missing the equivalent block.

This PR:

- **`claude-update.yml`** — adds the by-name bot whitelist to the write-access check, ahead of the permission API call. The block sets both `has_write_access=true` and the `author` output (which downstream steps use for attribution and the "Review updated on @author's request" notification). `workflow_dispatch` runs are unaffected — they already short-circuit earlier in the step.
- **`claude-code-review.yml` / `claude-triage.yml`** — updates the "keep this list in sync" cross-reference comments to name all three files now that the whitelist lives in three places.

No change to the trigger filter or the set of trusted bots — this only closes the gap for the review-refresh path.

### Related issues (optional)

Unblocks the `#update-review` path referenced in #20413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFTd5Y8YEjBiPnpqjFrnem)_