### PR TITLE
layouts: add shared overline breadcrumb partial

### DIFF
--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -9,15 +9,11 @@
     {{ end }}
     <div class="font-body container mx-auto px-6 md:px-8 mt-16">
         <section id="hero" class="flex flex-col items-center text-center w-full max-w-4xl mx-auto">
-            <nav aria-label="Breadcrumb" class="mb-6">
-                <ol class="flex flex-wrap items-center justify-center gap-2 font-overline text-gray-600">
-                    <li><a class="hover:text-violet-700" href="/case-studies/">Case Studies</a></li>
-                    {{ with $industryName }}
-                    <li aria-hidden="true" class="text-gray-400">/</li>
-                    <li class="text-gray-900 font-medium"><a class="hover:text-violet-700" href="/case-studies/industry/{{ $industry }}/" data-track="case-study-industry-{{ $industry }}">{{ . }}</a></li>
-                    {{ end }}
-                </ol>
-            </nav>
+            {{ $crumbs := slice (dict "name" "Case Studies" "url" "/case-studies/") }}
+            {{ with $industryName }}
+                {{ $crumbs = $crumbs | append (dict "name" . "url" (printf "/case-studies/industry/%s/" $industry) "data_track" (printf "case-study-industry-%s" $industry)) }}
+            {{ end }}
+            {{ partial "breadcrumb.html" (dict "align" "center" "class" "mb-6" "crumbs" $crumbs) }}
             <h1 class="heading-1 text-black mb-6">{{ .Title }}</h1>
             {{ with .Description }}
             <p class="body-lg text-gray-primary mb-0 max-w-2xl">{{ . | markdownify }}</p>

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -15,15 +15,10 @@
 
         {{/* Breadcrumb + header */}}
         <div class="flex flex-col gap-4">
-            <nav class="event-breadcrumb">
-                <a href="/events/">Events and Workshops</a>
-                <span class="event-breadcrumb-separator">/</span>
-                {{ if .Params.youtube_url }}
-                    <a href="/events/#on-demand">On-demand</a>
-                {{ else }}
-                    <a href="/events/#upcoming">Upcoming</a>
-                {{ end }}
-            </nav>
+            {{ $second := dict "name" "Upcoming" "url" "/events/#upcoming" }}
+            {{ if .Params.youtube_url }}{{ $second = dict "name" "On-demand" "url" "/events/#on-demand" }}{{ end }}
+            {{ partial "breadcrumb.html" (dict "crumbs" (slice
+                (dict "name" "Events and Workshops" "url" "/events/") $second)) }}
 
             <section class="template-event-single-header">
                 <h1 class="event-single-title">{{ .Params.title }}</h1>

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,0 +1,24 @@
+{{/*
+    Shared overline breadcrumb (non-docs template pages).
+
+    The /docs section uses its own `.docs-breadcrumb` family
+    (layouts/partials/docs/breadcrumb.html) — do not use this partial there.
+
+    Params (dict):
+      crumbs — ordered slice of dicts, each { "name", "url" }, with an optional
+               "data_track" analytics attribute. Every entry is a PARENT page;
+               never include the current page.
+      align  — optional; "center" adds justify-center (default left).
+      class  — optional extra classes on <nav> (callers supply their own margin).
+*/}}
+<nav aria-label="Breadcrumb"{{ with .class }} class="{{ . }}"{{ end }}>
+    {{/* list-none/pl-0/m-0 and per-item my-0 keep content-area list styles
+         (main.scss `main ol`/`main li`) from leaking in when a caller renders
+         this inside <main>; the color lives on the <a> to beat `main li a`. */}}
+    <ol class="flex flex-wrap items-center gap-2 list-none pl-0 m-0 font-overline-sm{{ if eq .align "center" }} justify-center{{ end }}">
+        {{ range $i, $c := .crumbs }}
+            {{ if $i }}<li aria-hidden="true" class="my-0 text-gray-400">/</li>{{ end }}
+            <li class="my-0"><a class="text-gray-800 hover:text-gray-900" href="{{ $c.url }}"{{ with $c.data_track }} data-track="{{ . }}"{{ end }}>{{ $c.name }}</a></li>
+        {{ end }}
+    </ol>
+</nav>

--- a/layouts/what-is/single.html
+++ b/layouts/what-is/single.html
@@ -15,13 +15,9 @@
 <header class="page-hero text-left">
     <div class="container mx-auto px-6 lg:px-0 flex flex-col items-start">
         {{ $section := partial "what-is/section-for-page.html" . }}
-        <nav aria-label="Breadcrumb" class="max-w-4xl mx-auto mb-6">
-            <ol class="flex flex-wrap items-center gap-2 font-overline text-gray-600">
-                <li><a class="hover:text-violet-700" href="/what-is/">What Is</a></li>
-                <li aria-hidden="true" class="text-gray-400">/</li>
-                <li class="text-gray-900 font-medium"><a class="hover:text-violet-700" href="{{ $section.url }}">{{ $section.title }}</a></li>
-            </ol>
-        </nav>
+        {{ partial "breadcrumb.html" (dict "class" "max-w-4xl mx-auto mb-6" "crumbs" (slice
+            (dict "name" "What Is" "url" "/what-is/")
+            (dict "name" $section.title "url" $section.url))) }}
         <div class="page-hero-title">
             <h1>
                 <span><span data-text="{{ .Params.page_title }}">{{ .Params.page_title | safeHTML }}</span></span>

--- a/theme/src/scss/_templates.scss
+++ b/theme/src/scss/_templates.scss
@@ -644,18 +644,6 @@
 }
 
 // Single event page styles
-.event-breadcrumb {
-    @apply font-overline;
-
-    a {
-        @apply no-underline text-violet-primary;
-    }
-
-    .event-breadcrumb-separator {
-        @apply mx-2 text-gray-400;
-    }
-}
-
 .template-event-single-header {
     .event-single-title {
         @include page-header();


### PR DESCRIPTION
### Proposed changes

Consolidates the near-identical "all-caps mono overline" breadcrumb trails on the **what-is**, **case-studies**, and **events** single pages into one shared `layouts/partials/breadcrumb.html`, standardizing them on muted gray links (`text-gray-800`, darkening to `text-gray-900` on hover) with a slash separator and uniform crumbs that list only parent pages. The partial resets list styles and sets the link color on the anchor so it renders correctly whether it's inside `<main>` (events) or outside it (what-is/case-studies), and the now-dead `.event-breadcrumb` SCSS is removed. The `/docs` `.docs-breadcrumb` family is intentionally left untouched.