### PR TITLE
Publish RFC 9727 API catalog + agent discovery (CloudFront)

### DIFF
--- a/infrastructure/cloudfrontFunctions.ts
+++ b/infrastructure/cloudfrontFunctions.ts
@@ -48,3 +48,31 @@ export function getMarkdownNegotiationFunctionAssociation(): aws.types.input.clo
         functionArn: markdownNegotiationFunction.arn,
     };
 }
+
+// CloudFront Function that stamps the correct Content-Type on the RFC 9727 API
+// catalog. The catalog is served from S3 as the extensionless object
+// /.well-known/api-catalog, so S3 hands it back as binary/octet-stream; agents
+// expect application/linkset+json. Runs at viewer-response and only rewrites
+// that single path, so every other response on the behavior is untouched.
+const apiCatalogContentTypeFunctionCode = `
+function handler(event) {
+    var response = event.response;
+    if (event.request.uri === '/.well-known/api-catalog') {
+        response.headers['content-type'] = { value: 'application/linkset+json' };
+    }
+    return response;
+}
+`;
+
+const apiCatalogContentTypeFunction = new aws.cloudfront.Function("api-catalog-content-type", {
+    runtime: "cloudfront-js-2.0",
+    code: apiCatalogContentTypeFunctionCode,
+    comment: "Sets Content-Type: application/linkset+json on /.well-known/api-catalog.",
+});
+
+export function getApiCatalogContentTypeFunctionAssociation(): aws.types.input.cloudfront.DistributionDefaultCacheBehaviorFunctionAssociation {
+    return {
+        eventType: "viewer-response",
+        functionArn: apiCatalogContentTypeFunction.arn,
+    };
+}

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
 
 import { getAIRedirectAndGoneAssociation, getEdgeRedirectAssociation } from "./cloudfrontLambdaAssociations";
-import { getMarkdownNegotiationFunctionAssociation } from "./cloudfrontFunctions";
+import { getMarkdownNegotiationFunctionAssociation, getApiCatalogContentTypeFunctionAssociation } from "./cloudfrontFunctions";
 
 const stackConfig = new pulumi.Config();
 
@@ -710,6 +710,13 @@ const DefaultCachePolicy = new aws.cloudfront.ResponseHeadersPolicy('default-cac
             header: "Cache-Control",
             value: "max-age=60, stale-while-revalidate=300",
             override: true,
+        }, {
+            // RFC 8288 Link header pointing agents at the RFC 9727 API catalog.
+            // Rides the default behavior, so it's present on the homepage (where
+            // agent-discovery scanners look) and other top-level pages.
+            header: "Link",
+            value: "</.well-known/api-catalog>; rel=\"api-catalog\"",
+            override: false,
         }],
     },
 });
@@ -976,6 +983,9 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     defaultCacheBehavior: {
         ...baseCacheBehavior,
         cachePolicyId: tenMinuteCacheKeyPolicy.id,
+        // Stamps Content-Type on /.well-known/api-catalog, which falls through to
+        // the default behavior. No-op for every other path.
+        functionAssociations: [getApiCatalogContentTypeFunctionAssociation()],
     },
 
     orderedCacheBehaviors: [

--- a/static/.well-known/api-catalog
+++ b/static/.well-known/api-catalog
@@ -1,0 +1,28 @@
+{
+    "linkset": [
+        {
+            "anchor": "https://api.pulumi.com",
+            "service-desc": [
+                {
+                    "href": "https://api.pulumi.com/api/openapi/pulumi-spec.json",
+                    "type": "application/json",
+                    "title": "Pulumi Cloud REST API (OpenAPI specification)"
+                }
+            ],
+            "service-doc": [
+                {
+                    "href": "https://www.pulumi.com/docs/reference/cloud-rest-api/",
+                    "type": "text/html",
+                    "title": "Pulumi Cloud REST API documentation"
+                }
+            ],
+            "status": [
+                {
+                    "href": "https://status.pulumi.com/",
+                    "type": "text/html",
+                    "title": "Pulumi status"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## What & why

Follow-up to #20567. Knocks out the **API Catalog** and **Link headers** checks on [isitagentready.com](https://isitagentready.com/www.pulumi.com) (Discoverability + API/Auth/MCP/Skill Discovery categories). Unlike #20567 this one needs CloudFront changes, hence a separate PR for infra review.

### `/.well-known/api-catalog` (RFC 9727)
A linkset pointing agents at the Pulumi Cloud REST API — all URLs verified public (200):
- `anchor`: `https://api.pulumi.com`
- `service-desc`: `https://api.pulumi.com/api/openapi/pulumi-spec.json` (the OpenAPI spec, same one `make build` fetches)
- `service-doc`: `https://www.pulumi.com/docs/reference/cloud-rest-api/`
- `status`: `https://status.pulumi.com/`

### CloudFront changes (`infrastructure/`)
- **Content-Type**: the catalog is an extensionless S3 object, so S3 serves `binary/octet-stream`. A small viewer-response CloudFront Function (`api-catalog-content-type`) stamps `application/linkset+json` on that one path — no-op for everything else. Follows the existing `markdown-negotiation` function pattern.
- **Link header (RFC 8288)**: adds `Link: </.well-known/api-catalog>; rel="api-catalog"` to `DefaultCachePolicy`, so it rides the default behavior and is present on the homepage where discovery scanners look.

## Reviewer notes (⚠️ infra)
- **Not testable locally** — the CloudFront Function + response-header policy only take effect once the `www` stack deploys. `tsc --noEmit` passes in `infrastructure/`. Please sanity-check on a preview/test stack: `curl -sI https://<host>/` shows the `Link` header, and `curl -sI https://<host>/.well-known/api-catalog` shows `content-type: application/linkset+json`.
- The content-type function attaches at **viewer-response** on the default behavior; it coexists with the existing viewer-request Lambda@Edge (different event type). Confirm that's acceptable in your CloudFront setup.
- Alternative if you'd rather not add a CF function: set the content-type at S3 upload time (`aws s3 cp --content-type application/linkset+json --metadata-directive REPLACE`) in the deploy step. Happy to switch to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)