### PR TITLE
Identify signed-in users to Segment

### DIFF
--- a/theme/src/ts/consent-manager/index.ts
+++ b/theme/src/ts/consent-manager/index.ts
@@ -14,11 +14,8 @@ function clearContainer() {
     if (container) container.innerHTML = "";
 }
 
-// Identifies the signed-in user to Segment, sending every field from the auth
-// cookie as traits. Calls queued on the analytics stub are replayed once
-// analytics loads, so this stays gated behind the consent flow: nothing is
-// sent unless conditionallyLoadAnalytics() has (or later does) call load().
-// extraTraits lets callers attach context (e.g. tracking preferences).
+// Identifies the signed-in user to Segment. Queued on the analytics stub, so
+// it stays consent-gated: only flushed once analytics actually loads.
 function identifyUser(extraTraits: Record<string, unknown> = {}) {
     if (!window.analytics) return;
     const user = getUserInfo();

--- a/theme/src/ts/consent-manager/index.ts
+++ b/theme/src/ts/consent-manager/index.ts
@@ -3,6 +3,7 @@ import { inEU } from "./eu-detection";
 import { getPreferences, savePreferences } from "./cookies";
 import { fetchDestinations, conditionallyLoadAnalytics } from "./analytics";
 import { renderBanner, renderPreferencesDialog } from "./banner";
+import { getUserInfo } from "./user";
 
 let container: HTMLElement | null = null;
 let destinations: Destination[] = [];
@@ -11,6 +12,22 @@ let config: ConsentManagerConfig;
 
 function clearContainer() {
     if (container) container.innerHTML = "";
+}
+
+// Identifies the signed-in user to Segment, sending every field from the auth
+// cookie as traits. Calls queued on the analytics stub are replayed once
+// analytics loads, so this stays gated behind the consent flow: nothing is
+// sent unless conditionallyLoadAnalytics() has (or later does) call load().
+// extraTraits lets callers attach context (e.g. tracking preferences).
+function identifyUser(extraTraits: Record<string, unknown> = {}) {
+    if (!window.analytics) return;
+    const user = getUserInfo();
+    const traits = { ...(user ? user.traits : {}), ...extraTraits };
+    if (user) {
+        window.analytics.identify(user.userId, traits);
+    } else if (Object.keys(traits).length > 0) {
+        window.analytics.identify(traits);
+    }
 }
 
 function showBanner() {
@@ -36,7 +53,7 @@ function showPreferences() {
         config,
         destinations,
         current,
-        (prefs) => {
+        prefs => {
             saveAndLoad(prefs);
             if (dialog.parentNode) dialog.parentNode.removeChild(dialog);
         },
@@ -59,18 +76,9 @@ function saveAndLoad(destinationPreferences: Record<string, boolean>) {
     savePreferences(destinationPreferences);
     clearContainer();
 
-    conditionallyLoadAnalytics(
-        config.writeKey,
-        destinations,
-        destinationPreferences,
-        isConsentRequired,
-    );
+    conditionallyLoadAnalytics(config.writeKey, destinations, destinationPreferences, isConsentRequired);
 
-    if (window.analytics) {
-        window.analytics.identify({
-            destinationTrackingPreferences: destinationPreferences,
-        });
-    }
+    identifyUser({ destinationTrackingPreferences: destinationPreferences });
 }
 
 function openConsentManager() {
@@ -98,12 +106,9 @@ async function init() {
 
     const { destinationPreferences } = getPreferences();
 
-    conditionallyLoadAnalytics(
-        config.writeKey,
-        destinations,
-        destinationPreferences,
-        isConsentRequired,
-    );
+    conditionallyLoadAnalytics(config.writeKey, destinations, destinationPreferences, isConsentRequired);
+
+    identifyUser();
 
     if (isConsentRequired && !destinationPreferences) {
         showBanner();

--- a/theme/src/ts/consent-manager/types.ts
+++ b/theme/src/ts/consent-manager/types.ts
@@ -33,7 +33,7 @@ declare global {
 export interface SegmentAnalytics {
     load: (writeKey: string, options?: { integrations?: Record<string, boolean> }) => void;
     addSourceMiddleware: (middleware: (args: MiddlewareArgs) => void) => void;
-    identify: (traits: Record<string, unknown>) => void;
+    identify: (userIdOrTraits: string | Record<string, unknown>, traits?: Record<string, unknown>) => void;
     initialized?: boolean;
 }
 

--- a/theme/src/ts/consent-manager/user.ts
+++ b/theme/src/ts/consent-manager/user.ts
@@ -5,11 +5,8 @@ export interface UserInfo {
     traits: Record<string, unknown>;
 }
 
-// Reads the auth cookie the app sets for a signed-in user. The value is a
-// URL-encoded JSON string prefixed with Express's "j:" marker. Returns the
-// userId plus every other field in the cookie as identify traits, so any
-// user info the app adds later (email, name, orgs, ...) flows through
-// automatically. Returns null when no identifiable user is present.
+// Reads the signed-in user from the auth cookie: a URL-encoded JSON string
+// with Express's "j:" prefix. Returns userId plus any other fields as traits.
 export function getUserInfo(): UserInfo | null {
     try {
         const cookie = document.cookie.split("; ").find(s => s.indexOf(`${USER_INFO_COOKIE}=`) === 0);

--- a/theme/src/ts/consent-manager/user.ts
+++ b/theme/src/ts/consent-manager/user.ts
@@ -1,0 +1,28 @@
+const USER_INFO_COOKIE = "pulumi_web_user_info";
+
+export interface UserInfo {
+    userId: string;
+    traits: Record<string, unknown>;
+}
+
+// Reads the auth cookie the app sets for a signed-in user. The value is a
+// URL-encoded JSON string prefixed with Express's "j:" marker. Returns the
+// userId plus every other field in the cookie as identify traits, so any
+// user info the app adds later (email, name, orgs, ...) flows through
+// automatically. Returns null when no identifiable user is present.
+export function getUserInfo(): UserInfo | null {
+    try {
+        const cookie = document.cookie.split("; ").find(s => s.indexOf(`${USER_INFO_COOKIE}=`) === 0);
+        if (!cookie) return null;
+
+        const raw = decodeURIComponent(cookie.slice(cookie.indexOf("=") + 1));
+        const json = raw.indexOf("j:") === 0 ? raw.slice(2) : raw;
+        const parsed = JSON.parse(json);
+        if (!parsed || !parsed.userId) return null;
+
+        const { userId, ...traits } = parsed;
+        return { userId: String(userId), traits };
+    } catch {
+        return null;
+    }
+}


### PR DESCRIPTION
## What & why

The consent manager loads analytics.js but never told Segment **who** the signed-in user is — `identify()` only carried tracking-consent preferences. This wires up user identification so website sessions stitch to the user's Segment profile.

When a user is signed in (auth cookie present), we now call `analytics.identify(userId, traits)`:

- `userId` and any other fields are read from the `pulumi_web_user_info` cookie.
- Traits **merge** rather than replace, so a sparse cookie won't clobber richer traits (e.g. email) the app already set on that profile — and any fields the app later adds to the cookie flow through automatically.
- Called on normal page loads (`init()`) and when a fresh consent choice is made (`saveAndLoad()`).

## Consent-safe

`identify` is queued on the analytics stub and only flushed once `conditionallyLoadAnalytics()` actually calls `load()`. If consent is declined, nothing is sent.

## Assumptions this relies on

1. The app's `identify` uses the same Pulumi `userId` that lands in the `pulumi_web_user_info` cookie (same identity space → Segment stitches them).
2. Segment merges identify traits, so calling with sparse traits from the website is safe.

## Testing

- `yarn webpack --mode production` compiles cleanly; `consent-manager` bundle rebuilds.
- Prettier passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)