### PR TITLE
docs(oidc-issuers): document deny-always-wins policy precedence

### DIFF
--- a/content/docs/administration/access-identity/oidc-issuers/_index.md
+++ b/content/docs/administration/access-identity/oidc-issuers/_index.md
@@ -95,7 +95,7 @@ Each policy must state the **Token type** the policy issues (Organization, Team,
 
 We recommend verifying the token's audience and subject claims against the provider's security guidance. For example, a GitHub Actions policy commonly checks `aud` against `urn:pulumi:org:<org-name>` and `sub` against `repo:<organization>/<repo>:*`.
 
-When a token's claims match more than one policy, **deny always takes precedence over allow**, regardless of how the policies are ordered or how specific each policy's claim match is. If you need to carve out an exception to a broad deny policy, narrow the deny policy's own claim match instead of adding a more specific allow policy — a narrower allow will not override a matching deny.
+When a token's claims match more than one policy, **deny always takes precedence over allow**, regardless of how the policies are ordered or how specific each policy's claim match is.
 
 To target nested claims, define the claim path. Given this token payload:
 

--- a/content/docs/administration/access-identity/oidc-issuers/_index.md
+++ b/content/docs/administration/access-identity/oidc-issuers/_index.md
@@ -95,6 +95,8 @@ Each policy must state the **Token type** the policy issues (Organization, Team,
 
 We recommend verifying the token's audience and subject claims against the provider's security guidance. For example, a GitHub Actions policy commonly checks `aud` against `urn:pulumi:org:<org-name>` and `sub` against `repo:<organization>/<repo>:*`.
 
+When a token's claims match more than one policy, **deny always takes precedence over allow**, regardless of how the policies are ordered or how specific each policy's claim match is. If you need to carve out an exception to a broad deny policy, narrow the deny policy's own claim match instead of adding a more specific allow policy — a narrower allow will not override a matching deny.
+
 To target nested claims, define the claim path. Given this token payload:
 
 ```json


### PR DESCRIPTION
## Summary

Pulumi Cloud OIDC authorization policies evaluate deny before allow: when a token's claims match more than one policy, deny wins regardless of array order or how specific each policy's claim match is. This isn't documented anywhere, and it's a real footgun — a narrower `allow` policy will not override a broader matching `deny`, which is easy to assume otherwise.

Adds a short paragraph to the "Configure the authorization policies" section spelling this out and pointing readers at the actual fix (narrow the `deny` policy's own claim match, not add a more specific `allow`).

## Test plan

- [x] Confirm the added paragraph renders correctly under `content/docs/administration/access-identity/oidc-issuers/_index.md#configure-the-authorization-policies`