### PR TITLE
blog: add list/expanded view toggle to the homepage feed

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -21,7 +21,7 @@
                     {{ range . }}{{ partial "blog/card/small.html" (dict "page" .) }}{{ end }}
                 </div>
             {{ end }}
-            <div class="mb-6 flex items-center justify-between gap-4">
+            <div class="mb-6 flex items-start justify-between gap-4">
                 {{ partial "blog/filter-bar.html" . }}
                 {{ partial "blog/view-toggle.html" . }}
             </div>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -21,8 +21,9 @@
                     {{ range . }}{{ partial "blog/card/small.html" (dict "page" .) }}{{ end }}
                 </div>
             {{ end }}
-            <div class="mb-6">
+            <div class="mb-6 flex items-center justify-between gap-4">
                 {{ partial "blog/filter-bar.html" . }}
+                {{ partial "blog/view-toggle.html" . }}
             </div>
         {{ end }}
 

--- a/layouts/partials/blog/card/list-row.html
+++ b/layouts/partials/blog/card/list-row.html
@@ -32,10 +32,10 @@
     </div>
 
     {{/* Card view (toggled on). */}}
-    <div data-row-card class="hidden gap-4 py-6 md:gap-8">
+    <div data-row-card class="hidden items-center gap-4 py-6 md:gap-8">
         <div class="flex min-w-0 flex-1 flex-col items-start gap-2">
             {{ partial "blog/category-badge.html" (dict "category" $page.Params.category "link" false) }}
-            <h3 class="mt-1 mb-0!"><a href="{{ $page.RelPermalink }}" data-track="blog-card-{{ $page.Title | urlize }}" class="text-service-black transition-colors after:absolute after:inset-0 after:content-[''] group-hover:text-violet-primary">{{ $page.Title }}</a></h3>
+            <h3 class="heading-4 mt-1 mb-0!"><a href="{{ $page.RelPermalink }}" data-track="blog-card-{{ $page.Title | urlize }}" class="text-service-black transition-colors after:absolute after:inset-0 after:content-[''] group-hover:text-violet-primary">{{ $page.Title }}</a></h3>
             {{- with $excerpt }}<p class="m-0! body-sm text-service-black line-clamp-2">{{ . }}</p>{{ end -}}
             <div class="mt-1">{{ partial "blog/post-meta.html" (dict "page" $page) }}</div>
         </div>

--- a/layouts/partials/blog/card/list-row.html
+++ b/layouts/partials/blog/card/list-row.html
@@ -1,18 +1,49 @@
 {{- /*
-    Hairline list row: title (h4) left; category badge + avatar stack + date
-    right. `data-post-row` marks it for the client-side infinite-scroll /
-    category-filter JS to extract and append. Whole row is a stretched link.
+    Homepage feed row, rendered in two interchangeable forms inside one
+    `[data-post-row]` element; the homepage view toggle swaps which one shows by
+    putting `.is-cards` on the `[data-post-list]` container (see _blog.scss and
+    theme/src/ts/blog-list.ts). Carrying both forms in the markup means the
+    infinite-scroll / category-filter JS — which clones `[data-post-row]` nodes —
+    gets the toggle for free.
+
+      compact (default): title (h4) left; category badge + avatar stack + date
+                         right. Whole row is a stretched link.
+      cards:             category, title (h3), excerpt, byline stacked left, with
+                         an optional square feature image on the right — arranged
+                         like the other blog cards.
 
     Params: page (required) the post page.
 */ -}}
 {{- $page := .page -}}
-<article data-post-row data-category="{{ $page.Params.category }}" class="group relative flex flex-col md:flex-row items-start md:items-center gap-2 md:gap-4 border-b border-gray-200 py-6 last:border-0">
-    <h4 class="m-0! min-w-0 flex-1 md:truncate"><a href="{{ $page.RelPermalink }}" data-track="blog-row-{{ $page.Title | urlize }}" class="text-service-black transition-colors after:absolute after:inset-0 after:content-[''] group-hover:text-violet-primary">{{ $page.Title }}</a></h4>
-    <div class="flex shrink-0 items-center gap-2">
-        <span class="hidden md:inline-flex">{{ partial "blog/category-badge.html" (dict "category" $page.Params.category "link" false) }}</span>
-        <span class="w-32 mx-auto hidden md:inline-flex justify-center">
-        {{ partial "blog/avatars.html" (dict "authors" $page.Params.authors "label" false) }}
-        </span>
-        <time class="body-sm whitespace-nowrap text-service-black md:w-28 md:text-right" datetime="{{ $page.Date.Format "2006-01-02" }}">{{ $page.Date.Format "Jan 2, 2006" }}</time>
+{{- $excerpt := $page.Params.meta_desc -}}
+{{- if not $excerpt }}{{ $excerpt = $page.Summary | plainify | truncate 160 }}{{ end -}}
+<article data-post-row data-category="{{ $page.Params.category }}" class="group relative border-b border-gray-200 last:border-0">
+
+    {{/* Compact list view (default). */}}
+    <div data-row-compact class="flex flex-col md:flex-row items-start md:items-center gap-2 md:gap-4 py-6">
+        <h4 class="m-0! min-w-0 flex-1 md:truncate"><a href="{{ $page.RelPermalink }}" data-track="blog-row-{{ $page.Title | urlize }}" class="text-service-black transition-colors after:absolute after:inset-0 after:content-[''] group-hover:text-violet-primary">{{ $page.Title }}</a></h4>
+        <div class="flex shrink-0 items-center gap-2">
+            <span class="hidden md:inline-flex">{{ partial "blog/category-badge.html" (dict "category" $page.Params.category "link" false) }}</span>
+            <span class="w-32 mx-auto hidden md:inline-flex justify-center">
+            {{ partial "blog/avatars.html" (dict "authors" $page.Params.authors "label" false) }}
+            </span>
+            <time class="body-sm whitespace-nowrap text-service-black md:w-28 md:text-right" datetime="{{ $page.Date.Format "2006-01-02" }}">{{ $page.Date.Format "Jan 2, 2006" }}</time>
+        </div>
     </div>
+
+    {{/* Card view (toggled on). */}}
+    <div data-row-card class="hidden gap-4 py-6 md:gap-8">
+        <div class="flex min-w-0 flex-1 flex-col items-start gap-2">
+            {{ partial "blog/category-badge.html" (dict "category" $page.Params.category "link" false) }}
+            <h3 class="mt-1 mb-0!"><a href="{{ $page.RelPermalink }}" data-track="blog-card-{{ $page.Title | urlize }}" class="text-service-black transition-colors after:absolute after:inset-0 after:content-[''] group-hover:text-violet-primary">{{ $page.Title }}</a></h3>
+            {{- with $excerpt }}<p class="m-0! body-sm text-service-black line-clamp-2">{{ . }}</p>{{ end -}}
+            <div class="mt-1">{{ partial "blog/post-meta.html" (dict "page" $page) }}</div>
+        </div>
+        {{ if partial "blog/has-feature-image.html" $page }}
+        <div class="flex size-20 sm:size-28 lg:size-36 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-violet-950">
+            {{ partial "blog/feature-image.html" (dict "page" $page "w" 288 "h" 288 "mode" "fit" "class" "h-full w-auto max-w-none") }}
+        </div>
+        {{ end }}
+    </div>
+
 </article>

--- a/layouts/partials/blog/view-toggle.html
+++ b/layouts/partials/blog/view-toggle.html
@@ -1,0 +1,15 @@
+{{- /*
+    Homepage feed view toggle: compact list (default) vs. card rows. Mirrors the
+    /releases/ view control (partials/releases/changelog-index.html), but this
+    one is client-side — the buttons carry no href; theme/src/ts/blog-list.ts
+    toggles `.is-cards` on the `[data-post-list]` container and persists the
+    choice. The compact button is the server-rendered default (aria-current).
+*/ -}}
+<div data-blog-view-toggle role="group" aria-label="Post list view" class="btn-group shrink-0">
+    <button type="button" data-view="list" aria-current="page" aria-label="Compact list view" title="Compact list" data-track="blog-view-list" class="btn btn-icon-sm btn-outline">
+        {{ partial "icon.html" (dict "name" "list-dashes") }}
+    </button>
+    <button type="button" data-view="cards" aria-label="Card view" title="Cards" data-track="blog-view-cards" class="btn btn-icon-sm btn-outline">
+        {{ partial "icon.html" (dict "name" "cards") }}
+    </button>
+</div>

--- a/theme/src/scss/_blog.scss
+++ b/theme/src/scss/_blog.scss
@@ -44,6 +44,23 @@
     @apply border-gray-500 bg-gray-100;
 }
 
+// Homepage feed list/card view toggle (partials/blog/view-toggle.html +
+// theme/src/ts/blog-list.ts). Each row (partials/blog/card/list-row.html)
+// carries both a compact and a card representation; `.is-cards` on the
+// container swaps which one shows. `!important` beats the utilities-layer
+// display classes (`flex`/`hidden`) on the two row wrappers.
+[data-post-list].is-cards [data-row-compact] {
+    display: none !important;
+}
+[data-post-list].is-cards [data-row-card] {
+    display: flex !important;
+}
+
+// Selected pill in the view toggle — matches the category filter's active state.
+[data-blog-view-toggle] [aria-current="page"] {
+    @apply border-gray-500 bg-gray-100;
+}
+
 // Offset anchor / TOC jumps so the target heading clears the sticky site nav
 // instead of hiding under it.
 .blog-post-content :is(h1, h2, h3, h4, h5, h6) {

--- a/theme/src/ts/blog-list.ts
+++ b/theme/src/ts/blog-list.ts
@@ -32,6 +32,50 @@ document.addEventListener("DOMContentLoaded", () => {
     const paginator = document.querySelector<HTMLElement>("[data-paginator]");
     const filterBar = document.querySelector<HTMLElement>("[data-blog-filter]");
 
+    // --- Homepage list/card view toggle ---------------------------------------
+    // Each row carries both a compact and a card representation; `.is-cards` on
+    // the list container swaps which one shows (see _blog.scss). Appended /
+    // filtered rows clone the same markup, so they inherit the current view for
+    // free. The choice is remembered across visits.
+    const viewToggle = document.querySelector<HTMLElement>("[data-blog-view-toggle]");
+    if (viewToggle) {
+        const VIEW_KEY = "pulumi-blog-view";
+        const applyView = (view: string) => {
+            const cards = view === "cards";
+            list.classList.toggle("is-cards", cards);
+            viewToggle.querySelectorAll<HTMLElement>("[data-view]").forEach(btn => {
+                const on = (btn.dataset.view || "list") === (cards ? "cards" : "list");
+                if (on) {
+                    btn.setAttribute("aria-current", "page");
+                } else {
+                    btn.removeAttribute("aria-current");
+                }
+            });
+        };
+        let stored: string | null = null;
+        try {
+            stored = localStorage.getItem(VIEW_KEY);
+        } catch {
+            // localStorage unavailable (private mode / blocked) — default view.
+        }
+        if (stored === "cards") {
+            applyView("cards");
+        }
+        viewToggle.addEventListener("click", e => {
+            const btn = (e.target as HTMLElement).closest<HTMLElement>("[data-view]");
+            if (!btn) {
+                return;
+            }
+            const view = btn.dataset.view || "list";
+            applyView(view);
+            try {
+                localStorage.setItem(VIEW_KEY, view);
+            } catch {
+                // Ignore persistence failures; the toggle still works this session.
+            }
+        });
+    }
+
     // Snapshot the server-rendered "All" state so the filter can restore it.
     const originalHTML = list.innerHTML;
     const originalNextUrl = paginator ? paginator.getAttribute("data-next-url") : null;


### PR DESCRIPTION
### Proposed changes

Adds a client-side list/expanded view toggle to the right of the blog homepage filter bar (mirroring the `/releases/` button group). The default compact list view is unchanged; the expanded view arranges each row like the other blog cards — category, title, excerpt (meta description, falling back to a clamped summary), and byline — with an optional square feature image on the right. Each row carries both representations, so the infinite-scroll and category-filter paths inherit the toggle for free, and the choice is persisted to `localStorage` under a blog-scoped key. Homepage only.

### Related issues (optional)

https://github.com/pulumi/marketing/issues/1790

<img width="1348" height="649" alt="Screenshot 2026-07-24 at 11 43 28 AM" src="https://github.com/user-attachments/assets/f49a405b-9293-45c2-8371-bf688db57654" />

