### PR TITLE
docs(rest-api): remove enum comment suppression guard clause

### DIFF
--- a/layouts/partials/openapi/enum-values.html
+++ b/layouts/partials/openapi/enum-values.html
@@ -10,23 +10,12 @@
 
   Input: dict with "schema" — the schema or property object holding `.enum`.
 */}}
-{{/*
-  Descriptions to suppress: a few upstream enum comments are engineer-facing
-  implementation notes, not public API docs (e.g. "…is an implementation quirk…",
-  "Do not remove this type - it is used by Pulumi Cloud code"). Keyed by
-  "<enumTypeName>.<fieldName>". The value's name still renders; only its comment
-  is withheld. Remove an entry once the comment is reworded at the source (the
-  pulumi-service Java IDL, which generates the OpenAPI spec).
-*/}}
-{{ $suppressComments := slice "StackPermission.Creator" "AppUpdateKind.Rename" }}
 {{ $schema := .schema }}
 {{ $enum := $schema.enum }}
 {{ $ext := index $schema "x-pulumi-model-property" }}
-{{ $typeName := "" }}
 {{ $names := slice }}
 {{ $comments := slice }}
 {{ with $ext }}
-  {{ $typeName = .enumTypeName | default "" }}
   {{ with .enumFieldNames }}{{ $names = . }}{{ end }}
   {{ with .enumFieldComments }}{{ $comments = . }}{{ end }}
 {{ end }}
@@ -37,7 +26,7 @@
       <dt><code>{{ $v }}</code> &mdash; {{ $fieldName }}</dt>
       {{ if lt $i (len $comments) }}
         {{ $c := index $comments $i }}
-        {{ if and $c (not (in $suppressComments (printf "%s.%s" $typeName $fieldName))) }}<dd>{{ $c | markdownify }}</dd>{{ end }}
+        {{ if $c }}<dd>{{ $c | markdownify }}</dd>{{ end }}
       {{ end }}
     {{ end }}
   </dl>


### PR DESCRIPTION
## Description

Removes the temporary guard clause in `layouts/partials/openapi/enum-values.html` that suppressed two engineer-facing enum field comments from the public REST API docs (`StackPermission.Creator` and `AppUpdateKind.Rename`).

The upstream fix — [pulumi/pulumi-service#46718](https://github.com/pulumi/pulumi-service/pull/46718), which rewords those comments at the source (the Java IDL that generates the OpenAPI spec) — has merged, so the guard is no longer needed. Enum comments now render whenever present.

The `$suppressComments` denylist and the `$typeName` variable that only fed it are both removed.

Fixes #20488

## Draft note

Kept as a **draft** until the reworded comments ship and are live in the OpenAPI spec consumed by this site. Once confirmed live, mark ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)