### PR TITLE
Extend BreadcrumbList schema to cover 9 missing docs subsections

### DIFF
--- a/layouts/partials/schema/collectors/breadcrumb-entity.html
+++ b/layouts/partials/schema/collectors/breadcrumb-entity.html
@@ -105,7 +105,99 @@
       "item" "https://www.pulumi.com/docs/pulumi-cloud/"
     ) }}
 
-  {{/* End of main docs sections (IaC, Insights, ESC, Pulumi Cloud) */}}
+  {{/* Add Administration if in the docs/administration section */}}
+  {{ else if in .RelPermalink "/docs/administration/" }}
+    {{ $position = add $position 1 }}
+    {{ $breadcrumbs = $breadcrumbs | append (dict
+      "@type" "ListItem"
+      "position" $position
+      "name" "Administration"
+      "item" "https://www.pulumi.com/docs/administration/"
+    ) }}
+
+  {{/* Add Deployments & Workflows if in the docs/deployments section */}}
+  {{ else if in .RelPermalink "/docs/deployments/" }}
+    {{ $position = add $position 1 }}
+    {{ $breadcrumbs = $breadcrumbs | append (dict
+      "@type" "ListItem"
+      "position" $position
+      "name" "Deployments & Workflows"
+      "item" "https://www.pulumi.com/docs/deployments/"
+    ) }}
+
+  {{/* Add Internal Developer Platform if in the docs/idp section */}}
+  {{ else if in .RelPermalink "/docs/idp/" }}
+    {{ $position = add $position 1 }}
+    {{ $breadcrumbs = $breadcrumbs | append (dict
+      "@type" "ListItem"
+      "position" $position
+      "name" "Internal Developer Platform"
+      "item" "https://www.pulumi.com/docs/idp/"
+    ) }}
+
+  {{/* Add Integrations if in the docs/integrations section */}}
+  {{ else if in .RelPermalink "/docs/integrations/" }}
+    {{ $position = add $position 1 }}
+    {{ $breadcrumbs = $breadcrumbs | append (dict
+      "@type" "ListItem"
+      "position" $position
+      "name" "Integrations"
+      "item" "https://www.pulumi.com/docs/integrations/"
+    ) }}
+
+  {{/* Add Infrastructure AI if in the docs/ai section */}}
+  {{ else if in .RelPermalink "/docs/ai/" }}
+    {{ $position = add $position 1 }}
+    {{ $breadcrumbs = $breadcrumbs | append (dict
+      "@type" "ListItem"
+      "position" $position
+      "name" "Infrastructure AI"
+      "item" "https://www.pulumi.com/docs/ai/"
+    ) }}
+
+  {{/* Add Reference if in the docs/reference section */}}
+  {{ else if in .RelPermalink "/docs/reference/" }}
+    {{ $position = add $position 1 }}
+    {{ $breadcrumbs = $breadcrumbs | append (dict
+      "@type" "ListItem"
+      "position" $position
+      "name" "Reference"
+      "item" "https://www.pulumi.com/docs/reference/"
+    ) }}
+
+  {{/* Add Support & Troubleshooting if in the docs/support section */}}
+  {{ else if in .RelPermalink "/docs/support/" }}
+    {{ $position = add $position 1 }}
+    {{ $breadcrumbs = $breadcrumbs | append (dict
+      "@type" "ListItem"
+      "position" $position
+      "name" "Support & Troubleshooting"
+      "item" "https://www.pulumi.com/docs/support/"
+    ) }}
+
+  {{/* Add Download & Install if in the docs/install section */}}
+  {{ else if in .RelPermalink "/docs/install/" }}
+    {{ $position = add $position 1 }}
+    {{ $breadcrumbs = $breadcrumbs | append (dict
+      "@type" "ListItem"
+      "position" $position
+      "name" "Download & Install Pulumi"
+      "item" "https://www.pulumi.com/docs/install/"
+    ) }}
+
+  {{/* Add Get Started if in the docs/get-started section */}}
+  {{ else if in .RelPermalink "/docs/get-started/" }}
+    {{ $position = add $position 1 }}
+    {{ $breadcrumbs = $breadcrumbs | append (dict
+      "@type" "ListItem"
+      "position" $position
+      "name" "Get Started"
+      "item" "https://www.pulumi.com/docs/get-started/"
+    ) }}
+
+  {{/* End of main docs sections (IaC, Insights, ESC, Pulumi Cloud, Administration,
+       Deployments & Workflows, IDP, Integrations, Infrastructure AI, Reference,
+       Support & Troubleshooting, Install, Get Started) */}}
   {{ end }}
 
   {{/* Additional nesting for IaC Clouds section only - this is separate from the main section logic above */}}


### PR DESCRIPTION
## Problem

`layouts/partials/schema/collectors/breadcrumb-entity.html` only assigns a named, section-level BreadcrumbList entry for `docs/iac`, `docs/insights`, `docs/esc`, and `docs/pulumi-cloud` (a folder that no longer exists under `content/docs/` today). Every other docs subsection falls through to a flat `Home -> Documentation -> [Page Title]` breadcrumb, skipping the section level entirely, which under-describes the site's actual information architecture to both search engines and AI crawlers/LLMs that rely on BreadcrumbList to understand page hierarchy and topical grouping.

Counting pages under `content/docs/*/` in the current tree, the following 9 subsections were affected:

| Subsection | Pages | Title used |
|---|---|---|
| `docs/administration` | 79 | Administration |
| `docs/deployments` | 29 | Deployments & Workflows |
| `docs/idp` | 25 | Internal Developer Platform |
| `docs/integrations` | 22 | Integrations |
| `docs/ai` | 16 | Infrastructure AI |
| `docs/reference` | 14 | Reference |
| `docs/support` | 9 | Support & Troubleshooting |
| `docs/install` | 2 | Download & Install Pulumi |
| `docs/get-started` | 1 | Get Started |

That's ~197 docs pages missing a breadcrumb level, including `docs/ai` (the Neo / Infrastructure AI docs) and `docs/idp` (Internal Developer Platform), both central to current product positioning and both pages we want AI systems and search engines to understand clearly within the site hierarchy.

## Fix

Adds 9 new `else if` branches to the existing docs-hierarchy chain in `breadcrumb-entity.html`, following the exact same pattern already used for `docs/iac`, `docs/insights`, `docs/esc`, and `docs/pulumi-cloud`: a section-level `ListItem` with a display name and canonical section URL, inserted between "Documentation" and the page's own title. Purely additive, no existing branches were changed or removed, so `docs/iac`/`docs/insights`/`docs/esc`/`docs/pulumi-cloud` pages are unaffected.

## Evidence

- Page counts above are from `find content/docs/*/  -name "*.md" | wc -l` against the current `master` tree.
- `docs/ai` and `docs/idp` were prioritized because AI-native positioning (Neo and related capabilities) is a current strategic priority, and both sections deserve complete, correctly-nested structured data given that priority.

## Verification

Built a minimal standalone Hugo test harness (Hugo v0.128.0 extended) that renders `breadcrumb-entity.html` directly against dummy pages in each of the 9 new subsections plus a `docs/iac` page as a regression check. All 9 new sections render the expected 4-level hierarchy (`Home -> Documentation -> Section -> Page`) with valid, parseable JSON-LD, e.g.:

```json
{"itemListElement":[
  {"name":"Home","position":1},
  {"name":"Documentation","position":2},
  {"name":"Infrastructure AI","position":3},
  {"name":"Infrastructure AI Overview","position":4}
]}
```

The pre-existing `docs/iac` branch (and its nested AWS/Clouds/Guides logic) was re-verified unchanged and still renders correctly, confirming no regression.

## What this is NOT

This is not new content, not a change to visible on-page breadcrumbs (only the structured-data graph), and not a touch to the `docs/pulumi-cloud` or `docs/iac` branches, which are left exactly as they were.

---

🧠 *This PR was created by [workprentice](https://github.com/workprentice) on behalf of @joeduffy.*
