### PR TITLE
Fix stale links and metadata drift in the get-started flows

### DIFF
--- a/content/docs/iac/get-started/aws/begin.md
+++ b/content/docs/iac/get-started/aws/begin.md
@@ -8,6 +8,7 @@ weight: 2
 menu:
     iac:
         name: Install Pulumi
+        identifier: aws-get-started.begin
         parent: aws-get-started
         weight: 2
 

--- a/content/docs/iac/get-started/aws/create-component.md
+++ b/content/docs/iac/get-started/aws/create-component.md
@@ -7,6 +7,7 @@ weight: 7
 menu:
     iac:
         name: Create a component
+        identifier: aws-get-started.create-component
         parent: aws-get-started
         weight: 7
 

--- a/content/docs/iac/get-started/aws/create-project.md
+++ b/content/docs/iac/get-started/aws/create-project.md
@@ -7,6 +7,7 @@ weight: 4
 menu:
     iac:
         name: Create project
+        identifier: aws-get-started.create-project
         parent: aws-get-started
         weight: 4
 

--- a/content/docs/iac/get-started/aws/deploy-stack.md
+++ b/content/docs/iac/get-started/aws/deploy-stack.md
@@ -7,6 +7,7 @@ weight: 5
 menu:
     iac:
         name: Deploy
+        identifier: aws-get-started.deploy-stack
         parent: aws-get-started
         weight: 5
 

--- a/content/docs/iac/get-started/aws/destroy-stack.md
+++ b/content/docs/iac/get-started/aws/destroy-stack.md
@@ -7,6 +7,7 @@ weight: 8
 menu:
     iac:
         name: Cleanup & destroy
+        identifier: aws-get-started.destroy-stack
         parent: aws-get-started
         weight: 8
 

--- a/content/docs/iac/get-started/aws/modify-program.md
+++ b/content/docs/iac/get-started/aws/modify-program.md
@@ -7,6 +7,7 @@ weight: 6
 menu:
     iac:
         name: Make an update
+        identifier: aws-get-started.modify-program
         parent: aws-get-started
         weight: 6
 

--- a/content/docs/iac/get-started/aws/next-steps.md
+++ b/content/docs/iac/get-started/aws/next-steps.md
@@ -9,6 +9,7 @@ weight: 9
 menu:
     iac:
         name: Next steps
+        identifier: aws-get-started.next-steps
         parent: aws-get-started
         weight: 9
 
@@ -53,9 +54,9 @@ Easily deploy the most common cloud architectures, from [static websites](/templ
 
 ## Dive into the docs
 
-Read more about Pulumi's architecture and foundational concepts in depth, including [projects](/docs/concepts/projects/), [stacks](/docs/concepts/stack/), [configuration](/docs/concepts/config/), [secrets](/docs/concepts/secrets/), [resources](/docs/concepts/resources/), [state](/docs/concepts/state/), and more.
+Read more about Pulumi's architecture and foundational concepts in depth, including [projects](/docs/iac/concepts/projects/), [stacks](/docs/iac/concepts/stacks/), [configuration](/docs/iac/concepts/config/), [secrets](/docs/iac/concepts/secrets/), [resources](/docs/iac/concepts/resources/), [state](/docs/iac/concepts/state-and-backends/), and more.
 
-{{< get-started-next-step path="/docs/concepts/" label="Read the docs" ref="gs-aws-docs" >}}
+{{< get-started-next-step path="/docs/iac/concepts/" label="Read the docs" ref="gs-aws-docs" >}}
 
 ## Check out the blog
 

--- a/content/docs/iac/get-started/azure/next-steps.md
+++ b/content/docs/iac/get-started/azure/next-steps.md
@@ -53,9 +53,9 @@ Deploy the most common cloud architectures, from [static websites](/templates/st
 
 ## Dive into the docs
 
-Read more about Pulumi's architecture and foundational concepts in depth, including [projects](/docs/concepts/projects/), [stacks](/docs/concepts/stack/), [configuration](/docs/concepts/config/), [secrets](/docs/concepts/secrets/), [resources](/docs/concepts/resources/), [state](/docs/concepts/state/), and more.
+Read more about Pulumi's architecture and foundational concepts in depth, including [projects](/docs/iac/concepts/projects/), [stacks](/docs/iac/concepts/stacks/), [configuration](/docs/iac/concepts/config/), [secrets](/docs/iac/concepts/secrets/), [resources](/docs/iac/concepts/resources/), [state](/docs/iac/concepts/state-and-backends/), and more.
 
-{{< get-started-next-step path="/docs/concepts/" label="Read the docs" ref="gs-azure-docs" >}}
+{{< get-started-next-step path="/docs/iac/concepts/" label="Read the docs" ref="gs-azure-docs" >}}
 
 ## Check out the blog
 

--- a/content/docs/iac/get-started/gcp/next-steps.md
+++ b/content/docs/iac/get-started/gcp/next-steps.md
@@ -38,7 +38,7 @@ With Pulumi ESC you can:
 - **Trust (and prove) your secrets are secure.** Every environment can be locked down with role-based access controls (RBAC) and versioned with all changes fully logged for auditing.
 - **Ditch `.env` files.** No more storing secrets in plaintext on dev computers. Developers can easily access secrets via CLI, API, Kubernetes operator, the Pulumi Cloud UI, and in-code with Typescript/Javascript, Python, and Go SDKs.
 
-{{< get-started-next-step path="/docs/esc/get-started" label="Learn more about Pulumi ESC" ref="gs-gcp-esc" >}}
+{{< get-started-next-step path="/docs/esc/get-started/" label="Learn more about Pulumi ESC" ref="gs-gcp-esc" >}}
 
 ## Try a tutorial
 

--- a/content/docs/iac/get-started/kubernetes/destroy-stack.md
+++ b/content/docs/iac/get-started/kubernetes/destroy-stack.md
@@ -39,7 +39,7 @@ $ pulumi destroy
 
 Just like `pulumi up`, you'll be shown a preview to ensure that you want to proceed:
 
-```bash
+```
 Previewing destroy (dev):
 
      Type                                        Name            Plan

--- a/content/docs/iac/get-started/kubernetes/modify-program.md
+++ b/content/docs/iac/get-started/kubernetes/modify-program.md
@@ -446,7 +446,7 @@ The YAML program always uses a `ClusterIP` service and does not read the `isMini
 
 {{% /choosable %}}
 
-Our program now creates a service to access the NGINX deployment, and requires a new [config](/docs/concepts/config/) value to indicate whether the program is being deployed to Minikube or not.
+Our program now creates a service to access the NGINX deployment, and requires a new [config](/docs/iac/concepts/config/) value to indicate whether the program is being deployed to Minikube or not.
 
 The configuration value can be set for the stack using `pulumi config set isMinikube <true|false>` command.
 
@@ -519,7 +519,7 @@ Duration: 12s
 
 ### Verify the deployment
 
-View the `ip` [stack output](/docs/concepts/stack#outputs) from the NGINX service:
+View the `ip` [stack output](/docs/iac/concepts/stacks/#outputs) from the NGINX service:
 
 {{% choosable "os" "macos,linux" %}}
 

--- a/content/docs/iac/get-started/kubernetes/next-steps.md
+++ b/content/docs/iac/get-started/kubernetes/next-steps.md
@@ -34,7 +34,7 @@ With Pulumi ESC you can:
 - **Trust (and prove) your secrets are secure.** Every environment can be locked down with role-based access controls (RBAC) and versioned with all changes fully logged for auditing.
 - **Ditch `.env` files.** No more storing secrets in plaintext on dev computers. Developers can access secrets via CLI, API, Kubernetes operator, the Pulumi Cloud UI, and in-code with Typescript/Javascript, Python, and Go SDKs.
 
-{{< get-started-next-step path="/docs/esc/get-started" label="Learn more about Pulumi ESC" ref="gs-k8-esc" >}}
+{{< get-started-next-step path="/docs/esc/get-started/" label="Learn more about Pulumi ESC" ref="gs-k8-esc" >}}
 
 ## Learn Pulumi
 
@@ -50,9 +50,9 @@ Deploy the most common cloud architectures, from [static websites](/templates/st
 
 ## Dive into the docs
 
-Read more about Pulumi's architecture and foundational concepts in depth, including [projects](/docs/concepts/projects/), [stacks](/docs/concepts/stack/), [configuration](/docs/concepts/config/), [secrets](/docs/concepts/secrets/), [resources](/docs/concepts/resources/), [state](/docs/concepts/state/), and more.
+Read more about Pulumi's architecture and foundational concepts in depth, including [projects](/docs/iac/concepts/projects/), [stacks](/docs/iac/concepts/stacks/), [configuration](/docs/iac/concepts/config/), [secrets](/docs/iac/concepts/secrets/), [resources](/docs/iac/concepts/resources/), [state](/docs/iac/concepts/state-and-backends/), and more.
 
-{{< get-started-next-step path="/docs/concepts/" label="Read the docs" ref="gs-k8s-docs" >}}
+{{< get-started-next-step path="/docs/iac/concepts/" label="Read the docs" ref="gs-k8s-docs" >}}
 
 ## Blog posts
 

--- a/layouts/partials/docs/markdown-pipeline.md
+++ b/layouts/partials/docs/markdown-pipeline.md
@@ -36,7 +36,11 @@
     {{- $seg = replaceRE `(?m)^[ \t]{4,}` "" $seg -}}
     {{- /* Phase 4: Normalize blank runs so inline conversions can match cleanly */ -}}
     {{- $seg = replaceRE `\n{3,}` "\n\n" $seg -}}
-    {{- /* Phase 5: Convert inline HTML to markdown */ -}}
+    {{- /* Phase 5: Convert inline HTML to markdown. The <a><code> form must run
+           before the generic anchor rule: [^<]* can't cross the nested <code> tag,
+           so without it these links fall through to the bare-anchor strip below and
+           lose their href. */ -}}
+    {{- $seg = replaceRE `<a[^>]*href="([^"]*)"[^>]*><code[^>]*>([^<]*)</code></a>` "[`$2`]($1)" $seg -}}
     {{- $seg = replaceRE `<a[^>]*href="([^"]*)"[^>]*>([^<]*)</a>` "[$2]($1)" $seg -}}
     {{- /* Collapse whitespace inside markdown link brackets (from multi-line <a> tags) */ -}}
     {{- $seg = replaceRE `\[\s+` "[" $seg -}}

--- a/layouts/shortcodes/auto-naming-note.html
+++ b/layouts/shortcodes/auto-naming-note.html
@@ -10,7 +10,7 @@
     <div class="content">
         The extra characters you see tacked onto the {{ $resource }} name (<code>-{{ $suffix }}</code>) are the result of <em>auto-naming</em>,
         a feature that lets you use the same resource names across multiple stacks without naming collisions. You can
-        disable or fine-tune this. To learn how, <a href="/docs/concepts/resources/names/#autonaming">read more about
+        disable or fine-tune this. To learn how, <a href="/docs/iac/concepts/resources/names/#autonaming">read more about
         auto-naming.</a>
     </div>
 </div>

--- a/layouts/shortcodes/auto-naming-note.markdown.md
+++ b/layouts/shortcodes/auto-naming-note.markdown.md
@@ -1,4 +1,4 @@
 {{- $resource := default "resource" (.Get "resource") -}}
 {{- $suffix := default "abc123" (.Get "suffix") -}}
 
-> **Note:** The extra characters you see tacked onto the {{ $resource }} name (`-{{ $suffix }}`) are the result of *auto-naming*, a feature that lets you use the same resource names across multiple stacks without naming collisions. You can disable or fine-tune this. To learn how, [read more about auto-naming](/docs/concepts/resources/names/#autonaming).
+> **Note:** The extra characters you see tacked onto the {{ $resource }} name (`-{{ $suffix }}`) are the result of *auto-naming*, a feature that lets you use the same resource names across multiple stacks without naming collisions. You can disable or fine-tune this. To learn how, [read more about auto-naming](/docs/iac/concepts/resources/names/#autonaming).


### PR DESCRIPTION
> [!WARNING]
> I enabled auto-merge on this.

### Proposed changes

The four per-cloud get-started flows are hand-maintained copies, and the copies have drifted apart. This PR fixes the reader-visible defects that resulted — **in place, with no restructuring**. It carries none of the shared-fragment architecture from #20530, which was shelved; these fixes stand on their own and were simply bundled into that PR by circumstance.

**Stale concept links.** The `/docs/concepts/...` paths are outdated. Fixed in the aws, azure, and kubernetes `next-steps` pages and in kubernetes `modify-program`. GCP was already correct and served as the model — note that `stack` becomes `stacks` and `state` becomes `state-and-backends`, so these are not a blanket prefix insertion.

**`auto-naming-note` shortcode** pointed at that same legacy path; it now links `/docs/iac/concepts/resources/names/#autonaming`. This note renders on all four `deploy-stack` pages, so the fix reaches every cloud's flow. Both the `.html` and `.markdown.md` twins are updated.

**ESC call-to-action** on the gcp and kubernetes `next-steps` pages lacked its trailing slash, taking a redirect on every click. Normalized to `/docs/esc/get-started/`, matching aws and azure.

**Mislabeled code fence.** Kubernetes `destroy-stack` tagged a block of `pulumi destroy` console output as `bash`, so Chroma was highlighting CLI output as shell source. The fence is now untagged, like the equivalent blocks in the other three clouds.

**Missing menu identifiers.** The five aws pages without `menu.iac.identifier` now set it, matching azure, gcp, and kubernetes. This is inert for navigation — it surfaces in the rendered diff as `data-menu-id` attributes appearing in the shared iac sidebar, which is why so many unrelated docs pages show a diff.

**Markdown-pipeline bug fix.** In the `/docs` markdown output format, links whose text is code — `<a><code>`, e.g. [`pulumi stack rm`](/docs/iac/cli/commands/pulumi_stack_rm) — were stripped to bare text and lost their href. The generic anchor rule's `[^<]*` cannot cross the nested `<code>` tag, so the anchor survived to the bare-anchor strip in Phase 6. A preceding rule now converts them to `` [`text`](href) ``. Beyond the get-started flows this restores lost links on `install`, `iac/cli/environment-variables`, `iac/concepts/secrets`, and two building-extending guides.

### Verification

Built the site before and after and diffed **every** rendered page in **both** output formats (`index.html` and the content-negotiation `index.md`). Every page that differs falls into exactly one of two buckets:

- the pages named above, changing only in the ways described;
- unrelated pages differing *solely* by the inert `data-menu-id` sidebar attributes.

Nothing else moved. Spot-checks confirmed the intended behavior end to end: the kubernetes console block lost its `bash` tag in both formats, and `winget` on the install page regained its href in the markdown output.

`make lint` passes (markdown lint: 0 errors across 1832 files; prettier clean). Because this touches the markdown pipeline, the generated-markdown lint gate was also run against both builds and reports the identical pre-existing error count (22) on each — no regression.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Extracted from #20530 (closed unmerged — the deduplication architecture was shelved; these defect fixes were not).
