### PR TITLE
docs-review: fix the L0 anchor and the detector-inflated trail count

### DIFF
--- a/.claude/commands/docs-review/references/output-format.md
+++ b/.claude/commands/docs-review/references/output-format.md
@@ -42,7 +42,7 @@ Every review — initial or re-entrant, interactive or CI — produces output in
 ### 🔍 Verification trail
 
 <details>
-<summary><strong>N claims extracted</strong> · <strong>X</strong> verified · <strong>Y</strong> unverifiable · <strong>Z</strong> contradicted</summary>
+<summary><strong>N claims extracted</strong> · <strong>X</strong> verified · <strong>Y</strong> unverifiable · <strong>Z</strong> contradicted[ · <strong>D</strong> detector findings]</summary>
 
 - L<line> "<claim text>" → ✅ verified (evidence: <source pointer>)
 - L<line> "<claim text>" → 🤷 unverifiable (no inline citation; author question filed)
@@ -195,7 +195,7 @@ Some passes (claim extraction, cross-sibling reads) fan out into parallel specia
 
 The 🔍 Verification trail section sits between the bucket count table and the 🚨 Outstanding bucket. It renders the `evidence_trail` from `docs-review:references:fact-check` verbatim — one bullet per claim record, including cross-sibling-consistency checks framed as `claim_type: cross-reference`.
 
-**Render every claim** — verified, unverifiable, contradicted, sibling-checked. The collapsed `<details>` summary shows totals: `N claims extracted · X verified · Y unverifiable · Z contradicted` (sibling checks count under verified/contradicted by their result). Bold each numeral.
+**Render every claim** — verified, unverifiable, contradicted, sibling-checked. The collapsed `<details>` summary shows totals: `N claims extracted · X verified · Y unverifiable · Z contradicted` (sibling checks count under verified/contradicted by their result). Bold each numeral. `🚩 flagged` detector lines (`route: "preflight"`) are **not** claims: they are excluded from `N` — which therefore equals `Y` in the investigation log's "X of Y claims verified" — and counted in none of X/Y/Z. When any are present, a trailing `· D detector findings` segment carries them, so the trail's own lines still add up to `N + D`.
 
 **The candidate-claims floor must be fully covered.** When the workflow's claim-extraction pre-step ran, `.candidate-claims.json` is the *floor* — every entry in it must appear in this trail with a verdict (the `candidate-claims-coverage` validator rule fails the review otherwise, soft-flooring loudly). `N claims extracted` (the `<details>` summary) and `Y` in the investigation-log "X of Y claims verified" line are therefore **≥ the count of `.candidate-claims.json` entries** — you may add claims the artifact missed (`N`/`Y` go up), you may not drop one (`N`/`Y` can't go below the floor). When the workflow's verification pre-step also ran, `.verified-claims.json` is the *verdict source* — render each floor entry's trail line with the verdict + `evidence` + `source` it records there (don't re-verify); the `verified-claims-trail-faithful` validator rule fails the review when the trail's verdict word disagrees with the artifact's in the dangerous direction. A candidate claim you (or the verifier) triage down to "not actually a checkable claim" still gets a trail line: `- L<line> "<text>" → ➖ not-a-claim — <one-line reason>` (git metadata, a Dockerfile-comment tag, a faithful description of the author's own design — see `docs-review:references:claim-extraction` §"What is NOT a claim"). See `docs-review:references:fact-check` §Pre-step artifact `.candidate-claims.json` and §Routed verification.
 

--- a/.claude/commands/docs-review/scripts/compose-review.py
+++ b/.claude/commands/docs-review/scripts/compose-review.py
@@ -401,6 +401,29 @@ def _frontmatter_synthetic_verdicts(frontmatter_files: list[dict]) -> list[dict]
 
 _RT_SOURCE = "readthrough pre-step"
 
+# Backstop mirror of `readthrough.py`'s normalize_line_range() — kept here (and
+# deliberately duplicated rather than imported; these scripts are standalone by
+# design) so an artifact from an older readthrough run, or one whose anchor
+# repair failed, still can't render the degenerate `L0` anchor in both the trail
+# line and the bucket bullet. File-less, so no anchor-quote fallback: numeric
+# parse only, then `L1`.
+_RT_DASHES = str.maketrans({c: "-" for c in "‐‑‒–—―−"})
+_RT_L_RANGE_RE = re.compile(r"L(\d+)(?:\s*-\s*L?(\d+))?", re.IGNORECASE)
+_RT_BARE_RANGE_RE = re.compile(r"(\d+)(?:\s*-\s*(\d+))?")
+
+
+def _rt_normalize_line_range(raw: str) -> str:
+    """Coerce a readthrough `line_range` to `L<a>` / `L<a>-<b>`; "" if unusable."""
+    s = (raw or "").translate(_RT_DASHES)
+    m = _RT_L_RANGE_RE.search(s) or _RT_BARE_RANGE_RE.search(s)
+    if not m:
+        return ""
+    a = int(m.group(1))
+    b = int(m.group(2)) if m.group(2) else a
+    if a <= 0:  # `L0` is not a line
+        return ""
+    return f"L{a}" if b <= a else f"L{a}-{b}"
+
 
 def _readthrough_synthetic_verdicts(readthrough_artifact: dict | None) -> list[dict]:
     """Synthesize `🚩 flagged` verdict-shaped dicts from `.readthrough-findings.json`.
@@ -425,7 +448,7 @@ def _readthrough_synthetic_verdicts(readthrough_artifact: dict | None) -> list[d
         out.append({
             "claim_id": f"readthrough-{len(out)}",
             "file": f.get("file") or "",
-            "line_range": f.get("line_range") or "L1",
+            "line_range": _rt_normalize_line_range(f.get("line_range")) or "L1",
             "text": (anchor or mode)[:TEXT_TRUNC],
             "type": f"readthrough-{mode}",
             "route": "preflight",
@@ -768,10 +791,20 @@ def _evidence_pointer(v: dict) -> str:
 
 
 def render_trail(verdicts: list[dict], degraded_note: str | None) -> tuple[str, int, int, int, int]:
-    """Return (block, n, x_verified, y_unverifiable, z_contradicted)."""
+    """Return (block, n_claims, x_verified, y_unverifiable, z_contradicted).
+
+    `n_claims` excludes `route: "preflight"` detector synthetics (Hugo build,
+    frontmatter collisions, readthrough coherence). They are not claims, they
+    are counted in none of x/y/z, and the investigation log's "X of Y claims
+    verified" already excludes them (compute_route_counts) — so counting them
+    in N made the two headline numbers disagree by exactly the detector count
+    and gave the 🚩 lines a phantom presence in a claim tally. They get their
+    own trailing count instead.
+    """
     if not verdicts:
         return ("### 🔍 Verification trail\n\n_No verifiable claims extracted from this diff._", 0, 0, 0, 0)
-    n = len(verdicts)
+    n_detector = sum(1 for v in verdicts if v.get("route") == "preflight")
+    n = len(verdicts) - n_detector
     x = sum(1 for v in verdicts if v.get("verdict") in ("verified", "matches"))
     y = sum(1 for v in verdicts if v.get("verdict") == "unverifiable")
     z = sum(1 for v in verdicts if v.get("verdict") in ("contradicted", "mismatch"))
@@ -791,10 +824,16 @@ def render_trail(verdicts: list[dict], degraded_note: str | None) -> tuple[str, 
         file_path = (v.get("file") or "").strip()
         file_in = f" in `{file_path}`" if file_path else ""
         lines.append(f"- {first}{file_in} {text}{also} → {emoji} {verdict} ({pointer})")
+    detector_part = ""
+    if n_detector:
+        detector_part = (
+            f" · <strong>{n_detector}</strong> detector "
+            f"finding{'' if n_detector == 1 else 's'}"
+        )
     header = (
         f"<details>\n<summary><strong>{n} claims extracted</strong> · "
         f"<strong>{x}</strong> verified · <strong>{y}</strong> unverifiable · "
-        f"<strong>{z}</strong> contradicted</summary>"
+        f"<strong>{z}</strong> contradicted{detector_part}</summary>"
     )
     block = "### 🔍 Verification trail\n\n" + header + "\n\n" + "\n".join(lines) + "\n\n</details>"
     if degraded_note:

--- a/.claude/commands/docs-review/scripts/readthrough.py
+++ b/.claude/commands/docs-review/scripts/readthrough.py
@@ -40,7 +40,10 @@ Output schema:
       "model": "claude-sonnet-5",
       "findings": [
         {"file": "content/docs/x.md",
-         "line_range": "L40-58",         # references the numbered file body we sent
+         "line_range": "L40-58",         # references the numbered file body we sent,
+                                         # normalized to `L<a>` / `L<a>-<b>` (see
+                                         # normalize_line_range); "" when the model's
+                                         # answer carried no recoverable anchor
          "anchor_quote": "<short verbatim span the finding is about>",
          "failure_mode": "prerequisite-inversion",   # one of FAILURE_MODES
          "fix_class": "local_repair",                 # local_repair | reconception
@@ -92,6 +95,21 @@ CHUNK_LINES = 1200
 CONTENT_MD_RE = re.compile(r"^content/.*\.md$")
 DIFF_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$")
 HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+# The schema asks for `L42` / `L42-58`, but the model occasionally answers with a
+# bare or prose-wrapped range ("41", "lines 41-43", "L41–43" with an en dash).
+# Downstream, `compose-review.py`'s `first_line_ref()` finds no `L\d+` token in
+# those and falls back to the degenerate `L0` — which renders in the trail line
+# AND the bucket bullet, pointing the reader at a line that doesn't exist and
+# severing the only visible link between the two. Normalize here, at the
+# producer, so every consumer of the artifact (the composer and the
+# existing-content sweep both read `line_range` verbatim) gets a real anchor.
+_DASHES = str.maketrans({c: "-" for c in "‐‑‒–—―−"})
+_L_RANGE_RE = re.compile(r"L(\d+)(?:\s*-\s*L?(\d+))?", re.IGNORECASE)
+_BARE_RANGE_RE = re.compile(r"(\d+)(?:\s*-\s*(\d+))?")
+# Below this length an anchor prefix stops being distinctive enough to locate a
+# line by substring match; better no anchor than a confidently wrong one.
+MIN_ANCHOR_PROBE = 12
 
 # The closed rubric — kept in sync with references/readthrough.md. Anything a
 # finding can't be tagged with (and anchored to) is out of scope by construction.
@@ -283,6 +301,48 @@ def number_lines(text: str) -> str:
     return "\n".join(f"{i}\t{line}" for i, line in enumerate(text.splitlines(), start=1))
 
 
+# ---- line-range normalization ----------------------------------------------
+
+
+def _squash(s: str) -> str:
+    return " ".join((s or "").split())
+
+
+def locate_anchor(file_text: str, anchor_quote: str) -> int:
+    """1-based line of the first line containing `anchor_quote` (or a distinctive
+    prefix of it, since the model may quote across a wrap), else 0."""
+    needle = _squash(anchor_quote)
+    if not needle or not file_text:
+        return 0
+    lines = [_squash(ln) for ln in file_text.splitlines()]
+    for probe in (needle, needle[:60], needle[:40]):
+        if len(probe) < MIN_ANCHOR_PROBE:
+            break
+        for i, line in enumerate(lines, start=1):
+            if probe in line:
+                return i
+    return 0
+
+
+def normalize_line_range(raw: str, file_text: str = "", anchor_quote: str = "") -> str:
+    """Coerce a model-supplied line reference to the canonical `L<a>` / `L<a>-<b>`.
+
+    Accepts `L41`, `L41-43`, `L41–43`, `41`, `41-43`, `lines 41-43`. When no
+    usable number is present, falls back to locating `anchor_quote` in
+    `file_text`. Returns "" when nothing can be recovered, so the caller can
+    decide what to do rather than emit a bogus anchor.
+    """
+    s = (raw or "").translate(_DASHES)
+    m = _L_RANGE_RE.search(s) or _BARE_RANGE_RE.search(s)
+    if m:
+        a = int(m.group(1))
+        b = int(m.group(2)) if m.group(2) else a
+        if a > 0:  # `L0` is not a line; fall through to the anchor lookup
+            return f"L{a}" if b <= a else f"L{a}-{b}"
+    line = locate_anchor(file_text, anchor_quote)
+    return f"L{line}" if line else ""
+
+
 # ---- user-message construction ---------------------------------------------
 
 
@@ -448,11 +508,30 @@ def process_file(api_key: str, repo_root: Path, patch: str, path: str,
                 agg_usage[k] += int(usage.get(k, 0) or 0)
         except Exception as e:  # noqa: BLE001
             errors.append(f"{path}: API call failed: {type(e).__name__}: {e}")
-    # Stamp file; drop entries missing required fields.
+    # The working-tree copy backs the anchor-quote fallback in
+    # normalize_line_range(); absent (diff-reconstructed view), normalization
+    # degrades to the numeric parse alone.
+    file_path = repo_root / path
+    file_text = ""
+    if file_path.is_file():
+        try:
+            file_text = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            pass
+    # Stamp file; normalize the anchor; drop entries missing required fields.
     for f in all_findings:
         if not (f.get("line_range") and f.get("anchor_quote") and f.get("failure_mode") and f.get("fix_class")):
             continue
         f["file"] = path
+        normalized = normalize_line_range(f.get("line_range"), file_text, f.get("anchor_quote"))
+        if normalized:
+            f["line_range"] = normalized
+        else:
+            # Unrecoverable — record it rather than shipping a range that renders
+            # as `L0` downstream. The finding still surfaces; only its anchor is
+            # degraded, and the composer's backstop supplies `L1`.
+            errors.append(f"{path}: unparseable line_range {f.get('line_range')!r}; anchor degraded")
+            f["line_range"] = ""
         f.setdefault("fix_class", "reconception")
         result["findings"].append(f)
     result["usage"] = agg_usage

--- a/.claude/commands/docs-review/scripts/test_flagged_verdict.py
+++ b/.claude/commands/docs-review/scripts/test_flagged_verdict.py
@@ -97,6 +97,18 @@ def main() -> int:
     check("1 of 2 claims verified" in log, "claim count excludes the 2 detector findings")
     check("routed: 0 inline, 2 Pass 1" in log, "route counts exclude preflight (sum to 2)")
 
+    # --- ...and the trail header agrees with that count. Counting detectors in N
+    # made the two headline numbers disagree by exactly the detector count, and
+    # gave 🚩 lines a phantom presence in a tally they contribute to nowhere. ---
+    mixed_trail, n_claims, *_ = cr.render_trail(mixed, None)
+    check(n_claims == 2, "render_trail's N counts claims only")
+    check("<strong>2 claims extracted</strong>" in mixed_trail, "header N excludes detector findings")
+    check("<strong>2</strong> detector findings" in mixed_trail, "detector findings carry their own count")
+    claims_only, *_ = cr.render_trail([{"verdict": "verified", "route": "pass1"}], None)
+    check("detector finding" not in claims_only, "no detector segment when there are none")
+    one_detector, *_ = cr.render_trail([{"verdict": "verified", "route": "pass1"}, sv[0]], None)
+    check("<strong>1</strong> detector finding<" in one_detector, "detector count is singular for one")
+
     # --- validate-pinned accepts a flagged trail line + its bucket bullet ---
     body = (
         "### 🔍 Verification trail\n\n"

--- a/.claude/commands/docs-review/scripts/test_readthrough.py
+++ b/.claude/commands/docs-review/scripts/test_readthrough.py
@@ -147,6 +147,43 @@ def main() -> int:
     check([v["fix_class"] for v in sv] == ["local_repair", "reconception"],
           "fix_class carried through to the composer")
 
+    # --- line_range normalization (the degenerate `L0` anchor) ---
+    # The model is asked for `L42`/`L42-58` but sometimes answers with a bare or
+    # prose-wrapped range; unnormalized, those render as `L0` in BOTH the trail
+    # line and the bucket bullet, pointing at a line that doesn't exist.
+    page = ("---\ntitle: T\n---\n\nIntro paragraph.\n\n"
+            "You might have been in a situation where pulumi failed.\n")
+    check(rt.normalize_line_range("L41") == "L41", "canonical single ref passes through")
+    check(rt.normalize_line_range("L41-43") == "L41-43", "canonical span passes through")
+    check(rt.normalize_line_range("L41–43") == "L41-43", "en-dash span normalized")
+    check(rt.normalize_line_range("41-43") == "L41-43", "bare span normalized")
+    check(rt.normalize_line_range("lines 41-43") == "L41-43", "prose-wrapped span normalized")
+    check(rt.normalize_line_range("line 41") == "L41", "prose-wrapped single line normalized")
+    check(rt.normalize_line_range("L41-41") == "L41", "degenerate span collapses to one ref")
+    check(rt.normalize_line_range("L0") == "", "L0 is not a line — nothing recovered")
+    check(rt.normalize_line_range("") == "", "empty range recovers nothing without a quote")
+    check(rt.normalize_line_range("somewhere", page, "You might have been in a situation") == "L7",
+          "unparseable range falls back to the anchor quote's line")
+    check(rt.locate_anchor(page, "no such text anywhere in this page") == 0,
+          "a quote absent from the page locates nothing")
+    check(rt.normalize_line_range("nope", page, "short") == "",
+          "an anchor probe below the distinctiveness floor is not used")
+
+    # --- the composer backstop never renders L0 for a readthrough finding ---
+    bad = cr._readthrough_synthetic_verdicts({"ran": True, "findings": [
+        {"file": "content/docs/x.md", "line_range": "41-43", "anchor_quote": "q",
+         "failure_mode": "self-redundancy", "fix_class": "local_repair"},
+        {"file": "content/docs/x.md", "line_range": "unparseable", "anchor_quote": "q",
+         "failure_mode": "self-redundancy", "fix_class": "local_repair"},
+    ]})
+    check([v["line_range"] for v in bad] == ["L41-43", "L1"],
+          "composer backstop normalizes, falling back to L1 (never L0)")
+    trail_bad, *_ = cr.render_trail(bad, None)
+    check("L0" not in trail_bad, "no degenerate L0 anchor reaches the trail")
+    out_bad, _low_bad = cr.build_stubs(bad)
+    check(all("**[L0]**" not in s["bullet"] for s in out_bad),
+          "no degenerate L0 anchor reaches the bucket bullets")
+
     print(f"\n{len(_fails)} failure(s)")
     return 1 if _fails else 0
 


### PR DESCRIPTION
### Proposed changes

Two defects in the docs-review pipeline, both surfaced by the readthrough finding on #20371, which rendered as:

> L0 in `content/blog/automatic-logging/index.md` "You might have been in a situation where pulumi failed…" → 🚩 flagged (readthrough: self-redundancy)

That finding *was* correctly reflected in the review (as the ⚠️ Low-confidence bullet, and in the `coherence | MEDIUM` row) — the triage is working as specified. But two rendering bugs made it look like it had vanished.

**1. The `L0` anchor.** The schema asks the readthrough model for `L42` / `L42-58`, but it sometimes answers with a bare or prose-wrapped range (`41`, `lines 41-43`, `L41–43` with an en dash). `compose-review.py`'s `first_line_ref()` finds no `L\d+` token in those and falls back to the degenerate `L0`, which lands in **both** the trail line and the bucket bullet. Since the bullet is deliberately stripped of detector vocabulary (per `output-format.md`'s per-verdict table, it's written as a plain statement with no "readthrough" / "flagged" wording), the shared line ref is the *only* thing tying the two together — so an `L0` on both ends severs the link and points the reader at a line that doesn't exist. On #20371 the real anchor was line 41.

Fixed at the producer: `readthrough.py` now normalizes the model's range to canonical form, falls back to locating `anchor_quote` in the file when no usable number is present, and records an error when nothing can be recovered rather than shipping a bogus anchor. `compose-review.py` keeps a file-less mirror as a backstop for artifacts from older runs, falling back to `L1`. `first_line_ref`'s `L0` stays as the last-ditch fallback for malformed fact-check verdicts.

**2. The trail header count.** `render_trail` counted `route: "preflight"` detector synthetics (Hugo build, frontmatter collisions, readthrough coherence) in `N claims extracted`, while `x`/`y`/`z` and the investigation log's "X of Y claims verified" all exclude them. The two headline numbers therefore disagreed by exactly the detector count — `22 claims extracted` vs `10 of 21 claims verified` on #20371 — and the 🚩 lines had a phantom presence in a tally they contribute to nowhere. `N` is now claims-only (so it equals `Y`), with a trailing `· D detector findings` segment when any are present.

No change to triage behavior: a non-blocking readthrough nit still belongs in ⚠️ Low-confidence.

Verification — the exact #20371 case run through the real composer now anchors at `L41` in both places:

```
<summary><strong>1 claims extracted</strong> · … · <strong>1</strong> detector finding</summary>

- L45 … "stores them in $PULUMI_HOME/logs" → ✅ verified (…)
- L41 … "You might have been in a situation where pulumi failed…" → 🚩 flagged (readthrough: self-redundancy)

OUTSTANDING: ['L41']
```

Also updated `references/output-format.md` so the spec and the composer stay in sync, and extended `test_readthrough.py` (14 new checks: normalization cases, the anchor-quote fallback, the distinctiveness floor, and no-`L0`-reaches-the-trail-or-bullets) and `test_flagged_verdict.py` (6 new checks on the header counts). Full docs-review script suite passes; `./scripts/lint.sh` clean.

### Unreleased product version (optional)

N/A — tooling only, no content or product-version impact.

### Related issues (optional)

Surfaced by the review on #20371.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UE23YLxZdyJNEQvkyGCzsP)_