### PR TITLE
Document connecting SAML SSO to an existing account

### DIFF
--- a/content/docs/administration/access-identity/saml/_index.md
+++ b/content/docs/administration/access-identity/saml/_index.md
@@ -33,7 +33,7 @@ If you're a member of a SAML-based Pulumi organization, you can sign in to [your
 
 ## Connect SAML SSO to an existing account
 
-If you already have a Pulumi account and need to access a SAML-based organization, connect that organization's SAML SSO identity to your existing account rather than signing in to the organization directly. Signing in directly can return an "Email already in use" screen when your email already belongs to an account, and that screen cannot resolve the conflict on its own.
+If you already have a Pulumi account and need to access a SAML-based organization, connect that organization's SAML SSO identity to your existing account rather than signing in to the organization directly. Signing in directly can produce an "Email already in use" error when your email already belongs to an account, and that screen cannot resolve the conflict on its own.
 
 To connect a SAML SSO identity to your existing account:
 

--- a/content/docs/administration/access-identity/saml/_index.md
+++ b/content/docs/administration/access-identity/saml/_index.md
@@ -31,6 +31,20 @@ If you're a member of a SAML-based Pulumi organization, you can sign in to [your
 {{< sso-scim-limits-info >}}
 {{% /notes %}}
 
+## Connect SAML SSO to an existing account
+
+If you already have a Pulumi account and need to access a SAML-based organization, connect that organization's SAML SSO identity to your existing account rather than signing in to the organization directly. Signing in directly can return an "Email already in use" screen when your email already belongs to an account, and that screen cannot resolve the conflict on its own.
+
+To connect a SAML SSO identity to your existing account:
+
+1. Sign in to [Pulumi Cloud](https://app.pulumi.com/signin) with your existing account.
+1. Navigate to **Account Settings > Connect SAML SSO**.
+1. Enter the name of the organization you want to access, then complete the single sign-on prompt with your identity provider.
+
+After your identity provider confirms your identity, Pulumi adds the organization's SAML identity to your existing account and grants you access to the organization.
+
+If the connection fails, confirm with your organization administrator that your identity provider assigns you to the Pulumi application for that organization and that the SAML `NameID` it sends is stable. An unstable `NameID` can create duplicate identities and repeat the conflict.
+
 ## Integration Guides
 
 If you're looking to integrate Pulumi with your SAML 2.0 identity provider, refer to one of our example guides:

--- a/content/docs/support/faq/scim.md
+++ b/content/docs/support/faq/scim.md
@@ -45,6 +45,10 @@ Suggested Resolution: There are three possible solutions. The user can either:
 1. Change the email associated with their existing Pulumi account
 1. Connect their SAML credentials to their existing Pulumi account by navigating to Account Settings > Connect SAML SSO.
 
+{{% notes type="info" %}}
+If the existing account is already managed by SAML SSO in another Pulumi organization, use option 3. Signing in to the new organization directly returns an "Email already in use" screen, and an SSO-managed account cannot clear that screen on its own. Connect the new organization's SAML SSO identity from your account settings instead. See [Connect SAML SSO to an existing account](/docs/administration/access-identity/saml/#connect-saml-sso-to-an-existing-account).
+{{% /notes %}}
+
 #### UserName already exists
 
 ```json


### PR DESCRIPTION
Users who are already SAML-SSO-managed in one Pulumi organization had no clear path when they needed to access a second SAML organization: signing in directly returns an "Email already in use" screen that they can't clear from that screen. This documents the supported fix, connecting the second organization's SAML SSO identity to the existing account from Account Settings.

## Change Summary

- New "Connect SAML SSO to an existing account" section in the SAML admin overview: a three-step walkthrough plus a troubleshooting note on IdP app assignment and keeping the SAML `NameID` stable.
- Info note under the SCIM FAQ "Email already in use" resolution that points already-SSO-managed users to the connect flow and links the new section.

The guidance stays feature-agnostic and does not name any internal linked-organization mechanism, since that is not a public self-serve feature.

## Related Issues

Relates to pulumi/customer-support#2998
