### PR TITLE
content(events): wire HubSpot forms for Neo Docker Sandbox workshops

### DIFF
--- a/content/events/neo-in-a-docker-sandbox-eu/index.md
+++ b/content/events/neo-in-a-docker-sandbox-eu/index.md
@@ -76,7 +76,7 @@ tags:
 # The right hand side form section.
 form:
     # HubSpot form id.
-    hubspot_form_id:
-    salesforce_campaign_id:
+    hubspot_form_id: ef67fdd1-fe12-427d-84c3-f3b99476d792
+    salesforce_campaign_id: 701PQ00000yEZhiYAG
 
 ---

--- a/content/events/neo-in-a-docker-sandbox/index.md
+++ b/content/events/neo-in-a-docker-sandbox/index.md
@@ -76,7 +76,7 @@ tags:
 # The right hand side form section.
 form:
     # HubSpot form id.
-    hubspot_form_id:
-    salesforce_campaign_id:
+    hubspot_form_id: 37d15e98-1e00-4b10-864c-629d7f55d4a1
+    salesforce_campaign_id: 701PQ00000yEUGcYAO
 
 ---


### PR DESCRIPTION
## Summary

- Sets `hubspot_form_id` and `salesforce_campaign_id` on both Neo in a Docker Sandbox event pages, using the per-session IDs posted in pulumi/marketing#1798.
- US (`neo-in-a-docker-sandbox`): form `37d15e98-1e00-4b10-864c-629d7f55d4a1`, campaign `701PQ00000yEUGcYAO`.
- EU (`neo-in-a-docker-sandbox-eu`): form `ef67fdd1-fe12-427d-84c3-f3b99476d792`, campaign `701PQ00000yEZhiYAG`.

Note: the two sessions use different forms/campaigns per the issue comment, so each page gets its own pair.

## Test plan

- [x] IDs match the issue comment exactly
- [ ] Preview: registration form renders on both event pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)