### PR TITLE
fix(tutorials): stop sidebar from overflowing into the footer

### DIFF
--- a/theme/src/scss/docs/_tutorials.scss
+++ b/theme/src/scss/docs/_tutorials.scss
@@ -8,6 +8,16 @@
     nav.main-nav {
         padding-top: 1.5rem !important;
 
+        // The sticky sidebar container (.docs-main-nav) is capped at the visible
+        // viewport height, but the tutorials menu renders its items directly in
+        // this nav — there's no inner scroll element like the docs section's
+        // <pulumi-docs-nav>. Make the nav itself the scroll container so a long
+        // menu scrolls internally instead of overflowing the sidebar and running
+        // down into the footer.
+        height: 100%;
+        min-height: 0;
+        overflow-y: auto;
+
         div.toc-header {
             @apply ml-0;
 


### PR DESCRIPTION
### Proposed changes

The tutorials left sidebar reuses the shared docs sticky container (`.docs-main-nav`), which is height-capped to the visible viewport. Unlike the `/docs` menu — whose items live in a `<pulumi-docs-nav>` element that scrolls internally — the tutorials nav renders its items directly in `nav.main-nav` with no inner scroll element, so a tall menu overflowed the container and ran down into the footer. This makes `nav.main-nav` its own scroll container (`height: 100%; min-height: 0; overflow-y: auto`), scoped to the `.section-tutorials`/`.section-collections` sections so it covers every tutorials and collection-taxonomy page without touching `/docs`.

### Related issues (optional)

N/A