### PR TITLE
ci(claude-update): allow workprentice bot to trigger #update-review

### DIFF
--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -408,7 +408,19 @@ jobs:
           # claude-code-action@v1 by default. Same allowance
           # claude-code-review.yml makes for its bot-dispatched #new-review
           # path.
-          allowed_bots: 'github-actions[bot]'
+          #
+          # workprentice is also listed so that its own `@claude
+          # #update-review` mentions (issue_comment events whose actor is the
+          # bot) reach the action. Without it, those mentions clear this
+          # workflow's own check-access whitelist (the workprentice[bot]
+          # branch above) and then get bounced by claude-code-action's
+          # independent bot guard. The trust decision is already made for the
+          # sibling review workflows — see the matching allowed_bots in
+          # claude-code-review.yml and claude-social-review.yml. Both the bare
+          # and `[bot]`-suffixed forms are listed because the action reports
+          # the actor as bare `workprentice` while github.actor renders it as
+          # `workprentice[bot]`.
+          allowed_bots: 'github-actions[bot],workprentice,workprentice[bot]'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
### Proposed changes

The `#update-review` flow errors on every `@claude #update-review` mention posted by `workprentice[bot]` (observed on #20501). The run fails inside the **Run Claude Code** step:

```
Actor type: Bot
Action failed with error: Workflow initiated by non-human actor:
workprentice (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

**Root cause:** the run clears this workflow's *own* `check-access` gate — which already whitelists `workprentice[bot]` (`claude-update.yml:211-217`) — but is then bounced by `anthropics/claude-code-action@v1`'s **independent** bot guard. That guard only trusts bots named in the action's `allowed_bots` input, and `claude-update.yml:411` listed only `github-actions[bot]` (which covers the auto-refresh `workflow_dispatch` path, not a direct comment whose actor is `workprentice`).

This is an omission, not a deliberate design gap: the two sibling review workflows were already updated to trust `workprentice`, and `claude-update.yml` was missed in that rollout:

| Workflow | `allowed_bots` |
|---|---|
| `claude-code-review.yml:967` | `github-actions[bot],workprentice,workprentice[bot]` ✅ |
| `claude-social-review.yml:264` | `github-actions[bot],workprentice,workprentice[bot]` ✅ |
| `claude-update.yml:411` (before) | `github-actions[bot]` ❌ |

**Fix:** add `workprentice` (and the bare form the action reports — `github.actor` renders `workprentice[bot]` while the action reports bare `workprentice`) to `allowed_bots`, matching the siblings. No new trust surface: the decision to trust `workprentice` was already made repo-wide.

Opened as a **draft** because @CamSoper noted on #20501 that he wants to revisit the bot/token-spend design; this makes the concrete one-line change available for that discussion rather than presuming the outcome.

### Related issues (optional)

Surfaced by the failing update-review runs on #20501.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2pvu643Uha4FkKRNiV3bJ)_