### PR TITLE
A/B test the marketing CTA changes (#20347)

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -210,7 +210,8 @@ params:
     cta:
         primary:
             label: "Get started"
-            href: "/docs/iac/get-started"
+            label_short: "Sign up"
+            href: "https://app.pulumi.com/signup"
         secondary:
             label: "Contact us"
             href: "/contact/?form=sales"

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,10 +8,6 @@ include_organization_schema: true
 sections:
   - type: hero
     layout: split
-    cta_primary_text: Get started
-    cta_primary_link: https://app.pulumi.com/signup
-    cta_secondary_text: Download open source
-    cta_secondary_link: /docs/install/
     badge_highlight_text: "New Release:"
     badge_text: "Building for the Agentic Era"
     badge_link: /releases/agentic-infrastructure-era/

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,6 +20,21 @@
         {{- end }}
     </script>
 
+    {{- /* A/B test 20260723-mktg-ctas anti-flicker (homepage only): hold the
+           hero secondary CTA hidden (space reserved) before first paint so its
+           label doesn't visibly flip while GrowthBook resolves the variant.
+           mktg-ctas-experiment.ts reveals it on resolve; the timeout is a
+           safety net so a slow/blocked GrowthBook can never leave it hidden. */ -}}
+    {{ if .IsHome }}
+    <style>html.mktg-ctas-pending a[data-role="cta-secondary"]{visibility:hidden}</style>
+    <script>
+        document.documentElement.classList.add("mktg-ctas-pending");
+        window.setTimeout(function () {
+            document.documentElement.classList.remove("mktg-ctas-pending");
+        }, 400);
+    </script>
+    {{ end }}
+
     <!-- Preconnect to Segment (used on every page). -->
     <link rel="preconnect" href="https://cdn.segment.com" crossorigin />
     <!-- Preconnect to GrowthBook (A/B testing, used on every page). -->

--- a/layouts/partials/template-partials/template-hero.html
+++ b/layouts/partials/template-partials/template-hero.html
@@ -155,7 +155,7 @@
                 </a>
                 {{ end }}
                 {{ if $ctaSecondaryText }}
-                <a href="{{ $ctaSecondaryLink }}"{{ partial "template-partials/external-link-attrs.html" $ctaSecondaryLink | safeHTMLAttr }} class="btn btn-outline btn-xl w-full sm:w-auto">{{ $ctaSecondaryText }}</a>
+                <a href="{{ $ctaSecondaryLink }}"{{ partial "template-partials/external-link-attrs.html" $ctaSecondaryLink | safeHTMLAttr }} class="btn btn-outline btn-xl w-full sm:w-auto" data-role="cta-secondary">{{ $ctaSecondaryText }}</a>
                 {{ end }}
                 {{ if $ctaTertiaryText }}
                 <a href="{{ $ctaTertiaryLink }}"{{ partial "template-partials/external-link-attrs.html" $ctaTertiaryLink | safeHTMLAttr }} class="btn btn-outline btn-xl w-full sm:w-auto">{{ $ctaTertiaryText }}</a>
@@ -230,7 +230,7 @@
                 </a>
                 {{ end }}
                 {{ if $ctaSecondaryText }}
-                <a href="{{ $ctaSecondaryLink }}"{{ partial "template-partials/external-link-attrs.html" $ctaSecondaryLink | safeHTMLAttr }} class="btn btn-outline btn-xl w-full lg:w-auto">{{ $ctaSecondaryText }}</a>
+                <a href="{{ $ctaSecondaryLink }}"{{ partial "template-partials/external-link-attrs.html" $ctaSecondaryLink | safeHTMLAttr }} class="btn btn-outline btn-xl w-full lg:w-auto" data-role="cta-secondary">{{ $ctaSecondaryText }}</a>
                 {{ end }}
                 {{ if $ctaTertiaryText }}
                 <a href="{{ $ctaTertiaryLink }}"{{ partial "template-partials/external-link-attrs.html" $ctaTertiaryLink | safeHTMLAttr }} class="btn btn-outline btn-xl w-full lg:w-auto">{{ $ctaTertiaryText }}</a>

--- a/theme/src/ts/main.ts
+++ b/theme/src/ts/main.ts
@@ -35,6 +35,7 @@ import "./neo-mode";
 import "./console-banner";
 import "./announcement-banner";
 import "./statuspage";
+import "./mktg-ctas-experiment";
 
 // Register all Stencil components.
 defineCustomElements();

--- a/theme/src/ts/mktg-ctas-experiment.ts
+++ b/theme/src/ts/mktg-ctas-experiment.ts
@@ -9,6 +9,13 @@ import { getQueryVariable } from "./util";
 // bucket, this reapplies the #20347 changes on the client. Gated on the
 // GrowthBook boolean feature `20260723-mktg-ctas`; preview the variant directly
 // with `?variant-mktg-ctas=1`.
+//
+// Anti-flicker: on the homepage, an inline snippet in head.html hides the hero
+// secondary CTA (via `mktg-ctas-pending` on <html>) before first paint so its
+// label doesn't visibly flip. We reveal it here once the decision is final
+// (GrowthBook features loaded, or a URL override). head.html also reveals after
+// a 400ms timeout as a safety net, so a slow/blocked GrowthBook can never leave
+// the button hidden.
 const EXPERIMENT_KEY = "20260723-mktg-ctas";
 
 const VARIANT = {
@@ -17,51 +24,57 @@ const VARIANT = {
     heroSecondaryHref: "/docs/install/",
 };
 
-function applyMktgCtasVariant() {
+function isVariant(): boolean {
     const urlVariant = getQueryVariable("variant-mktg-ctas");
-    const showVariant = urlVariant ? urlVariant === "1" : gb.isOn(EXPERIMENT_KEY);
-    if (!showVariant) {
-        return;
+    return urlVariant ? urlVariant === "1" : gb.isOn(EXPERIMENT_KEY);
+}
+
+// Apply the treatment (if bucketed) and reveal the held hero CTA. Runs only once
+// the decision is final, so control and variant both reveal from here.
+function applyAndReveal() {
+    if (isVariant()) {
+        // Top-nav "Get started" CTA (desktop + mobile sheet): repoint to the docs guide.
+        document
+            .querySelectorAll<HTMLAnchorElement>(
+                'a[data-track="header-signup"], a[data-track="header-signup-mobile"]',
+            )
+            .forEach(cta => {
+                cta.href = VARIANT.navHref;
+            });
+
+        // Homepage hero secondary: swap "Contact us" for "Download open source".
+        if (window.location.pathname === "/") {
+            document
+                .querySelectorAll<HTMLAnchorElement>('a[data-role="cta-secondary"]')
+                .forEach(secondary => {
+                    if (/contact us/i.test(secondary.textContent || "")) {
+                        secondary.textContent = VARIANT.heroSecondaryText;
+                        secondary.href = VARIANT.heroSecondaryHref;
+                    }
+                });
+        }
     }
 
-    // Top-nav "Get started" CTA (desktop + mobile sheet): repoint to the docs guide.
-    document
-        .querySelectorAll<HTMLAnchorElement>(
-            'a[data-track="header-signup"], a[data-track="header-signup-mobile"]',
-        )
-        .forEach(cta => {
-            cta.href = VARIANT.navHref;
-        });
+    // Reveal the held hero secondary (both arms) now that the decision is applied.
+    document.documentElement.classList.remove("mktg-ctas-pending");
+}
 
-    // Homepage hero secondary button: swap "Contact us" for "Download open source".
-    if (window.location.pathname === "/") {
-        document
-            .querySelectorAll<HTMLAnchorElement>('a[data-role="cta-get-started"]')
-            .forEach(primary => {
-                // The nav CTAs also carry data-role="cta-get-started"; we only want
-                // the hero's primary button, so skip anything inside the header.
-                if (primary.closest("header") || primary.closest("[data-nav-sheet]")) {
-                    return;
-                }
-                const secondary =
-                    primary.parentElement?.querySelector<HTMLAnchorElement>("a.btn-outline");
-                if (secondary && /contact us/i.test(secondary.textContent || "")) {
-                    secondary.textContent = VARIANT.heroSecondaryText;
-                    secondary.href = VARIANT.heroSecondaryHref;
-                }
-            });
+function whenDomReady(fn: () => void) {
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", fn, { once: true });
+    } else {
+        fn();
     }
 }
 
-// Re-run whenever GrowthBook (re)renders, e.g. once feature values have loaded.
+// Flag path: GrowthBook calls the renderer once feature values have loaded, so
+// the decision is final here for both control and variant.
 gb.setRenderer(() => {
-    applyMktgCtasVariant();
+    whenDomReady(applyAndReveal);
 });
 
-// Also run once directly: covers the `?variant-mktg-ctas=1` preview and the case
-// where the renderer fires before the DOM is ready.
-if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", applyMktgCtasVariant);
-} else {
-    applyMktgCtasVariant();
+// URL-override preview (`?variant-mktg-ctas=1`): apply immediately without
+// waiting for GrowthBook.
+if (getQueryVariable("variant-mktg-ctas")) {
+    whenDomReady(applyAndReveal);
 }

--- a/theme/src/ts/mktg-ctas-experiment.ts
+++ b/theme/src/ts/mktg-ctas-experiment.ts
@@ -1,21 +1,12 @@
 import { gb } from "../../stencil/src/util/util";
 import { getQueryVariable } from "./util";
 
-// A/B test for the marketing CTA changes originally shipped in #20347:
-//   - Top-nav "Get started" button destination
-//   - Homepage hero secondary button
-//
-// Control (rendered server-side) is the pre-#20347 behavior. For the treatment
-// bucket, this reapplies the #20347 changes on the client. Gated on the
-// GrowthBook boolean feature `20260723-mktg-ctas`; preview the variant directly
-// with `?variant-mktg-ctas=1`.
-//
-// Anti-flicker: on the homepage, an inline snippet in head.html hides the hero
-// secondary CTA (via `mktg-ctas-pending` on <html>) before first paint so its
-// label doesn't visibly flip. We reveal it here once the decision is final
-// (GrowthBook features loaded, or a URL override). head.html also reveals after
-// a 400ms timeout as a safety net, so a slow/blocked GrowthBook can never leave
-// the button hidden.
+// A/B test for the #20347 marketing CTA changes (nav destination + homepage
+// hero secondary), gated on the GrowthBook flag `20260723-mktg-ctas`; preview
+// with `?variant-mktg-ctas=1`. Control renders server-side; this reapplies the
+// treatment client-side for bucketed visitors. The hero secondary is held
+// hidden pre-paint (see head.html) to avoid a label flip, and revealed here
+// once the decision is final.
 const EXPERIMENT_KEY = "20260723-mktg-ctas";
 
 const VARIANT = {

--- a/theme/src/ts/mktg-ctas-experiment.ts
+++ b/theme/src/ts/mktg-ctas-experiment.ts
@@ -1,0 +1,67 @@
+import { gb } from "../../stencil/src/util/util";
+import { getQueryVariable } from "./util";
+
+// A/B test for the marketing CTA changes originally shipped in #20347:
+//   - Top-nav "Get started" button destination
+//   - Homepage hero secondary button
+//
+// Control (rendered server-side) is the pre-#20347 behavior. For the treatment
+// bucket, this reapplies the #20347 changes on the client. Gated on the
+// GrowthBook boolean feature `20260723-mktg-ctas`; preview the variant directly
+// with `?variant-mktg-ctas=1`.
+const EXPERIMENT_KEY = "20260723-mktg-ctas";
+
+const VARIANT = {
+    navHref: "/docs/iac/get-started",
+    heroSecondaryText: "Download open source",
+    heroSecondaryHref: "/docs/install/",
+};
+
+function applyMktgCtasVariant() {
+    const urlVariant = getQueryVariable("variant-mktg-ctas");
+    const showVariant = urlVariant ? urlVariant === "1" : gb.isOn(EXPERIMENT_KEY);
+    if (!showVariant) {
+        return;
+    }
+
+    // Top-nav "Get started" CTA (desktop + mobile sheet): repoint to the docs guide.
+    document
+        .querySelectorAll<HTMLAnchorElement>(
+            'a[data-track="header-signup"], a[data-track="header-signup-mobile"]',
+        )
+        .forEach(cta => {
+            cta.href = VARIANT.navHref;
+        });
+
+    // Homepage hero secondary button: swap "Contact us" for "Download open source".
+    if (window.location.pathname === "/") {
+        document
+            .querySelectorAll<HTMLAnchorElement>('a[data-role="cta-get-started"]')
+            .forEach(primary => {
+                // The nav CTAs also carry data-role="cta-get-started"; we only want
+                // the hero's primary button, so skip anything inside the header.
+                if (primary.closest("header") || primary.closest("[data-nav-sheet]")) {
+                    return;
+                }
+                const secondary =
+                    primary.parentElement?.querySelector<HTMLAnchorElement>("a.btn-outline");
+                if (secondary && /contact us/i.test(secondary.textContent || "")) {
+                    secondary.textContent = VARIANT.heroSecondaryText;
+                    secondary.href = VARIANT.heroSecondaryHref;
+                }
+            });
+    }
+}
+
+// Re-run whenever GrowthBook (re)renders, e.g. once feature values have loaded.
+gb.setRenderer(() => {
+    applyMktgCtasVariant();
+});
+
+// Also run once directly: covers the `?variant-mktg-ctas=1` preview and the case
+// where the renderer fires before the DOM is ready.
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", applyMktgCtasVariant);
+} else {
+    applyMktgCtasVariant();
+}


### PR DESCRIPTION
Instead of shipping Chris's Monday CTA changes ([#20347](https://github.com/pulumi/docs/pull/20347)) to 100% of traffic, this gates them behind a GrowthBook experiment so we can measure the impact before committing.

## Control vs. variant

| Surface | Control (this PR, rendered server-side) | Variant (#20347, applied for the treatment bucket) |
|---|---|---|
| Top-nav "Get started" | → `app.pulumi.com/signup` | → `/docs/iac/get-started` |
| Homepage hero secondary | "Contact us" → `/contact/?form=sales` | "Download open source" → `/docs/install/` |

_(The hero **primary** button was unchanged by #20347 — it stayed "Get started" → signup — so the experiment doesn't touch it. And `label_short` turned out to be unused dead config, so the only real nav change is the destination.)_

## How it works

- **Reverts #20347** (`config.yml` + `content/_index.md`) so the pre-change CTAs are the control, rendered for everyone by default.
- **`theme/src/ts/mktg-ctas-experiment.ts`** reapplies the #20347 variant on the client for the treatment bucket — same pattern as the earlier `signup-cta-experiment.ts`. Targets the nav via `data-track="header-signup"` / `header-signup-mobile`, and the hero secondary scoped to the homepage.
- Gated on the boolean flag **`20260723-mktg-ctas`** (already created in GrowthBook). Exposure is tracked automatically through the existing GrowthBook → Segment `"Experiment Viewed"` callback.
- **Preview the variant** without the flag: append `?variant-mktg-ctas=1` to any page.

## To go live

The flag exists but you still need to **turn the experiment on and set the traffic split** (e.g. 50/50) in the GrowthBook dashboard. Until then, everyone sees the control.

## Heads-up

- **This reverts Chris's live change back to control** until the experiment concludes — worth a note to him.
- **Brief flicker**: control renders first, then the variant is applied client-side once GrowthBook loads (inherent to client-side experiments; same as the prior CTA test).

## Verification

- `theme` webpack build compiles + bundles the experiment cleanly (exit 0, no errors).
- Hugo build confirms the control renders: nav → `app.pulumi.com/signup`, hero secondary "Contact us" → `/contact/`; neither variant string appears in the static HTML.
- Pre-commit (markdown lint + Prettier) passed.

Left as **draft** — flip to ready once you've confirmed the GrowthBook rollout and given Chris a heads-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)