### PR TITLE
Restore GrowthBook A/B testing integration

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,19 +3,27 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0" />
 
-    <!-- Segment keys -->
+    <!-- GrowthBook / Segment keys -->
     <script>
         {{- if eq hugo.Environment "production" }}
             var segmentWriteKey = "UK90Ofwacetj5VCPJ7cUgkbNcKLSHO3u";
             var snippetName = "C8Y429BDEy/06ujkUhzfL.min.js";
+            window.growthbook_sdk_key="sdk-psPofGr6jFV2ja9O";
+            window.growthbook_decrypt_key="9NsAVMNWaDS+Oky3rhLQ+A==";
+            window.growthbook_dev_mode=false;
         {{- else }}
             var segmentWriteKey = "bATvhu6XKpwi7Cs258MGsELkDpVOzvdY";
             var snippetName = "C8Y429BDEy/hpBKpR8Nx1yVCjKPB2nJWg.min.js";
+            window.growthbook_sdk_key="sdk-BwIkZCqXQ9pZyp0P";
+            window.growthbook_decrypt_key=undefined;
+            window.growthbook_dev_mode=true;
         {{- end }}
     </script>
 
     <!-- Preconnect to Segment (used on every page). -->
     <link rel="preconnect" href="https://cdn.segment.com" crossorigin />
+    <!-- Preconnect to GrowthBook (A/B testing, used on every page). -->
+    <link rel="preconnect" href="https://cdn.growthbook.io" crossorigin />
     {{- if eq hugo.Environment "production" }}
     <!-- Preconnect to Common Room (production only). -->
     <link rel="preconnect" href="https://cdn.cr-relay.com" crossorigin />

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1077.0",
+    "@growthbook/growthbook": "^1.6.5",
     "@octokit/rest": "^21.1.1",
     "@resvg/resvg-js": "^2.6.2",
     "algoliasearch": "^5.55.1",

--- a/theme/package.json
+++ b/theme/package.json
@@ -10,6 +10,7 @@
         "@algolia/autocomplete-plugin-tags": "^1.19.9",
         "@algolia/autocomplete-theme-classic": "^1.19.9",
         "@algolia/client-search": "^5.55.1",
+        "@growthbook/growthbook": "^1.6.5",
         "@types/marked": "^4.0.8",
         "algoliasearch": "^5.55.1",
         "clipboard-polyfill": "^3.0.3",

--- a/theme/stencil/src/util/util.ts
+++ b/theme/stencil/src/util/util.ts
@@ -1,4 +1,42 @@
 import * as uuid from "uuid";
+import { GrowthBook } from "@growthbook/growthbook";
+
+// Initialize GrowthBook
+export const gb = new GrowthBook({
+    apiHost: "https://cdn.growthbook.io",
+    clientKey: (window as any).growthbook_sdk_key,
+    decryptionKey: (window as any).growthbook_decrypt_key,
+    enableDevMode: (window as any).growthbook_dev_mode,
+});
+
+gb.init({ streaming: true });
+
+// Hook up GrowthBook to analytics when ready
+(window as any).analytics.ready(function() {
+    gb.setTrackingCallback((experiment, result) => {
+        (window as any).analytics.track("Experiment Viewed", {
+            experimentId: experiment.key,
+            variationId: result.key,
+        });
+    });
+
+    gb.setAttributes({
+    // Set Anon/UserId for GB
+    ...gb.getAttributes(),
+        id: (window as any).analytics.user().anonymousId(),
+        userId: (window as any).analytics.user().id(),
+        url: (window as any).location.href,
+        path: (window as any).location.pathname,
+        query: (window as any).location.search,
+        referrer: document.referrer,
+        utmCampaign: getQueryVariable("utm_campaign"),
+        utmSource: getQueryVariable("utm_source"),
+        utmMedium: getQueryVariable("utm_medium"),
+        utmTerm: getQueryVariable("utm_term"),
+        utmContent: getQueryVariable("utm_content"),
+    })
+})
+    
 
 // Extracts a query string variable from the browser's location.
 export function getQueryVariable(paramKey: string): string | null {

--- a/theme/yarn.lock
+++ b/theme/yarn.lock
@@ -227,6 +227,13 @@
   dependencies:
     tslib "^2.4.0"
 
+"@growthbook/growthbook@^1.6.5":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-1.6.5.tgz#c9e2119187ee3288525a77a7c64353276f5ba91b"
+  integrity sha512-mUaMsgeUTpRIUOTn33EUXHRK6j7pxBjwqH4WpQyq+pukjd1AIzWlEa6w7i6bInJUcweGgP2beXZmaP6b6UPn7A==
+  dependencies:
+    dom-mutator "^0.6.0"
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -1042,6 +1049,11 @@ detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
+dom-mutator@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/dom-mutator/-/dom-mutator-0.6.0.tgz#079d7a4b3e8981a562cd777548b99baab51d65c5"
+  integrity sha512-iCt9o0aYfXMUkz/43ZOAUFQYotjGB+GNbYJiJdz4TgXkyToXbbRy5S6FbTp72lRBtfpUMwEc1KmpFEU4CZeoNg==
 
 dom-serializer@^1.0.1:
   version "1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,6 +474,13 @@
     "@shikijs/types" "^3.23.0"
     "@shikijs/vscode-textmate" "^10.0.2"
 
+"@growthbook/growthbook@^1.6.5":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-1.6.5.tgz#c9e2119187ee3288525a77a7c64353276f5ba91b"
+  integrity sha512-mUaMsgeUTpRIUOTn33EUXHRK6j7pxBjwqH4WpQyq+pukjd1AIzWlEa6w7i6bInJUcweGgP2beXZmaP6b6UPn7A==
+  dependencies:
+    dom-mutator "^0.6.0"
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"
@@ -2437,6 +2444,11 @@ devtools-protocol@0.0.1581282:
   version "0.0.1581282"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz#7f289b837e052ad04eb16e9575877801c2b3716c"
   integrity sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==
+
+dom-mutator@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/dom-mutator/-/dom-mutator-0.6.0.tgz#079d7a4b3e8981a562cd777548b99baab51d65c5"
+  integrity sha512-iCt9o0aYfXMUkz/43ZOAUFQYotjGB+GNbYJiJdz4TgXkyToXbbRy5S6FbTp72lRBtfpUMwEc1KmpFEU4CZeoNg==
 
 dom-serializer@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Brings GrowthBook back so we can resume A/B testing. This effectively reverts #18319, which removed it back in April to test PageSpeed impact.

## What's restored

- **`@growthbook/growthbook` dependency** in root + `theme/package.json`; both lockfiles regenerated (pulls `dom-mutator` back too).
- **SDK init + Segment tracking** in `theme/stencil/src/util/util.ts` — initializes against `cdn.growthbook.io`, fires `analytics.track("Experiment Viewed", …)` on exposure, and sets anon/user/UTM attributes.
- **Window keys + preconnect** in `head.html` (prod/non-prod SDK keys, `cdn.growthbook.io` preconnect).

## Things worth knowing before this merges

1. **"Latest" is 1.6.5 — the same version that was removed.** npm's current latest for `@growthbook/growthbook` is `1.6.5`, so there's no newer release to bump to; the init API is unchanged.
2. **This re-incurs the PageSpeed cost #18319 removed.** That PR pulled GrowthBook specifically to test load performance, *after* it had already been deferred and given a preconnect. Re-adding it brings that third-party request chain back. It's restored in its previously-optimized form (deferred init + preconnect), but the tradeoff is real — worth a Lighthouse check before marking ready.
3. **Ad-blocker exposure.** It calls `cdn.growthbook.io` directly. That host isn't on any current blocklist (I checked ~11, including Hagezi/OISD), but given past blocking pain, the durable fix is to **proxy it behind a first-party path** (like Segment's `evs.analytics.pulumi.com`) via a custom `apiHost`. Happy to do that as a follow-up — it's an infra change (subdomain/worker), not code-only.
4. **Verify the SDK keys are still valid** in the GrowthBook account — they're restored as-is from the April code and may have rotated.

## Deliberately NOT restored

- **The two April experiment files** (`cta-activations-direct-vs-docs`, `terraform-compare`): they were orphaned (imported by nothing), stale (Feb-2026 feature keys / old DOM selectors), and unnecessary — `util.ts` is imported by core Stencil components (`root`, `tooltip`, forms), so the GrowthBook init runs regardless. Define new experiments fresh (dashboard or new files).
- **`label-dependabot.yml` / `BUILD-AND-DEPLOY.md` references**: those sections were restructured since April; the original anchors are gone, so re-adding them would resurrect obsolete structure.

## Verification

- `@growthbook/growthbook@1.6.5` resolves in `node_modules`; lockfiles updated.
- Production Hugo build renders the prod SDK key + `cdn.growthbook.io` preconnect in `<head>`.
- Pre-commit (Prettier) passed.
- **CI should confirm the full theme/Stencil JS build** — I restored previously-working code with deps installed, but didn't run the complete bundle build locally.

Left as **draft** pending your review of the PageSpeed tradeoff and whether you want the first-party proxy folded in before this goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)