### PR TITLE
Document the default policy groups

### DIFF
--- a/content/docs/iac/concepts/plugins.md
+++ b/content/docs/iac/concepts/plugins.md
@@ -45,7 +45,7 @@ Pulumi-supported language plugins are installed automatically with the Pulumi CL
 
 Analyzer plugins scan Pulumi programs for potential issues and power [Pulumi Policy as Code](/docs/insights/policy/). These plugins enable you to enforce compliance, security, and best practices across your infrastructure.
 
-Policy plugins are installed automatically with the Pulumi CLI.
+Policy plugins are installed automatically with the Pulumi CLI. The policy packs themselves run on the machine that runs Pulumi, so that machine also needs the pack's [runtime](/docs/insights/policy/policy-packs/#runtime-requirements) installed.
 
 ### Converter plugins
 

--- a/content/docs/insights/discovery/get-started/add-policies.md
+++ b/content/docs/insights/discovery/get-started/add-policies.md
@@ -87,7 +87,7 @@ With your policy pack published, you'll need to create a Policy Group that assoc
 1. Now add your insights account to the policy group. Select **Add accounts** and type the name of the account you want to include for Insights policies. (e.g. production/us-west-2) Finally, select **Add account to policy group**
 
 {{% notes type="info" %}}
-By default, all accounts and stacks are automatically added to the `default-policy-group`.
+Cloud accounts are automatically added to `default-accounts-policy-group`, and stacks to `default-policy-group`, as they are created. See [default policy groups](/docs/insights/policy/policy-groups/#default-policy-groups).
 {{% /notes %}}
 
 ![Insights Policies - New Policy Pack](/docs/insights/assets/new-policy-pack.png)

--- a/content/docs/insights/policy/ci-cd.md
+++ b/content/docs/insights/policy/ci-cd.md
@@ -22,6 +22,10 @@ When your CI/CD pipeline runs Pulumi commands, policy enforcement happens automa
 1. If any policy in **advisory** mode detects a violation, a warning is logged but the operation continues.
 1. If any policy in **mandatory** mode detects a violation, the operation fails and the pipeline stops.
 
+{{% notes type="warning" %}}
+Your CI image needs the policy pack's [runtime](/docs/insights/policy/policy-packs/#runtime-requirements) installed, which is not necessarily the runtime your Pulumi program uses. All of Pulumi's pre-built policy packs run on Node.js, so a Python or Go pipeline that enforces one needs Node.js in the image as well.
+{{% /notes %}}
+
 You can also run policy packs locally in CI by passing the `--policy-pack` flag:
 
 ```bash

--- a/content/docs/insights/policy/cli.md
+++ b/content/docs/insights/policy/cli.md
@@ -51,7 +51,7 @@ pulumi up --policy-pack /path/to/pack-1 --policy-pack /path/to/pack-2
 ```
 
 {{% notes type="info" %}}
-When using `--policy-pack`, the policy pack must be present on disk. Pulumi Cloud users can skip this flag entirely because policy packs enabled through [policy groups](/docs/insights/policy/policy-groups/) are downloaded and applied automatically.
+When using `--policy-pack`, the policy pack must be present on disk. Pulumi Cloud users can skip this flag entirely because policy packs enabled through [policy groups](/docs/insights/policy/policy-groups/) are downloaded and applied automatically. Downloaded packs still run locally, so the machine needs the pack's [runtime](/docs/insights/policy/policy-packs/#runtime-requirements) installed.
 {{% /notes %}}
 
 ## Common workflows

--- a/content/docs/insights/policy/get-started.md
+++ b/content/docs/insights/policy/get-started.md
@@ -84,7 +84,7 @@ The policy groups table shows:
 - **Entities Applied**: Number of stacks or accounts governed by this group
 - **Policy Packs**: Number of policy packs included in this group
 
-Your organization includes a default policy group for each type: one for preventative policies (applies to all stacks) and one for audit policies (applies to all accounts). These default groups automatically include new stacks and accounts as they're created.
+Your organization includes a default policy group for each type: `default-policy-group` for preventative policies, which applies to all stacks, and `default-accounts-policy-group` for audit policies, which applies to all cloud accounts. These default groups automatically include new stacks and accounts as they're created, and there are limits on how you can change them. See [default policy groups](/docs/insights/policy/policy-groups/#default-policy-groups).
 
 #### Creating a preventative policy group
 

--- a/content/docs/insights/policy/policy-groups.md
+++ b/content/docs/insights/policy/policy-groups.md
@@ -75,7 +75,7 @@ With the REST API, a single [`PATCH`](/docs/reference/cloud-rest-api/policy-grou
 
 With Pulumi IaC, each attachment resource manages a single membership, so you can declare one against a default group without taking ownership of the group itself. The provider has no resource for attaching a policy pack to an existing policy group, so policy pack membership on a default group has to be managed from the console, the CLI, or the REST API. The provider also cannot rename a default group or change its type: both properties force a replacement on the `PolicyGroup` resource, and replacing a group means deleting it first, which Pulumi Cloud rejects for a default group.
 
-Because `default-policy-group` cannot be deleted, renamed, or converted to an audit group, removing its policy packs is the only way to stop it from enforcing anything.
+Because `default-policy-group` cannot be deleted, renamed, or converted to an audit group, what you change to stop it from blocking deployments is its policy packs: remove them, disable them with [`pulumi policy disable`](/docs/iac/cli/commands/pulumi_policy_disable/), or set their policies to advisory.
 
 {{% notes type="warning" %}}
 Do not manage a default policy group with the [`PolicyGroup`](/registry/packages/pulumiservice/api-docs/policygroup/) resource. That resource owns the group's lifecycle, so `pulumi destroy` attempts to delete it, and its `policyPacks` property replaces the group's entire list of policy packs. Use the attachment resources to manage membership instead.

--- a/content/docs/insights/policy/policy-groups.md
+++ b/content/docs/insights/policy/policy-groups.md
@@ -18,43 +18,68 @@ Policy groups organize one or more policy packs and apply them to specific stack
 
 ## Types of policy groups
 
-Pulumi Policies provides two types of policy groups, each designed for different enforcement patterns:
+Pulumi Policies provides two types of policy groups, each designed for a different enforcement pattern:
 
-### Preventative policy groups
+- <a id="preventative-policy-groups"></a>**Preventative policy groups** apply to Pulumi stacks and run before any resource is deployed. They act as guardrails during `pulumi preview` and `pulumi up`, evaluating the resources your program declares and reporting violations in the same command the developer was already running. Because they run ahead of the deployment, a policy set to `mandatory` enforcement stops a non-compliant change before it reaches your cloud provider. They see only the resources Pulumi manages.
 
-Preventative policy groups apply to Pulumi stacks and run *before* resources are deployed. They act as guardrails during `pulumi up` and `pulumi preview`, blocking non-compliant deployments before they reach your cloud environment.
+- <a id="audit-policy-groups"></a>**Audit policy groups** continuously monitor compliance for both Pulumi stacks and [cloud accounts](/docs/insights/accounts/). For stacks, they evaluate the latest state each time the stack updates. For cloud accounts, they scan on a schedule and cover every resource in the account, including resources created by hand, by another tool, or by a cloud service itself. Audit groups report violations rather than blocking them, which makes them the safest place to measure a new policy's impact before you enforce it anywhere.
 
-**Key characteristics:**
+At a glance:
 
-- Evaluate resources at deployment time
-- Can block deployments with `mandatory` enforcement
-- Only see resources managed by Pulumi
-- Provide immediate feedback to developers
+| | Preventative | Audit |
+|:-------------------------|:----------------------------------------|:-------------------------------------------------------------|
+| **Applies to** | Pulumi stacks | Pulumi stacks and cloud accounts |
+| **When it runs** | During `pulumi preview` and `pulumi up` | On stack updates, and on a schedule for cloud accounts |
+| **What it sees** | Resources Pulumi manages | Stack state, plus every resource in a connected cloud account |
+| **Blocks deployments** | Yes, with `mandatory` enforcement | No, findings are reported for you to act on |
 
-### Audit policy groups
+For guidance on which type to use, how to set enforcement levels, and how to roll policies out across an organization, see [Best practices](#best-practices).
 
-Audit policy groups provide continuous compliance monitoring for both Pulumi stacks and [cloud accounts](/docs/insights/accounts/). For stacks, they evaluate the latest state whenever the stack updates. For cloud accounts, they scan all resources on a schedule, including resources not managed by Pulumi.
+## Default policy groups
 
-**Key characteristics:**
+Every organization has two policy groups that Pulumi creates and maintains for you, one of each type:
 
-- Evaluate existing resources continuously
-- Cannot block deployments (reporting only)
-- See all resources in cloud accounts, not just Pulumi-managed
-- Provide compliance visibility and reporting
+| Policy group | Type | Joins automatically |
+|:--------------------------------|:----------------|:-------------------------------------------|
+| `default-policy-group` | Preventative | Every stack in the organization |
+| `default-accounts-policy-group` | Audit | Every cloud account connected to Insights |
 
-{{% notes "info" %}}
-When you enable Pulumi Policies for your organization, default policy groups are created automatically: `default-preventative-policy-group` for stacks and `default-audit-policy-group` for stacks and cloud accounts.
+New stacks and newly connected cloud accounts join the matching default group as they are created. You can remove a stack or account from its default group at any time, the same way you would with any other policy group. Because `default-accounts-policy-group` is an audit group, you can also add stacks to it, though none are added automatically.
+
+In the Pulumi Cloud console, the Policy Groups tab lists both default groups with a badge marking them as defaults. From the CLI, [`pulumi policy enable`](/docs/iac/cli/commands/pulumi_policy_enable/) and [`pulumi policy disable`](/docs/iac/cli/commands/pulumi_policy_disable/) act on the default policy group when you omit `--policy-group`.
+
+### Adding policy packs to the default preventative group
+
+{{% notes type="warning" %}}
+Be careful when changing the default policy group. `default-policy-group` is a preventative group that contains every stack in your organization. A policy pack added there takes effect on the next `pulumi preview` or `pulumi up` for every stack, and any policy set to `mandatory` starts blocking deployments immediately. There is no gradual rollout, and you cannot soften the impact afterward by converting the group to an audit group. The pack's runtime also becomes a requirement for everyone: because Pulumi's pre-built policy packs all run on Node.js, adding one means every machine that runs Pulumi needs Node.js installed.
 {{% /notes %}}
 
-## Comparison
+To roll out a new policy pack safely, add it to a purpose-built audit policy group first, review the findings, then move it to `default-policy-group` once you understand its impact. See [Best practices](#best-practices).
 
-| Feature | Preventative Policy Groups | Audit Policy Groups |
-|:----------------------|:------------------------------------|:-------------------------------------------|
-| **Target** | Pulumi stacks | Pulumi stacks and cloud accounts |
-| **When it runs** | During `pulumi up` / `pulumi preview` | On stack updates and scheduled scans |
-| **Primary goal** | Prevent non-compliant deployments | Detect and monitor existing non-compliance |
-| **Scope** | Pulumi-managed resources | Stack state and all cloud account resources |
-| **Blocks deployments?** | **Yes** (with `mandatory` enforcement) | **No** |
+Adding a policy pack to `default-policy-group` also makes that pack's [runtime](/docs/insights/policy/policy-packs/#runtime-requirements) a prerequisite for everyone who runs Pulumi against any stack in your organization. Pulumi's pre-built policy packs all run on Node.js, so enabling one for every stack means every developer machine and CI runner needs Node.js installed, whatever language the Pulumi programs themselves are written in.
+
+### Managing the default policy groups programmatically
+
+The default groups are fixed in identity and mutable only in membership. You can change what is in them; you cannot change what they are. These limits apply no matter how you make the change, including from the Pulumi Cloud console.
+
+| Operation | [REST API](/docs/reference/cloud-rest-api/policy-groups/) | [Pulumi Cloud provider](/registry/packages/pulumiservice/) |
+|:-----------------------------|:--------------------------------------------|:---------------------------------------------------------------------------------------------------------------|
+| Add or remove stacks | Yes: [`addStack` and `removeStack`](/docs/reference/cloud-rest-api/policy-groups/#patch-apiorgsorgnamepolicygroupspolicygroup) | Yes: [`PolicyGroupStackAttachment`](/registry/packages/pulumiservice/api-docs/api/policygroupstackattachment/) |
+| Add or remove cloud accounts | Yes: [`addInsightsAccount` and `removeInsightsAccount`](/docs/reference/cloud-rest-api/policy-groups/#patch-apiorgsorgnamepolicygroupspolicygroup) | Yes: [`PolicyGroupInsightsAccountAttachment`](/registry/packages/pulumiservice/api-docs/api/policygroupinsightsaccountattachment/) |
+| Add or remove policy packs | Yes: [`addPolicyPack` and `removePolicyPack`](/docs/reference/cloud-rest-api/policy-groups/#patch-apiorgsorgnamepolicygroupspolicygroup) | No |
+| Rename the group | No | No |
+| Change the group's type, for example from audit to preventative | No: [an update request](/docs/reference/cloud-rest-api/policy-groups/#patch-apiorgsorgnamepolicygroupspolicygroup) has no field for it | No |
+| Delete the group | No: [`DELETE`](/docs/reference/cloud-rest-api/policy-groups/#delete-apiorgsorgnamepolicygroupspolicygroup) rejects a default group | No |
+
+With the REST API, a single [`PATCH`](/docs/reference/cloud-rest-api/policy-groups/#patch-apiorgsorgnamepolicygroupspolicygroup) request adds or removes stacks, accounts, and policy packs. Note that the `stacks`, `policyPacks`, and `insightsAccounts` fields replace the group's entire list, so use the `add*` and `remove*` fields to change one membership at a time. To apply several changes at once, [`PATCH .../batch`](/docs/reference/cloud-rest-api/policy-groups/#patch-apiorgsorgnamepolicygroupspolicygroupbatch) accepts an array of the same request bodies.
+
+With Pulumi IaC, each attachment resource manages a single membership, so you can declare one against a default group without taking ownership of the group itself. The provider has no resource for attaching a policy pack to an existing policy group, so policy pack membership on a default group has to be managed from the console, the CLI, or the REST API. The provider also cannot rename a default group or change its type: both properties force a replacement on the `PolicyGroup` resource, and replacing a group means deleting it first, which Pulumi Cloud rejects for a default group.
+
+Because `default-policy-group` cannot be deleted, renamed, or converted to an audit group, removing its policy packs is the only way to stop it from enforcing anything.
+
+{{% notes type="warning" %}}
+Do not manage a default policy group with the [`PolicyGroup`](/registry/packages/pulumiservice/api-docs/policygroup/) resource. That resource owns the group's lifecycle, so `pulumi destroy` attempts to delete it, and its `policyPacks` property replaces the group's entire list of policy packs. Use the attachment resources to manage membership instead.
+{{% /notes %}}
 
 ## Enforcement levels
 
@@ -63,37 +88,51 @@ Policies within policy groups can have different enforcement levels:
 - **Advisory:** Issues warnings but allows deployments to proceed. Useful for testing new policies or providing informational guidance.
 - **Mandatory:** Blocks deployments when violations are detected. Use for critical security, compliance, or cost policies.
 
-## When to use each type
+## Managing policy groups at scale with ESC
 
-### Use preventative policy groups when you want to:
+<a id="esc-environments"></a>Once you have more than a handful of policy groups, keeping their configuration in sync becomes the hard part. Policy packs in a policy group can reference [Pulumi ESC](/docs/esc/) environments, which lets you define that configuration once and share it across every group that needs it, instead of editing each group separately.
 
-- **Block non-compliant deployments before they happen** - Prevent security issues like public S3 buckets or unencrypted databases from ever reaching production
-- **Provide fast feedback to developers** - Catch policy violations during development and testing, before code review or CI/CD
-- **Enforce standards for Pulumi-managed infrastructure** - Ensure all resources deployed through Pulumi meet organizational requirements
+When you attach an ESC environment to a policy pack, values from the environment's [`policyConfig`](/docs/esc/concepts/outputs/#policyconfig) and [`environmentVariables`](/docs/esc/concepts/outputs/#environmentvariables) are available to the policy pack at runtime. Updating the environment updates every policy group that references it.
 
-### Use audit policy groups when you want to:
-
-- **Monitor compliance continuously** - Track policy adherence across your entire cloud footprint, not just at deployment time
-- **Include non-Pulumi resources** - Scan resources created manually, through other tools, or by AWS/Azure/GCP services
-- **Test new policies safely** - Validate policy behavior in production without risking deployment disruptions
-- **Generate compliance reports** - Provide auditors with continuous evidence of policy monitoring and findings
+Environment references support [versioning and tagging](/docs/esc/concepts/versioning/), so a configuration change does not have to reach every group at once. Pin a reference to a specific revision or tag, such as `my-env@stable` or `my-env@v1`, to control when the change takes effect. This pairs well with tiered policy groups: point production at a pinned tag and lower environments at the moving one, so changes are exercised before they reach the stacks that matter most.
 
 ## Best practices
 
-**Start with audit, promote to preventative**: Test new policies in audit mode first to understand their impact, then promote successful policies to preventative enforcement.
+### Choosing a policy group type
 
-**Layer your enforcement**: Use preventative policies for critical "must never violate" rules and audit policies for continuous monitoring and reporting.
+<a id="when-to-use-each-type"></a>Prefer preventative policy groups wherever you can. Catching a problem before the resource is provisioned is the cheapest possible outcome: nothing is created, nothing has to be remediated, and no insecure resource ever exists, even briefly. The developer also sees the violation in the `pulumi preview` or `pulumi up` they were already running, rather than in a report someone reads days later.
 
-**Organize by risk level**: Group high-risk policies (security, compliance) separately from lower-risk policies (optimization, best practices) to manage exceptions more easily.
+Audit policy groups are the right choice in three situations:
 
-## ESC environments
+- **Your infrastructure isn't all managed by Pulumi.** Preventative policies only see resources that Pulumi manages, so if people in your organization still make changes by hand in the cloud console with any regularity, or use other infrastructure tools, an audit group is the only way to evaluate those resources at all.
 
-Policy packs in a policy group can reference [Pulumi ESC](/docs/esc/) environments for secrets and configuration. When you attach an ESC environment to a policy pack, values from the environment's [`policyConfig`](/docs/esc/concepts/outputs/#policyconfig) and [`environmentVariables`](/docs/esc/concepts/outputs/#environmentvariables) are available to the policy pack at runtime.
+- **You are adopting policy for the first time.** An audit group gives you a full catalog of what is already non-compliant before you decide what to enforce. That is a far better starting point than turning on preventative policies and discovering the same backlog one blocked deployment at a time.
 
-Environment references support [versioning and tagging](/docs/esc/concepts/versioning/). You can pin to a specific revision or tag (e.g., `my-env@stable` or `my-env@v1`) to control when configuration changes take effect.
+- **The teams hitting the policy may not be able to act on it.** A preventative policy is only useful if the person it blocks knows what to do next. Blocking a deployment on a violation a team lacks the context to resolve produces confusion and workarounds rather than compliance.
+
+### Choosing an enforcement level
+
+Match the [enforcement level](#enforcement-levels) to what the environment actually requires, rather than applying the same strictness everywhere.
+
+In development, test, and other lower environments, advisory enforcement is usually the better default. The warnings still tell developers what the standards are, but nobody is blocked from trying something out. Strict controls in these environments are often unnecessary and sometimes counterproductive, since discouraging experimentation costs more than the risk it removes.
+
+Reserve mandatory enforcement for environments that genuinely need strong controls: those holding sensitive data, serving production traffic, or falling within the scope of an audit. There, the cost of a violation reaching the environment is high enough to justify stopping the deployment.
+
+Because enforcement levels are set per policy pack, and per policy within a pack, the usual way to express this is with a separate policy group for each environment tier: one group covering lower-environment stacks where the packs are advisory, and another covering production stacks where the critical packs are mandatory.
+
+### Adopting policy across an organization
+
+Rolling policy out in stages gives teams time to absorb each change and gives you a chance to find noisy rules before they block anyone:
+
+1. **Start with an audit policy group.** Add the packs you are considering to an audit group covering your cloud accounts and stacks. Nothing is blocked, and after the first scan you have a complete inventory of what would be flagged. Work through the highest-severity findings before enforcing anything.
+
+1. **Move to a preventative policy group with everything advisory.** Once the backlog is manageable, add the packs to a preventative group with every policy set to advisory. Developers begin seeing violations at deployment time, and you learn which rules are noisy or produce false positives without anyone being stopped.
+
+1. **Make specific policies mandatory.** Promote policies to mandatory selectively, starting with the ones where a violation is genuinely unacceptable and the fix is well understood. Expand from there as teams build familiarity.
 
 ## Next steps
 
 - [Create and configure policy groups](/docs/insights/policy/get-started/)
 - [View and manage policy findings](/docs/insights/policy/policy-findings/)
+- [Check policy pack runtime requirements](/docs/insights/policy/policy-packs/#runtime-requirements)
 - [Write custom policy packs](/docs/insights/policy/policy-packs/authoring/)

--- a/content/docs/insights/policy/policy-packs/_index.md
+++ b/content/docs/insights/policy/policy-packs/_index.md
@@ -2,7 +2,7 @@
 title: Policy Packs
 title_tag: Policy Packs | Pulumi Policies
 h1: Policy Packs
-meta_desc: Learn how to use Policy Packs to enforce organizational standards and best practices across your Pulumi infrastructure as code.
+meta_desc: How policy packs are structured, versioned, and applied, including the runtime each pack requires on the machines that run Pulumi.
 menu:
   insights:
     parent: insights-policy
@@ -18,35 +18,55 @@ aliases:
   - /docs/insights/policy/policy-as-code/configuration/
 ---
 
-Policy packs are collections of rules that enforce compliance and best practices across your infrastructure. Each policy pack contains one or more policies that validate resource properties, configurations, or relationships between resources.
+A policy pack is the unit that Pulumi Policies publishes, versions, and applies. Each pack is a project directory holding a `PulumiPolicy.yaml` file and one or more policies, and each policy inspects resources and reports a violation when something does not meet your standards.
+
+A pack does nothing on its own. To enforce it, add it to a [policy group](/docs/insights/policy/policy-groups/), which determines the stacks or cloud accounts it applies to and whether violations block a deployment or are reported for later.
 
 ## Types of policy packs
 
-Pulumi offers two approaches to policy enforcement:
+- <a id="pre-built-policy-packs"></a>**[Pre-built policy packs](/docs/insights/policy/policy-packs/pre-built-packs/)** are written and maintained by Pulumi. They cover common compliance frameworks, including CIS, PCI DSS, HITRUST, and NIST, as well as security, cost, and operational best practices for AWS, Azure, and Google Cloud. You enable them from Pulumi Cloud without writing any code.
 
-### Pre-built policy packs
+- <a id="custom-policy-packs"></a>**[Custom policy packs](/docs/insights/policy/policy-packs/authoring/)** are the ones you write yourself, in TypeScript, Python, or [OPA (Rego)](/docs/insights/policy/policy-packs/authoring/#opa), to enforce requirements specific to your organization. You can test a custom pack locally with `pulumi preview --policy-pack` before publishing it to Pulumi Cloud.
 
-Pulumi provides ready-to-use policy packs for common compliance frameworks including CIS, PCI DSS, HITRUST, and NIST. These packs are maintained by Pulumi and cover security, cost, and operational best practices for AWS, Azure, and Google Cloud.
+The two are meant to be combined. A policy group can hold a pre-built pack and your own pack at the same time, so you can adopt a framework wholesale and layer your organization's rules on top of it.
 
-You can enable pre-built packs directly from Pulumi Cloud with no code required.
+## What a policy pack contains
 
-[Explore pre-built policy packs →](/docs/insights/policy/policy-packs/pre-built-packs/)
+Every pack has a [`PulumiPolicy.yaml`](/docs/insights/policy/policy-packs/project-file/) project file, the policy equivalent of `Pulumi.yaml`. It declares the pack's runtime and, optionally, its version, description, and entry point.
 
-### Custom policy packs
+Each policy in the pack has a name, a description, and a validation function. A policy can examine a single resource as it is declared, or the whole stack at once when a rule depends on more than one resource. Policies also carry [metadata](/docs/insights/policy/policy-packs/metadata/) that Pulumi surfaces alongside findings: a severity, remediation steps, links to external documentation, and references to the compliance framework control a policy implements.
 
-Write your own policies in TypeScript, Python, or [OPA (Rego)](/docs/insights/policy/policy-packs/authoring/#opa) to enforce organization-specific requirements. Custom policies can validate individual resources or entire stack configurations, with support for:
+Enforcement is set per policy. A policy can warn (`advisory`), block the deployment (`mandatory`), fix the violation automatically (`remediate`), or be turned off (`disabled`). A policy group can override these levels for the packs it applies, so the same pack can warn in one group and block in another.
 
-- Configurable enforcement levels (advisory, mandatory, disabled)
-- Custom configuration schemas for flexible policy behavior
-- Local testing before publishing
-- Version management and updates
+A policy can also define a configuration schema, which turns fixed values into parameters that are set when the pack is applied. That is what lets one pack enforce a stricter threshold in production than in development without maintaining two copies of it.
 
-[Learn to author custom policies →](/docs/insights/policy/policy-packs/authoring/)
+## Versions
+
+Policy packs follow [semantic versioning](https://semver.org/). Publishing a pack with [`pulumi policy publish`](/docs/iac/cli/commands/pulumi_policy_publish/) creates a new version rather than replacing the existing one.
+
+A policy group references a particular version, so publishing does not change what is enforced until a group is pointed at the new version. If you would rather track releases automatically, enable `latest` instead of a specific version.
+
+## Runtime requirements
+
+Policy packs run on the machine that runs Pulumi, so the pack's runtime must be installed there. The [`runtime`](/docs/insights/policy/policy-packs/project-file/) declared in the pack's `PulumiPolicy.yaml` determines what is required, not the language your Pulumi program is written in. A Python or Go stack governed by a TypeScript policy pack still needs Node.js.
+
+| Pack runtime | Requirement on the machine running Pulumi |
+|:-------------|:--------------------------------------------------------------------------------|
+| `nodejs` | Node.js |
+| `python` | Python. Pulumi creates the virtual environment and installs dependencies for you. |
+| `opa` | None. Pulumi CLI v3.227.0 and later install the OPA analyzer plugin on first use. |
+
+**Pulumi's pre-built policy packs all run on Node.js.** If you enable CIS, PCI DSS, NIST, HITRUST, ISO 27001, CMMC, or Pulumi Best Practices, every machine that runs `pulumi preview` or `pulumi up` against a governed stack needs Node.js installed.
+
+Bun is not a substitute. Although Pulumi supports [`runtime: bun`](/docs/iac/languages-sdks/javascript/#bun-runtime) for Pulumi programs, a policy pack that declares `runtime: nodejs` is always executed with Node.js, even when the stack's own program uses Bun.
+
+When Pulumi Cloud enforces a policy pack through a [policy group](/docs/insights/policy/policy-groups/), the CLI downloads the pack to `~/.pulumi/policies` and installs its dependencies the first time it encounters a given version. That first run needs network access to the relevant package registry; later runs use the cached copy.
 
 ## Next steps
 
 - [Browse pre-built policy packs](/docs/insights/policy/policy-packs/pre-built-packs/)
 - [Write custom policy packs](/docs/insights/policy/policy-packs/authoring/)
+- [Run policies in CI/CD](/docs/insights/policy/ci-cd/)
 - [PulumiPolicy.yaml project file reference](/docs/insights/policy/policy-packs/project-file/)
 - [Configure policy groups](/docs/insights/policy/policy-groups/)
 - [View policy findings](/docs/insights/policy/policy-findings/)

--- a/content/docs/insights/policy/policy-packs/authoring.md
+++ b/content/docs/insights/policy/policy-packs/authoring.md
@@ -45,6 +45,8 @@ Before authoring your first policy pack, ensure you have:
 - (Optional) Access to Pulumi Cloud if you want to publish and centrally manage policy packs. Not required for local policy pack usage with open source Pulumi.
 - An understanding of [Policy as Code core concepts](/docs/insights/policy/).
 
+The runtime you choose here also becomes a requirement for everyone who runs Pulumi against a stack your pack governs. See [runtime requirements](/docs/insights/policy/policy-packs/#runtime-requirements).
+
 ## Creating a policy pack
 
 Create your first policy pack:


### PR DESCRIPTION
Documents the two policy groups every organization gets automatically, and the policy pack runtime requirements that were previously undocumented.

Fixes #20554

## Changes

- **Default policy groups**: new section on `/docs/insights/policy/policy-groups/` covering both groups, automatic membership, which properties are immutable, and the blast radius of adding a pack to the default preventative group.
- **Name correction**: the page named `default-preventative-policy-group` and `default-audit-policy-group`. Neither exists. Verified against four live orgs and `pulumi-service` (`cmd/service/model/policy_groups.go`): the real names are `default-policy-group` (stacks, preventative) and `default-accounts-policy-group` (accounts, audit). Also fixed on the discovery and policy get-started pages.
- **Runtime requirements**: new section on `/docs/insights/policy/policy-packs/`. The pack's runtime, not the program's language, decides what the client needs. All 28 Pulumi pre-built packs are `runtime: nodejs`, and Bun does not substitute. Cross-referenced from the CI/CD, CLI, and plugins pages.
- **Structure and tone**: merged the comparison table into Types, consolidated guidance under Best practices (type choice, enforcement levels, adoption path), and reduced the marketing voice on the policy packs page.

## Follow-ups (not in this PR)

- Upstream `pulumi-service` spec PR: `PATCH .../policygroups/{policyGroup}` doesn't document that `newName` is rejected on default groups, or that a group's type is set at creation only.
- Whether Pulumi Cloud accepts `runtime: bun` on publish is unverified server-side, so `project-file.md` still lists only `nodejs`/`python`/`opa`.