### PR TITLE
docs-review: make the pinned-review footer clearer and unlosable

### DIFF
--- a/.claude/commands/docs-review/footer.md
+++ b/.claude/commands/docs-review/footer.md
@@ -1,0 +1,11 @@
+<!-- CLAUDE_REVIEW_FOOTER -->
+
+---
+
+- **Refresh this review** — comment `@claude #update-review`. Say what you fixed, or which finding you dispute and why; both work in the same mention.
+- **Ask for anything else** — comment `@claude` with no hashtag (questions, one-off fixes). Leaves this review untouched.
+
+> [!IMPORTANT]
+> Please don't hide, resolve, or delete this comment! It breaks things!
+
+📖 [How pre-merge review works](https://github.com/pulumi/docs/blob/master/CONTRIBUTING.md#after-review--three-paths-to-refresh) — the full lifecycle, short-circuits, and escape hatches.

--- a/.claude/commands/docs-review/references/output-format.md
+++ b/.claude/commands/docs-review/references/output-format.md
@@ -80,14 +80,24 @@ Every review — initial or re-entrant, interactive or CI — produces output in
 
 - <ISO 8601 timestamp> — <one-line summary> (<commit SHA prefix>)
 
+<!-- CLAUDE_REVIEW_FOOTER -->
+
 ---
-Need a re-review? Want to dispute a finding? Mention `@claude` and include `#update-review`.  
-(For ad-hoc questions or fixes, just `@claude` — no hashtag.)
+
+- **Refresh this review** — comment `@claude #update-review`. …
+- **Ask for anything else** — comment `@claude` with no hashtag …
+
+> [!IMPORTANT]
+> Please don't hide, resolve, or delete this comment! It breaks things!
+
+📖 [How pre-merge review works](…) — the full lifecycle, short-circuits, and escape hatches.
 ```
 
 **Mandatory sections render on every review** — Investigation log, bucket count table, 🔍 Verification trail, 🚨 Outstanding, ⚠️ Low-confidence, 📜 Review history, and (for `content/blog/**`) 📊 Editorial balance. When a section has no content, render its explicit-empty form; never omit the heading. The empty form means "checked, nothing to render"; absence means "didn't check." A missing mandatory section is a reviewer bug.
 
-The table header row stays fixed; only the number row changes per review. Bold the numbers so they read at a glance even when zero. The footer tagline is part of every initial and re-entrant review.
+The table header row stays fixed; only the number row changes per review. Bold the numbers so they read at a glance even when zero.
+
+**You do not write the footer.** Its canonical text lives in `.claude/commands/docs-review/footer.md`, and `pinned-comment.sh` is its sole writer on publish: it strips whatever footer the inbound body carries and stamps a fresh copy onto *every* comment of a split review, so the refresh instructions ride on the 1/M comment people actually read rather than only on the tail. `compose-review.py` renders the same file into the draft (abridged above — read `footer.md` for the exact text) so drafts stay complete documents. Leave it in place when you edit the draft; if you drop it, publish restores it. To change the wording, edit `footer.md` — that one file feeds the composer, the shell, and this reference.
 
 The ⚠️ Low-confidence count includes style findings. The maintainer's review burden equals the count rendered in the table; understating it is a false signal.
 

--- a/.claude/commands/docs-review/scripts/compose-review.py
+++ b/.claude/commands/docs-review/scripts/compose-review.py
@@ -72,6 +72,14 @@ from pathlib import Path
 
 # ---- constants -------------------------------------------------------------
 
+# Single source of truth for the review footer. `pinned-comment.sh` reads the
+# same file and is the authoritative writer on publish (it stamps the footer
+# onto every page of a split review); the sentinel is how both sides find and
+# strip an existing copy. Keep the sentinel in sync with the shell's
+# FOOTER_SENTINEL.
+FOOTER_SENTINEL = "<!-- CLAUDE_REVIEW_FOOTER -->"
+FOOTER_PATH = Path(__file__).resolve().parent.parent / "footer.md"
+
 # Quick-win: an `unverifiable` *factual* claim renders in ⚠️ Low-confidence
 # (with an author-question line), not 🚨. Flip to "outstanding" if that spec
 # change reverts. (The validator never enforced always-🚨 for unverifiable —
@@ -955,11 +963,21 @@ def render_review_history(timestamp: str, head_sha_short: str) -> str:
 
 
 def render_footer() -> str:
-    return (
-        "---\n"
-        "Need a re-review? Want to dispute a finding? Mention `@claude` and include `#update-review`.  \n"
-        "(For ad-hoc questions or fixes, just `@claude` — no hashtag.)"
-    )
+    """Return the canonical footer, read from `docs-review/footer.md`.
+
+    `pinned-comment.sh` is the authoritative writer: on upsert it strips this
+    block from the inbound body and re-stamps it onto EVERY page of a split
+    review. Rendering it here anyway keeps the composed draft (and the local
+    `/docs-review` output, which never reaches the shell) a complete document,
+    and keeps exactly one copy of the text in the repo.
+
+    If the file is unreadable, emit the bare sentinel: it renders to nothing in
+    a GitHub comment, and the shell still supplies the real text on publish.
+    """
+    try:
+        return FOOTER_PATH.read_text(encoding="utf-8").rstrip("\n")
+    except OSError:
+        return FOOTER_SENTINEL
 
 
 # ---- stub bucket bullets ---------------------------------------------------

--- a/.claude/commands/docs-review/scripts/pinned-comment.sh
+++ b/.claude/commands/docs-review/scripts/pinned-comment.sh
@@ -28,6 +28,20 @@ set -euo pipefail
 MARKER_RE='^<!-- CLAUDE_REVIEW ([0-9]+)/([0-9]+) -->'
 DEFAULT_MAX_BYTES=60000
 
+# The review footer (refresh instructions + the don't-hide-me warning) lives in
+# one place, `docs-review/footer.md`, and this script is its authoritative
+# writer: split_body strips any inbound copy and every page gets a freshly
+# stamped one. Two reasons it can't just ride along in the composed body:
+#   1. On a split review the composed footer lands on the LAST page only --
+#      i.e. comment 3/3 -- while the comment everyone actually reads is 1/3.
+#   2. The re-entrant path re-renders the whole body through the model, which
+#      can silently drop it. Stamping here makes that unlosable.
+# compose-review.py renders the same file so drafts stay complete documents;
+# keep FOOTER_SENTINEL in sync with its copy of the constant.
+FOOTER_SENTINEL='<!-- CLAUDE_REVIEW_FOOTER -->'
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FOOTER_FILE="$SCRIPT_DIR/../footer.md"
+
 usage() {
     sed -n '2,19p' "$0" | sed 's/^# \{0,1\}//' >&2
     exit 2
@@ -54,8 +68,21 @@ resolve_repo() {
     fi
 }
 
+# load_footer
+# Print the canonical footer text (no trailing newline handling; callers add).
+# Missing/unreadable file is non-fatal: publish an un-footered review rather
+# than block the pipeline on a missing doc fragment.
+load_footer() {
+    if [[ -r "$FOOTER_FILE" ]]; then
+        cat "$FOOTER_FILE"
+    else
+        printf 'pinned-comment.sh: WARNING: footer file not readable (%s); publishing without a footer\n' \
+            "$FOOTER_FILE" >&2
+    fi
+}
+
 # list_pinned_comments <repo> <pr>
-# Emits TSV: comment_id<TAB>position<TAB>total<TAB>created_at
+# Emits TSV: comment_id<TAB>position<TAB>total<TAB>created_at<TAB>node_id
 # Sorted by position ascending.
 list_pinned_comments() {
     local repo="$1" pr="$2"
@@ -72,8 +99,48 @@ list_pinned_comments() {
         | . as $c
         | (.body | split("\n") | .[0]) as $line1
         | ($line1 | capture("^<!-- CLAUDE_REVIEW (?<n>[0-9]+)/(?<m>[0-9]+) -->")? // empty)
-        | [$c.id, .n, .m, $c.created_at] | @tsv
+        | [$c.id, .n, .m, $c.created_at, $c.node_id] | @tsv
     ' | sort -t$'\t' -k2,2n
+}
+
+# unminimize_if_hidden <node_id>
+# GitHub lets anyone with write access hide a comment (Hide -> Resolved), which
+# collapses it in the UI. The REST list endpoint still returns it, body intact,
+# so upsert would happily PATCH a comment nobody can see: the refresh job runs
+# green, posts its progress comment, and the updated review is invisible. That
+# is exactly what happened on pulumi/docs#20533 -- an `#update-review` reported
+# success at 14:12 and the PR showed nothing until a `#new-review` six hours
+# later. Unhide before patching so the update lands somewhere visible.
+#
+# Non-fatal on failure: unminimizeComment can be refused by the token's scopes,
+# and a visible-but-stale review still beats no review at all. We warn loudly
+# instead, so the operator sees why the refresh looked like a no-op.
+unminimize_if_hidden() {
+    local node_id="$1"
+    [[ -z "$node_id" || "$node_id" == "null" ]] && return 0
+
+    local minimized
+    minimized=$(gh api graphql -f query='
+        query($id: ID!) {
+          node(id: $id) { ... on IssueComment { isMinimized } }
+        }' -f id="$node_id" --jq '.data.node.isMinimized' 2>/dev/null || true)
+
+    [[ "$minimized" != "true" ]] && return 0
+
+    if (( DRY_RUN )); then
+        printf '[dry-run] unminimizeComment %s\n' "$node_id" >&2
+        return 0
+    fi
+
+    if gh api graphql -f query='
+        mutation($id: ID!) {
+          unminimizeComment(input: {subjectId: $id}) { clientMutationId }
+        }' -f id="$node_id" >/dev/null 2>&1; then
+        printf 'pinned-comment.sh: unhid minimized pinned comment %s before patching\n' "$node_id" >&2
+    else
+        printf 'pinned-comment.sh: WARNING: pinned comment %s is hidden and could not be unhidden; this update will not be visible on the PR\n' \
+            "$node_id" >&2
+    fi
 }
 
 # fetch_pinned_bodies <repo> <pr>
@@ -111,6 +178,10 @@ split_body() {
     #   echo the previous pinned body (marker included) into the upsert
     #   input, and without this filter render_with_markers would prepend a
     #   second marker on top of the stale one.
+    # - Strip the footer the same way, for the same reason: everything from
+    #   the CLAUDE_REVIEW_FOOTER sentinel to EOF is dropped and re-stamped per
+    #   page by append_footer. The footer is by contract the LAST block of the
+    #   body (output-format.md), so sentinel-to-EOF is the whole of it.
     # - Walk the remaining lines, accumulating into the current page.
     # - When adding the next line would exceed max_bytes, finalize the page
     #   and start a new one with that line.
@@ -121,7 +192,7 @@ split_body() {
     #   `<details>` at the start of the next so the spilled list stays
     #   visually collapsed (otherwise the trailing items render as a naked
     #   bulleted list under the next H3 heading).
-    awk -v max="$max_bytes" -v outdir="$tmpdir" '
+    awk -v max="$max_bytes" -v outdir="$tmpdir" -v sentinel="$FOOTER_SENTINEL" '
         function flush() {
             if (length(buf) == 0) return
             # If a <details> is open mid-flush, close it on this page; the
@@ -143,7 +214,9 @@ split_body() {
                 cur = length(cont)
             }
         }
-        BEGIN { page = 0; buf = ""; cur = 0; in_details = 0; soft = int(max * 0.75) }
+        BEGIN { page = 0; buf = ""; cur = 0; in_details = 0; soft = int(max * 0.75); footer = 0 }
+        index($0, sentinel) == 1 { footer = 1 }
+        footer { next }
         /^<!-- CLAUDE_REVIEW [0-9]+\/[0-9]+ -->[[:space:]]*$/ { next }
         {
             line = $0 "\n"
@@ -185,6 +258,20 @@ render_with_markers() {
         printf '%s\n' "$marker" >"$tmp"
         cat "$page" >>"$tmp"
         mv "$tmp" "$page"
+    done
+}
+
+# append_footer <pages_dir> <footer_file>
+# Append the canonical footer to every page, so the refresh instructions and
+# the don't-hide-me warning ride on the comment the reader is actually looking
+# at -- not just on the tail comment of a split review.
+append_footer() {
+    local pages_dir="$1" footer_file="$2"
+    [[ -s "$footer_file" ]] || return 0
+    local page
+    for page in "$pages_dir"/page-*; do
+        printf '\n' >>"$page"
+        cat "$footer_file" >>"$page"
     done
 }
 
@@ -263,13 +350,26 @@ cmd_upsert() {
         fi
     fi
 
+    # Reserve the footer's bytes out of the per-page budget up front: it is
+    # appended to every page after the split, and a page sized to exactly
+    # MAX_BYTES plus a footer would sail past GitHub's 65536 hard cap.
+    local footer_file
+    footer_file=$(mktemp)
+    load_footer >"$footer_file"
+    local footer_bytes=0
+    [[ -s "$footer_file" ]] && footer_bytes=$(( $(wc -c <"$footer_file") + 1 ))
+    local split_budget=$(( MAX_BYTES - footer_bytes ))
+    (( split_budget > 0 )) || die "footer ($footer_bytes bytes) exceeds --max-bytes ($MAX_BYTES)"
+
     local pages_dir
-    pages_dir=$(split_body "$body_file" "$MAX_BYTES")
+    pages_dir=$(split_body "$body_file" "$split_budget")
     local pages
     pages=( "$pages_dir"/page-* )
     local total=${#pages[@]}
     (( total > 0 )) || die "split produced no pages (empty input?)"
     render_with_markers "$pages_dir" "$total"
+    append_footer "$pages_dir" "$footer_file"
+    rm -f "$footer_file"
 
     # Re-glob after marker prepend.
     pages=( "$pages_dir"/page-* )
@@ -277,9 +377,11 @@ cmd_upsert() {
     local existing_tsv
     existing_tsv=$(list_pinned_comments "$repo" "$pr" || true)
     local existing_ids=()
+    local existing_nodes=()
     if [[ -n "$existing_tsv" ]]; then
-        while IFS=$'\t' read -r id _pos _tot _created; do
+        while IFS=$'\t' read -r id _pos _tot _created node_id; do
             existing_ids+=("$id")
+            existing_nodes+=("$node_id")
         done <<< "$existing_tsv"
     fi
 
@@ -288,6 +390,7 @@ cmd_upsert() {
     for (( i = 0; i < total; i++ )); do
         local page="${pages[$i]}"
         if (( i < existing_count )); then
+            unminimize_if_hidden "${existing_nodes[$i]}"
             patch_comment "$repo" "${existing_ids[$i]}" "$page"
         else
             create_comment "$repo" "$pr" "$page"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ Rare. Use when the pinned-review state is corrupted (the 1/M comment was manuall
 
 The `<!-- CLAUDE_REVIEW N/M -->` comments are managed by the pipeline. Don't delete them — the re-entrant skill expects to find and edit them in place. If you accidentally delete the 1/M summary, the next run posts fresh at the bottom of the timeline; recoverable but ugly.
 
+**Don't hide them either.** Marking the pinned comment resolved (**Hide** → *Resolved*) collapses it but leaves it in place, so a later `#update-review` edits a comment nobody can see: the job runs green, posts its "🤖 Review updated" progress note, and the refreshed review never appears. The publish path now unhides the comment before patching, but the mutation can be refused by the token's scopes — if a refresh looks like a no-op, check whether the pinned comment is collapsed and unhide it. Use the ✅ Resolved section inside the review to track what you've addressed; that's what it's for.
+
 The pinned comment is also the pipeline's outcome ledger: after a PR closes, a weekly scrape derives what happened to each finding (fixed, conceded, disputed, or merged over) and aggregates it into the Monday `#docs-ops` digest, which is how the review's severity rules get tuned over time.
 
 ### Trivial, frontmatter-only, and oversized short-circuits


### PR DESCRIPTION
### Proposed changes

On #20533 a contributor marked the pinned review resolved (**Hide** → *Resolved*). GitHub collapses such a comment but leaves it in place, and the REST list endpoint still returns it body-intact — so the follow-up `#update-review` PATCHed a comment nobody could see. The job ran green and posted its "🤖 Review updated on @jkodroff's request" note at 14:12; the refreshed review never appeared. It took a `#new-review` six hours later to recover.

The footer's wording was the trigger, but three things had to change:

**1. Footer text → `.claude/commands/docs-review/footer.md` (new file, single source of truth)**

Read by both `compose-review.py` and `pinned-comment.sh`. It now leads with the copy-pasteable mention for each path instead of describing it in prose, carries an `> [!IMPORTANT]` block asking people not to hide/resolve/delete the comment, and links to `CONTRIBUTING.md#after-review--three-paths-to-refresh`. `[!IMPORTANT]` deliberately avoids `[!CAUTION]`/`[!WARNING]`, which already carry specific meanings in a review body.

**2. `pinned-comment.sh` is now the footer's authoritative writer**

`split_body` strips any inbound copy from the sentinel to EOF — exactly as it already does for `CLAUDE_REVIEW` markers, and for the same round-trip reason — and the footer is stamped onto *every* page. Previously the composed footer landed on the **last** comment of a split review while the comment people actually read is 1/M, and a re-entrant render could drop it entirely. Footer bytes are reserved from the per-page budget so appending can't cross GitHub's 65536 hard cap.

**3. Unhide before patching**

`list_pinned_comments` now carries each comment's `node_id`; `upsert` checks `isMinimized` and calls `unminimizeComment` before PATCHing. Failure is non-fatal but warns loudly — a visible-stale review beats no review.

No `validate-pinned.py` rule for the footer: the shell restores it *after* the validator runs, so a rule there would fail bodies that publish correctly anyway. The shell guarantee is strictly stronger than a validator check.

**One thing to verify in the wild:** `claude-update.yml` grants `issues: read` + `pull-requests: write`. Existing PATCH/DELETE of PR issue-comments works under that, but whether GraphQL `unminimizeComment` does is untested here. If the warning shows up in run logs, the fix is bumping that workflow to `issues: write`.

Verified: `bash -n` clean; a 4-page split stamps exactly one footer per page, all under cap; re-splitting an already-stamped page stays at one footer and one marker (round-trip idempotent); `validate-pinned.py` returns byte-identical results on the PR 20079 fixture with the old vs. new footer; all 10 `docs-review` test scripts pass. Meta files only — no `content/` changes, nothing in the markdown linter's scope.

### Related issues (optional)

Follows from the `#update-review` failure on #20533.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk4PR4RousySMe3dHcr8m2)_