### PR TITLE
infra: grant DWH read access to content-review ledger bucket

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -308,21 +308,39 @@ if (config.enableDataWarehouseAccess) {
         bucket: contentReviewLedgerBucket.bucket,
         policy: pulumi.all([contentReviewLedgerBucket.arn, dwhBucketReaderRole])
             .apply(([bucketArn, roleArn]) => JSON.stringify({
-                "Version": "2012-10-17",
-                "Statement": [
+                Version: "2012-10-17",
+                Statement: [
+                    // Data warehouse (Snowpipe) read access. GetObjectVersion is
+                    // included because the ledger bucket is versioned and the
+                    // per-review history lives in S3 object versions.
                     {
-                        "Effect": "Allow",
-                        "Principal": { "AWS": roleArn },
-                        "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
-                        "Resource": bucketArn,
+                        Sid: "DataWarehouseReadObjects",
+                        Effect: "Allow",
+                        Principal: { AWS: roleArn },
+                        Action: ["s3:GetObject", "s3:GetObjectVersion"],
+                        Resource: `${bucketArn}/*`
                     },
                     {
-                        "Effect": "Allow",
-                        "Principal": { "AWS": roleArn },
-                        "Action": ["s3:GetObject"],
-                        "Resource": `${bucketArn}/*`,
+                        Sid: "DataWarehouseListBucket",
+                        Effect: "Allow",
+                        Principal: { AWS: roleArn },
+                        Action: ["s3:ListBucket", "s3:GetBucketLocation"],
+                        Resource: bucketArn
                     },
-                ],
+                    // Enforce TLS
+                    {
+                        Sid: "RestrictToTLSRequestsOnly",
+                        Effect: "Deny",
+                        Principal: "*",
+                        Action: "s3:*",
+                        Resource: [bucketArn, `${bucketArn}/*`],
+                        Condition: {
+                            Bool: {
+                                "aws:SecureTransport": "false"
+                            }
+                        }
+                    }
+                ]
             })),
     });
 }

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -298,6 +298,35 @@ new aws.s3.BucketPublicAccessBlock("content-review-ledger-public-access-block", 
     restrictPublicBuckets: true,
 });
 
+// Grant the data warehouse's Snowpipe reader role read access so the ledger can
+// be synced into Snowflake (pulumi/data#873). Only when DWH access is enabled.
+if (config.enableDataWarehouseAccess) {
+    const prodBucketsStack = new pulumi.StackReference("pulumi/dwh-workflows-loader-prodbuckets/production");
+    const dwhBucketReaderRole = prodBucketsStack.getOutput("dwhBucketReaderRole");
+
+    new aws.s3.BucketPolicy("content-review-ledger-dwh-read-policy", {
+        bucket: contentReviewLedgerBucket.bucket,
+        policy: pulumi.all([contentReviewLedgerBucket.arn, dwhBucketReaderRole])
+            .apply(([bucketArn, roleArn]) => JSON.stringify({
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": { "AWS": roleArn },
+                        "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+                        "Resource": bucketArn,
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Principal": { "AWS": roleArn },
+                        "Action": ["s3:GetObject"],
+                        "Resource": `${bucketArn}/*`,
+                    },
+                ],
+            })),
+    });
+}
+
 const bundlesBucket = new aws.s3.Bucket("bundles-bucket", {
     forceDestroy: true,
 });


### PR DESCRIPTION
## What

Adds a `BucketPolicy` on the `content-review-ledger` bucket granting the data warehouse's Snowpipe reader role read access (`s3:ListBucket` + `s3:GetBucketLocation` on the bucket, `s3:GetObject` on `/*`), so the daily content-review ledger can be synced into Snowflake.

The reader role ARN comes from a StackReference to `pulumi/dwh-workflows-loader-prodbuckets/production` (`dwhBucketReaderRole` output), and the whole block is gated behind the existing `enableDataWarehouseAccess` config flag — same pattern already used for the airflow DWH stack reference.

## Why

Onboarding the docs content-review ledger into the DWH — **pulumi/data#873**. Today the ledger only lives in S3; with this access the DWH can land it, model a `fct_content_review`, and power a small content-review-health dashboard for the docs team (coverage / freshness / fixes / backlog, weighted by traffic).

The DWH side (Snowpipe loader + dbt models + cube + Airflow) is in a separate `dwh-workflows` PR; this PR is the one cross-account permission it depends on.

## Notes

- No behavior change unless `enableDataWarehouseAccess` is set on the stack.
- Read-only access (no write/delete).

cc the content-review workflow / infra owner for review — this touches `infrastructure/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)