### PR TITLE
Add docs for using Neo in your editor via ACP

### DIFF
--- a/content/blog/copilot-in-vscode/index.md
+++ b/content/blog/copilot-in-vscode/index.md
@@ -10,6 +10,7 @@ feature_image: feature.png
 # date/time.
 date: 2025-02-03
 lastmod: 2026-06-30
+updated: 2026-07-28
 
 # The draft setting determines whether a post is published. Set it to true if
 # you want to be able to merge the post without publishing it.
@@ -52,7 +53,7 @@ social:
 ---
 
 {{< notes type="info" >}}
-Note: This post discusses Pulumi Copilot, which Pulumi Neo has replaced. [Learn about Neo →](/docs/ai/)
+Note: This post discusses Pulumi Copilot, which Pulumi Neo has replaced. The Pulumi Copilot Chat extension for VS Code is deprecated — instead, run [Neo directly in your editor](/docs/ai/neo/editors/) via the Agent Client Protocol.
 {{< /notes >}}
 
 Programming languages offer dozens of advantages for writing Infrastructure as Code (IaC). One of them is that Large Language Models are  effective at using general-purpose programming languages, thanks to the vast amount of high-quality training data available. Building on this advantage, we introduced Pulumi AI and Pulumi Copilot last year to enhance Infrastructure-as-Code development with generative AI capabilities. These tools have significantly streamlined infrastructure deployment for tens of thousands of developers.

--- a/content/blog/copilot-in-vscode/index.md
+++ b/content/blog/copilot-in-vscode/index.md
@@ -9,7 +9,6 @@ feature_image: feature.png
 # the time portion of the date value; posts are sorted in descending order by
 # date/time.
 date: 2025-02-03
-lastmod: 2026-06-30
 updated: 2026-07-28
 
 # The draft setting determines whether a post is published. Set it to true if

--- a/content/docs/administration/access-identity/rbac/scopes/org-settings.md
+++ b/content/docs/administration/access-identity/rbac/scopes/org-settings.md
@@ -40,7 +40,7 @@ Pulumi Cloud's configurable RBAC features are only available in the Pulumi Enter
 ## AI
 
 {{% notes "info" %}}
-These scopes control access to the legacy Pulumi Copilot conversation API, used only by the deprecated Pulumi Copilot VS Code extension. For Pulumi's current AI capabilities, see [Pulumi Neo](/docs/ai/) — including [Neo in your editor](/docs/ai/neo/editors/).
+These scopes control access to the legacy Pulumi Copilot conversation API, currently used only by the Pulumi Copilot VS Code extension. For Pulumi's current AI capabilities, see [Pulumi Neo](/docs/ai/).
 {{% /notes %}}
 
 | Value | Description |

--- a/content/docs/administration/access-identity/rbac/scopes/org-settings.md
+++ b/content/docs/administration/access-identity/rbac/scopes/org-settings.md
@@ -40,7 +40,7 @@ Pulumi Cloud's configurable RBAC features are only available in the Pulumi Enter
 ## AI
 
 {{% notes "info" %}}
-These scopes control access to the legacy Pulumi Copilot conversation API, currently used only by the Pulumi Copilot VS Code extension. For Pulumi's current AI capabilities, see [Pulumi Neo](/docs/ai/).
+These scopes control access to the legacy Pulumi Copilot conversation API, used only by the deprecated Pulumi Copilot VS Code extension. For Pulumi's current AI capabilities, see [Pulumi Neo](/docs/ai/) — including [Neo in your editor](/docs/ai/neo/editors/).
 {{% /notes %}}
 
 | Value | Description |

--- a/content/docs/ai/neo/_index.md
+++ b/content/docs/ai/neo/_index.md
@@ -64,6 +64,9 @@ controls, and integrations carry over whichever surface you start from.
   interactive session that inherits your local setup: the CLIs you've
   authenticated, your environment variables and kubeconfigs, and the project
   you're editing.
+- **Your editor.** Use [Neo in your editor's agent panel](/docs/ai/neo/editors/)
+  in Zed, JetBrains IDEs, VS Code, and Cursor through the Agent Client
+  Protocol, working on the project you have open.
 - **Slack.** Mention [`@Neo`](/docs/ai/neo/integrations/slack/) in any channel
   and it replies in the thread, so you can check stack state or investigate a
   failure without leaving the conversation.

--- a/content/docs/ai/neo/editors/_index.md
+++ b/content/docs/ai/neo/editors/_index.md
@@ -24,7 +24,7 @@ Like [Neo in the CLI](/docs/ai/neo/pulumi-cli/), an editor session runs locally 
 
 ## Zed
 
-Zed supports ACP agents natively. Go to **Settings** > **AI** > **External Agents** > **Configure**, then select **Add Agent** > **Add Custom Agent** and fill in:
+Zed supports ACP agents natively. Navigate to **Settings** > **AI** > **External Agents** > **Configure**, then select **Add Agent** > **Add Custom Agent** and fill in:
 
 - **Name**: `Pulumi Neo`
 - **Command**: `pulumi`

--- a/content/docs/ai/neo/editors/_index.md
+++ b/content/docs/ai/neo/editors/_index.md
@@ -15,7 +15,7 @@ Neo can run directly inside your editor's agent panel. You chat with Neo, review
 
 Editors connect to Neo through the [Agent Client Protocol (ACP)](https://agentclientprotocol.com), the same open standard they use to host agents like Claude Code and Gemini CLI. Zed and JetBrains IDEs support ACP natively; VS Code and Cursor support it through an extension.
 
-Like [Neo in the CLI](/docs/ai/neo/pulumi-cli/), an editor session runs locally and inherits your setup: your `pulumi login`, the CLIs you've authenticated, your environment variables and kubeconfigs, and the project you have open.
+Like [Neo in the CLI](/docs/ai/neo/pulumi-cli/), an editor session runs locally and inherits your setup: your `pulumi login`, the CLIs you've authenticated, your environment variables and kubeconfigs, and the project you have open. Neo edits your local files directly, so its changes show up in your working tree as it makes them.
 
 ## Prerequisites
 

--- a/content/docs/ai/neo/editors/_index.md
+++ b/content/docs/ai/neo/editors/_index.md
@@ -24,19 +24,11 @@ Like [Neo in the CLI](/docs/ai/neo/pulumi-cli/), an editor session runs locally 
 
 ## Zed
 
-Zed supports ACP agents natively. Open the agent settings (`agent: open settings`), go to **External Agents**, select **Add Agent** > **Add Custom Agent**, and add Neo to the `agent_servers` block in your `settings.json`:
+Zed supports ACP agents natively. Go to **Settings** > **AI** > **External Agents** > **Configure**, then select **Add Agent** > **Add Custom Agent** and fill in:
 
-```json
-{
-    "agent_servers": {
-        "Pulumi Neo": {
-            "type": "custom",
-            "command": "pulumi",
-            "args": ["neo", "acp"]
-        }
-    }
-}
-```
+- **Name**: `Pulumi Neo`
+- **Command**: `pulumi`
+- **Arguments**: `neo acp`
 
 Open the Agent Panel, start a new thread, and select **Pulumi Neo** as the agent.
 

--- a/content/docs/ai/neo/editors/_index.md
+++ b/content/docs/ai/neo/editors/_index.md
@@ -1,0 +1,90 @@
+---
+title: Neo in Your Editor
+title_tag: Neo in Your Editor
+h1: Neo in Your Editor
+meta_desc: Use Pulumi Neo directly inside Zed, JetBrains IDEs, VS Code, and Cursor through the Agent Client Protocol (ACP).
+menu:
+    ai:
+        name: Neo in your editor
+        identifier: ai-editors
+        parent: ai-neo
+        weight: 16
+---
+
+Neo can run directly inside your editor's agent panel. You chat with Neo, review its plans, and watch its edits in the same window as your code, with no separate terminal session or browser tab.
+
+Editors connect to Neo through the [Agent Client Protocol (ACP)](https://agentclientprotocol.com), the same open standard they use to host agents like Claude Code and Gemini CLI. Zed and JetBrains IDEs support ACP natively; VS Code and Cursor support it through an extension.
+
+Like [Neo in the CLI](/docs/ai/neo/pulumi-cli/), an editor session runs locally and inherits your setup: your `pulumi login`, the CLIs you've authenticated, your environment variables and kubeconfigs, and the project you have open.
+
+## Prerequisites
+
+1. [Pulumi CLI](/docs/install/) v3.254.0 or later
+1. Authenticate to Pulumi Cloud with `pulumi login`
+
+## Zed
+
+Zed supports ACP agents natively. Open the agent settings (`agent: open settings`), go to **External Agents**, select **Add Agent** > **Add Custom Agent**, and add Neo to the `agent_servers` block in your `settings.json`:
+
+```json
+{
+    "agent_servers": {
+        "Pulumi Neo": {
+            "type": "custom",
+            "command": "pulumi",
+            "args": ["neo", "acp"]
+        }
+    }
+}
+```
+
+Open the Agent Panel, start a new thread, and select **Pulumi Neo** as the agent.
+
+## JetBrains IDEs
+
+JetBrains IDEs (IntelliJ IDEA, GoLand, PyCharm, WebStorm, and the rest of the lineup) support ACP agents through JetBrains AI Assistant 2026.2 or later. Open the **AI Chat** tool window, open the chat menu, and select **Add Custom Agent**. The IDE opens `~/.jetbrains/acp.json` for editing; add Neo under `agent_servers`:
+
+```json
+{
+    "agent_servers": {
+        "Pulumi Neo": {
+            "command": "pulumi",
+            "args": ["neo", "acp"]
+        }
+    }
+}
+```
+
+If the IDE doesn't inherit your shell's `PATH`, use the full path to the `pulumi` binary in `command`. Restart the IDE after editing the file, then select **Pulumi Neo** from the agent selector in AI Chat.
+
+## VS Code and Cursor
+
+VS Code doesn't support ACP natively, so install the open source [ACP Client](https://marketplace.visualstudio.com/items?itemName=formulahendry.acp-client) extension. In Cursor (and other VS Code-compatible editors), install the same extension from the [Open VSX registry](https://open-vsx.org/extension/formulahendry/acp-client).
+
+Add Neo as a custom agent in your `settings.json`:
+
+```json
+{
+    "acp.agents": {
+        "Pulumi Neo": {
+            "command": "pulumi",
+            "args": ["neo", "acp"]
+        }
+    }
+}
+```
+
+Open the **ACP Client** panel from the Activity Bar and select **Pulumi Neo** to start a session.
+
+## Controls
+
+The controls you have elsewhere apply in your editor, exposed as session options in the agent UI:
+
+- **[Permission modes](/docs/ai/neo/permissions/#permission-mode-and-approval-mode)** (default, read-only) govern what Neo can change
+- **[Plan mode](/docs/ai/neo/tasks/#plan-mode)** lets Neo research and agree on a plan with you before executing
+
+Tool call approvals surface in the editor's agent panel, so you review Neo's actions the same way you review those of any other agent you run there.
+
+## How permissions work
+
+An editor session uses your existing `pulumi login` and the [RBAC permissions](/docs/administration/access-identity/rbac/) of your Pulumi user. Identity, RBAC, and audit all run through your Pulumi Cloud login, the same way they do in the console.

--- a/content/docs/ai/neo/editors/_index.md
+++ b/content/docs/ai/neo/editors/_index.md
@@ -1,11 +1,11 @@
 ---
-title: Neo in Your Editor
-title_tag: Neo in Your Editor
-h1: Neo in Your Editor
+title: Neo in Your Editor (ACP)
+title_tag: Neo in Your Editor (ACP)
+h1: Neo in Your Editor (ACP)
 meta_desc: Use Pulumi Neo directly inside Zed, JetBrains IDEs, VS Code, and Cursor through the Agent Client Protocol (ACP).
 menu:
     ai:
-        name: Neo in your editor
+        name: Neo in your editor (ACP)
         identifier: ai-editors
         parent: ai-neo
         weight: 16

--- a/content/docs/ai/neo/pulumi-cli/_index.md
+++ b/content/docs/ai/neo/pulumi-cli/_index.md
@@ -13,7 +13,7 @@ menu:
         weight: 15
 ---
 
-`pulumi neo` is Neo in your terminal. Run the command from your project directory to start an interactive session.
+`pulumi neo` is Neo in your terminal. Run the command from your project directory to start an interactive session. Prefer working in your IDE? Neo can also run [directly in your editor](/docs/ai/neo/editors/).
 
 ## What local execution unlocks
 


### PR DESCRIPTION
Pulumi CLI v3.254.0 added `pulumi neo acp`, which runs Neo as an [Agent Client Protocol](https://agentclientprotocol.com) agent. This PR adds a **Neo in Your Editor (ACP)** page at `/docs/ai/neo/editors/` with setup instructions for Zed, JetBrains IDEs, and VS Code/Cursor (via the ACP Client extension), and cross-links it from the Neo landing and CLI pages.

It also marks the deprecated Pulumi Copilot VS Code extension as superseded, pointing the `copilot-in-vscode` blog post banner at the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)