### PR TITLE
Make tf-tool a real chooser type, and fail lint on unknown chooser types

### DIFF
--- a/scripts/lint/lint-markdown.js
+++ b/scripts/lint/lint-markdown.js
@@ -906,6 +906,22 @@ const parseChooserRegistry = (function () {
             }
         });
 
+        // Fail loudly here for the same reason the union parse does above: an
+        // unresolved type leaves the option-key check with nothing to compare
+        // against, so it quietly passes everything. A regex that stops matching
+        // (a reformat moving the closing `];`, a renamed supported* list, a
+        // restructured mapOptions switch) would otherwise disable half the guard.
+        types.forEach(function (type) {
+            if (!optionsByType[type]) {
+                const listName = typeToList[type];
+                const where = listName ? `(list: ${listName})` : "(no matching case in mapOptions)";
+                throw new Error(
+                    `Could not parse option keys for chooser type '${type}' ${where} from ${CHOOSER_COMPONENT_PATH}. ` +
+                        `If the component was refactored, update parseChooserRegistry in this file to match.`,
+                );
+            }
+        });
+
         cached = { types, optionsByType };
         return cached;
     };

--- a/scripts/lint/lint-markdown.js
+++ b/scripts/lint/lint-markdown.js
@@ -840,6 +840,208 @@ function checkChangelogAssets() {
 }
 
 /**
+ * The Stencil chooser component, which is the single source of truth for which
+ * chooser types exist and which option keys each one accepts. The lint check
+ * below parses this file rather than duplicating its lists into a data file, so
+ * the guard can't drift out of sync with the component it's guarding.
+ */
+const CHOOSER_COMPONENT_PATH = path.resolve(__dirname, "../../theme/stencil/src/components/chooser/chooser.tsx");
+
+/**
+ * Option tokens that both chooser shortcodes rewrite before handing them to the
+ * component (layouts/shortcodes/{chooser,choosable}.html), and which therefore
+ * won't appear as keys in chooser.tsx.
+ */
+const CHOOSER_OPTION_ALIASES = ["nodejs"];
+
+/** Matches a chooser/choosable shortcode call, capturing its raw argument list. */
+const CHOOSER_SHORTCODE_REGEX = /\{\{[<%]\s*(chooser|choosable)\s+([^\n%>}]*?)\s*\/?\s*[%>]\}\}/g;
+
+/**
+ * Parses chooser.tsx into { types, optionsByType }: the set of valid chooser
+ * types (from the ChooserType union) and, for each type whose options we can
+ * resolve, the set of valid option keys (by following mapOptions' switch to the
+ * corresponding supported* list).
+ *
+ * Throws if the file can't be parsed into a non-empty type list. Failing loudly
+ * is deliberate: a silently-empty registry would turn this guard into a no-op,
+ * which is the exact failure mode it exists to prevent.
+ *
+ * @returns {{types: string[], optionsByType: Object<string, string[]>}}
+ */
+const parseChooserRegistry = (function () {
+    let cached;
+
+    return function () {
+        if (cached) {
+            return cached;
+        }
+
+        const src = fs.readFileSync(CHOOSER_COMPONENT_PATH, "utf8");
+
+        // export type ChooserType = "language" | "os" | ...;
+        const union = src.match(/export type ChooserType\s*=\s*([^;]+);/);
+        const types = union ? [...union[1].matchAll(/"([^"]+)"/g)].map(m => m[1]) : [];
+        if (types.length === 0) {
+            throw new Error(`Could not parse the ChooserType union from ${CHOOSER_COMPONENT_PATH}. ` + `If the component was refactored, update parseChooserRegistry in this file to match.`);
+        }
+
+        // case "language": options = this.supportedLanguages;
+        const typeToList = {};
+        for (const m of src.matchAll(/case\s+"([^"]+)":\s*options\s*=\s*this\.(\w+);/g)) {
+            typeToList[m[1]] = m[2];
+        }
+
+        // private supportedLanguages: SupportedLanguage[] = [ { key: "typescript", ... }, ... ];
+        const listKeys = {};
+        for (const m of src.matchAll(/private\s+(\w+):\s*\w+\[\]\s*=\s*\[([\s\S]*?)\n {4}\];/g)) {
+            listKeys[m[1]] = [...m[2].matchAll(/key:\s*"([^"]+)"/g)].map(k => k[1]);
+        }
+
+        const optionsByType = {};
+        types.forEach(function (type) {
+            const keys = listKeys[typeToList[type]];
+            if (keys && keys.length > 0) {
+                optionsByType[type] = keys;
+            }
+        });
+
+        cached = { types, optionsByType };
+        return cached;
+    };
+})();
+
+/**
+ * Recursively collects markdown files under a directory, applying the same
+ * exclusions as the front-matter walk (auto-generated reference and registry
+ * pages, which are produced elsewhere).
+ *
+ * The chooser check needs its own walk rather than reusing searchForMarkdown's
+ * file list, because that list omits pages the front-matter checks skip
+ * (auto-generated, noindex, redirect passthroughs) -- and a chooser renders on
+ * those pages just the same.
+ *
+ * @param {string} dir Absolute path to walk.
+ * @returns {string[]} Absolute paths of the markdown files found.
+ */
+function listMarkdownFiles(dir) {
+    const found = [];
+
+    function walk(current) {
+        let entries;
+        try {
+            entries = fs.readdirSync(current, { withFileTypes: true });
+        } catch (e) {
+            return;
+        }
+        entries.forEach(function (entry) {
+            const full = path.join(current, entry.name);
+            if (entry.isDirectory()) {
+                walk(full);
+            } else if (entry.name.endsWith(".md")) {
+                if (full.indexOf("/content/docs/reference/pkg") > -1 || full.indexOf("/content/registry") > -1) {
+                    return;
+                }
+                found.push(full);
+            }
+        });
+    }
+
+    walk(dir);
+    return found;
+}
+
+/**
+ * Validates every chooser/choosable shortcode call in the given markdown files.
+ *
+ * An unrecognized chooser type, or an option key the type doesn't define, fails
+ * silently at runtime: the component matches no options, renders zero tabs, and
+ * -- because a choosable only reveals itself when its value matches the current
+ * selection -- hides all of the content it wraps. A page can therefore lose
+ * every code block it has while still building, linting and rendering "fine".
+ * That shipped once already (tf-tool, PR #20001, invisible for four weeks), so
+ * it's a hard error here.
+ *
+ * @param {string[]} files Absolute paths of markdown files to check.
+ * @returns {{path: string, errors: Object[]}[]} One error group per bad file.
+ */
+function checkChooserShortcodes(files) {
+    const { types, optionsByType } = parseChooserRegistry();
+    const groups = [];
+
+    files.forEach(function (fullPath) {
+        let content;
+        try {
+            content = fs.readFileSync(fullPath, "utf8");
+        } catch (e) {
+            return; // Unreadable files are surfaced by the front-matter checks.
+        }
+
+        if (content.indexOf("chooser") === -1 && content.indexOf("choosable") === -1) {
+            return; // Fast path: the vast majority of files have neither.
+        }
+
+        const errors = [];
+
+        for (const match of content.matchAll(CHOOSER_SHORTCODE_REGEX)) {
+            const [full, shortcode, rawArgs] = match;
+            const args = (rawArgs.match(/"[^"]*"|\S+/g) || []).map(a => a.replace(/^"|"$/g, ""));
+            const lineNumber = content.slice(0, match.index).split("\n").length;
+
+            const type = args[0];
+            if (!type) {
+                continue; // The shortcode itself errors on missing arguments.
+            }
+
+            if (!types.includes(type)) {
+                errors.push({
+                    lineNumber: lineNumber,
+                    ruleDescription:
+                        `Unknown chooser type '${type}' in ${shortcode} shortcode. Valid types are: ` +
+                        `${types.join(", ")}. An unrecognized type renders no tabs AND hides all of the ` +
+                        `content it wraps, so the page silently loses it. Either use a valid type or add ` +
+                        `'${type}' to the chooser component (theme/stencil/src/components/chooser/chooser.tsx ` +
+                        `plus the store slice in theme/stencil/src/store/)`,
+                    errorDetail: full.trim(),
+                });
+                continue;
+            }
+
+            // The second positional argument is the option list (chooser) or the
+            // value(s) to match (choosable). A third argument, if present, is the
+            // mode, which the shortcodes validate themselves.
+            const valid = optionsByType[type];
+            if (!valid || !args[1]) {
+                continue;
+            }
+
+            const unknown = args[1]
+                .split(",")
+                .map(o => o.trim())
+                .filter(o => o.length > 0 && !valid.includes(o) && !CHOOSER_OPTION_ALIASES.includes(o));
+
+            if (unknown.length > 0) {
+                errors.push({
+                    lineNumber: lineNumber,
+                    ruleDescription:
+                        `Unknown '${type}' option${unknown.length > 1 ? "s" : ""} ${unknown.map(o => `'${o}'`).join(", ")} ` +
+                        `in ${shortcode} shortcode. Valid options for '${type}' are: ${valid.join(", ")}. ` +
+                        `An unrecognized option is silently dropped, which can leave the chooser with no ` +
+                        `tabs and its content hidden`,
+                    errorDetail: full.trim(),
+                });
+            }
+        }
+
+        if (errors.length > 0) {
+            groups.push({ path: fullPath, errors: errors });
+        }
+    });
+
+    return groups;
+}
+
+/**
  * Builds an array of markdown files to lint and checks each file's front matter
  * for formatting errors.
  *
@@ -1202,6 +1404,17 @@ if (filesFromArgs.length === 0) {
         errors.push(assetError);
     });
 }
+
+// Chooser/choosable shortcode calls live in the body rather than the front
+// matter, so they get their own pass over the same scope the caller asked for.
+const chooserScope =
+    filesFromArgs.length > 0
+        ? filesFromArgs.map(f => path.resolve(process.cwd(), f)).filter(f => f.endsWith(".md"))
+        : listMarkdownFiles(path.resolve(__dirname, "../../content"));
+
+checkChooserShortcodes(chooserScope).forEach(function (chooserError) {
+    errors.push(chooserError);
+});
 
 // Get the total number of errors.
 const errorsArray = errors.map(function (err) {

--- a/theme/stencil/src/components/choosable/choosable.tsx
+++ b/theme/stencil/src/components/choosable/choosable.tsx
@@ -91,7 +91,7 @@ export class Choosable {
             // @ts-ignore-next-line
             this.storeUnsubscribe = store.mapStateToProps(this, (state: AppState) => {
                 const {
-                    preferences: { language, k8sLanguage, os, cloud, persona, backend, pythontoolchain },
+                    preferences: { language, k8sLanguage, os, cloud, persona, backend, pythontoolchain, tfTool },
                 } = state;
 
                 switch (this.type) {
@@ -109,6 +109,8 @@ export class Choosable {
                         return { selection: backend };
                     case "pythontoolchain":
                         return { selection: pythontoolchain };
+                    case "tf-tool":
+                        return { selection: tfTool };
                 }
             });
         }

--- a/theme/stencil/src/components/chooser/chooser.tsx
+++ b/theme/stencil/src/components/chooser/chooser.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Host, h, Listen, Prop, State } from "@stencil/core";
 import { store, Unsubscribe } from "@stencil/redux";
 import { AppState } from "../../store/state";
-import { setLanguage, setK8sLanguage, setOS, setCloud, setPersona, setBackEnd, setPythonToolchain } from "../../store/actions/preferences";
+import { setLanguage, setK8sLanguage, setOS, setCloud, setPersona, setBackEnd, setPythonToolchain, setTfTool } from "../../store/actions/preferences";
 
 export type LanguageKey = "javascript" | "typescript" | "python" | "go" | "csharp" | "fsharp" | "visualbasic" | "java" | "yaml" | "hcl" | "opa";
 export type K8sLanguageKey = "typescript" | "yaml" | "typescript-kx";
@@ -10,12 +10,21 @@ export type CloudKey = "aws" | "azure" | "gcp" | "kubernetes" | "digitalocean" |
 export type PersonaKey = "developer" | "devops" | "security" | "leader";
 export type BackEndKey = "service" | "self-managed";
 export type PythonToolchainKey = "pip" | "uv" | "poetry";
+export type TfToolKey = "terraform" | "opentofu";
 
 export type ChooserMode = "local" | "global";
 export type ChooserOptionStyle = "tabbed" | "none";
-export type ChooserType = "language" | "k8s-language" | "os" | "cloud" | "persona" | "backend" | "pythontoolchain";
-export type ChooserKey = LanguageKey | K8sLanguageKey | OSKey | CloudKey | PersonaKey | BackEndKey | PythonToolchainKey;
-export type ChooserOption = SupportedLanguage | SupportedK8sLanguage | SupportedOS | SupportedCloud | SupportedPersona | SupportedBackEnd | SupportedPythonToolchain;
+export type ChooserType = "language" | "k8s-language" | "os" | "cloud" | "persona" | "backend" | "pythontoolchain" | "tf-tool";
+export type ChooserKey = LanguageKey | K8sLanguageKey | OSKey | CloudKey | PersonaKey | BackEndKey | PythonToolchainKey | TfToolKey;
+export type ChooserOption =
+    | SupportedLanguage
+    | SupportedK8sLanguage
+    | SupportedOS
+    | SupportedCloud
+    | SupportedPersona
+    | SupportedBackEnd
+    | SupportedPythonToolchain
+    | SupportedTfTool;
 
 export interface SupportedLanguage {
     key: LanguageKey;
@@ -64,6 +73,12 @@ interface SupportedBackEnd {
 
 interface SupportedPythonToolchain {
     key: PythonToolchainKey;
+    name: string;
+    preview: boolean;
+}
+
+interface SupportedTfTool {
+    key: TfToolKey;
     name: string;
     preview: boolean;
 }
@@ -139,6 +154,7 @@ export class Chooser {
     setPersona: typeof setPersona;
     setBackEnd: typeof setBackEnd;
     setPythonToolchain: typeof setPythonToolchain;
+    setTfTool: typeof setTfTool;
 
     componentWillLoad() {
         // By default, choosers act globally and use a tabbed layout.
@@ -157,6 +173,7 @@ export class Chooser {
             setPersona,
             setBackEnd,
             setPythonToolchain,
+            setTfTool,
         });
 
         // Try to subscribe immediately if the store is ready.
@@ -194,7 +211,7 @@ export class Chooser {
         // Map currently selected values from the store, so we can use them in this component.
         this.storeUnsubscribe = store.mapStateToProps(this, (state: AppState) => {
             const {
-                preferences: { language, k8sLanguage, os, cloud, persona, backend, pythontoolchain },
+                preferences: { language, k8sLanguage, os, cloud, persona, backend, pythontoolchain, tfTool },
             } = state;
 
             // In some cases, the user's preferred (i.e., most recently selected) choice
@@ -247,6 +264,8 @@ export class Chooser {
                     return preferredOrDefault(backend);
                 case "pythontoolchain":
                     return preferredOrDefault(pythontoolchain);
+                case "tf-tool":
+                    return preferredOrDefault(tfTool);
                 default:
                     return {};
             }
@@ -403,6 +422,9 @@ export class Chooser {
             case "pythontoolchain":
                 options = this.supportedPythonToolchains;
                 break;
+            case "tf-tool":
+                options = this.supportedTfTools;
+                break;
         }
 
         this.currentOptions = options.filter(opt => keys.includes(opt.key));
@@ -464,6 +486,9 @@ export class Chooser {
                     break;
                 case "pythontoolchain":
                     this.setPythonToolchain(key as PythonToolchainKey);
+                    break;
+                case "tf-tool":
+                    this.setTfTool(key as TfToolKey);
                     break;
             }
         }
@@ -677,6 +702,21 @@ export class Chooser {
         {
             key: "docker",
             name: "Docker",
+            preview: false,
+        },
+    ];
+
+    // The list of supported Terraform-compatible CLIs. Used by docs that show
+    // `terraform ...` invocations to offer the equivalent `tofu ...` command.
+    private supportedTfTools: SupportedTfTool[] = [
+        {
+            key: "terraform",
+            name: "Terraform",
+            preview: false,
+        },
+        {
+            key: "opentofu",
+            name: "OpenTofu",
             preview: false,
         },
     ];

--- a/theme/stencil/src/store/actions/index.ts
+++ b/theme/stencil/src/store/actions/index.ts
@@ -1,4 +1,4 @@
-import { SetLanguage, SetK8sLanguage, SetOS, SetCloud, SetPersona, SetBackEnd, SetPythonToolchain } from "./preferences";
+import { SetLanguage, SetK8sLanguage, SetOS, SetCloud, SetPersona, SetBackEnd, SetPythonToolchain, SetTfTool } from "./preferences";
 import { DismissBanner } from "./banners";
 import { GetUser } from "./user";
 
@@ -12,6 +12,7 @@ export enum TypeKeys {
     SET_PERSONA = "SET_PERSONA",
     SET_BACKEND = "SET_BACKEND",
     SET_PYTHONTOOLCHAIN = "SET_PYTHONTOOLCHAIN",
+    SET_TFTOOL = "SET_TFTOOL",
 
     // Banner-related action types.
     DISMISS_BANNER = "DISMISS_BANNER",
@@ -20,6 +21,6 @@ export enum TypeKeys {
     GET_USER_INFO = "GET_USER_INFO",
 }
 
-export type PreferencesAction = SetLanguage | SetK8sLanguage | SetOS | SetCloud | SetPersona | SetBackEnd | SetPythonToolchain;
+export type PreferencesAction = SetLanguage | SetK8sLanguage | SetOS | SetCloud | SetPersona | SetBackEnd | SetPythonToolchain | SetTfTool;
 export type BannersAction = DismissBanner;
 export type UserAction = GetUser;

--- a/theme/stencil/src/store/actions/preferences.ts
+++ b/theme/stencil/src/store/actions/preferences.ts
@@ -1,5 +1,5 @@
 import { TypeKeys } from "./index";
-import { LanguageKey, K8sLanguageKey, OSKey, CloudKey, PersonaKey, BackEndKey, PythonToolchainKey } from "../../components/chooser/chooser";
+import { LanguageKey, K8sLanguageKey, OSKey, CloudKey, PersonaKey, BackEndKey, PythonToolchainKey, TfToolKey } from "../../components/chooser/chooser";
 
 export interface SetLanguage {
     type: TypeKeys.SET_LANGUAGE;
@@ -34,6 +34,11 @@ export interface SetBackEnd {
 export interface SetPythonToolchain {
     type: TypeKeys.SET_PYTHONTOOLCHAIN;
     key: PythonToolchainKey;
+}
+
+export interface SetTfTool {
+    type: TypeKeys.SET_TFTOOL;
+    key: TfToolKey;
 }
 
 const dispatchAction = <T>(action: T) => (dispatch, _getState) => dispatch(action);
@@ -78,4 +83,10 @@ export const setBackEnd = (key: BackEndKey) => dispatchAction<SetBackEnd>({
 export const setPythonToolchain = (key: PythonToolchainKey) => dispatchAction<SetPythonToolchain>({
     key,
     type: TypeKeys.SET_PYTHONTOOLCHAIN,
+});
+
+// Set the currently selected Terraform-compatible CLI.
+export const setTfTool = (key: TfToolKey) => dispatchAction<SetTfTool>({
+    key,
+    type: TypeKeys.SET_TFTOOL,
 });

--- a/theme/stencil/src/store/index.ts
+++ b/theme/stencil/src/store/index.ts
@@ -108,7 +108,7 @@ export function normalizeState(persistedState: any): Partial<AppState> {
                 cloud: persistedState.preferences.cloud || "aws",
                 k8sLanguage: persistedState.preferences.k8sLanguage || "typescript",
                 persona: persistedState.preferences.persona || "developer",
-                backend: persistedState.backend || "service",
+                backend: persistedState.preferences.backend || "service",
                 pythontoolchain: persistedState.preferences.pythontoolchain || "pip",
                 tfTool: persistedState.preferences.tfTool || "terraform",
             };

--- a/theme/stencil/src/store/index.ts
+++ b/theme/stencil/src/store/index.ts
@@ -110,6 +110,7 @@ export function normalizeState(persistedState: any): Partial<AppState> {
                 persona: persistedState.preferences.persona || "developer",
                 backend: persistedState.backend || "service",
                 pythontoolchain: persistedState.preferences.pythontoolchain || "pip",
+                tfTool: persistedState.preferences.tfTool || "terraform",
             };
         }
     } catch (e) {

--- a/theme/stencil/src/store/reducers/preferences.ts
+++ b/theme/stencil/src/store/reducers/preferences.ts
@@ -12,6 +12,7 @@ const getInitialState = (): PreferencesState => {
         cloud: "aws",
         backend: "service",
         pythontoolchain: "pip",
+        tfTool: "terraform",
     };
 };
 
@@ -48,6 +49,8 @@ export const preferences = (currentState = getInitialState(), action: Preference
             return { ...currentState, backend: action.key };
         case TypeKeys.SET_PYTHONTOOLCHAIN:
             return { ...currentState, pythontoolchain: action.key };
+        case TypeKeys.SET_TFTOOL:
+            return { ...currentState, tfTool: action.key };
         default:
             return currentState;
     }

--- a/theme/stencil/src/store/state.d.ts
+++ b/theme/stencil/src/store/state.d.ts
@@ -1,4 +1,4 @@
-import { LanguageKey, K8sLanguageKey, OSKey, CloudKey, PersonaKey, BackEndKey, PythonToolchainKey } from "../components/chooser/chooser";
+import { LanguageKey, K8sLanguageKey, OSKey, CloudKey, PersonaKey, BackEndKey, PythonToolchainKey, TfToolKey } from "../components/chooser/chooser";
 
 // PreferencesState tracks settings like preferred language, cloud and operating system.
 // Values tracked in this state slice persist between pages and reloads.
@@ -9,7 +9,8 @@ export interface PreferencesState {
     cloud: CloudKey;
     persona: PersonaKey;
     backend: BackEndKey;
-    pythontoolchain: PythonToolchainKey
+    pythontoolchain: PythonToolchainKey;
+    tfTool: TfToolKey;
 }
 
 export interface Banner {

--- a/theme/stencil/src/store/store.spec.ts
+++ b/theme/stencil/src/store/store.spec.ts
@@ -33,6 +33,7 @@ describe("normalizeState", () => {
                         k8sLanguage: "typescript",
                         persona: "developer",
                         pythontoolchain: "pip",
+                        tfTool: "terraform",
                     },
                 });
             });

--- a/theme/stencil/src/store/store.spec.ts
+++ b/theme/stencil/src/store/store.spec.ts
@@ -32,6 +32,7 @@ describe("normalizeState", () => {
                         cloud: "aws",
                         k8sLanguage: "typescript",
                         persona: "developer",
+                        backend: "service",
                         pythontoolchain: "pip",
                         tfTool: "terraform",
                     },


### PR DESCRIPTION
> **tl;dr**: Joe/Workprentice submitted a doc change that used a chooser configuration that didn't exist. Joe missed it, I missed it, my automated tools missed it, and even if I had manually reviewed it from top to bottom... honestly? I'd probably have missed it without tools, too. I wouldn't have looked at the rendered preview, I'd probably have been looking at the diff.
>
> @nyobe noticed it when she went to make some similar documentation that uses `tf`/`tofu` choosers. (Thanks, Claire!)
> 
> This PR does two things: 
> 
> 1. Fixes the bug.
> 2. Builds a guardrail to blow up the build the next time an AI hallucinates a new chooser.

Fixes the Terraform/OpenTofu picker on the [Terraform state backend get-started page](https://www.pulumi.com/docs/iac/get-started/terraform/terraform-state-backend/), and adds a lint guard so this class of failure can't ship silently again.

## The bug

`tf-tool` was never a valid chooser type. The Stencil chooser resolves options through a closed switch in `mapOptions`, so an unrecognized type matched nothing: `currentOptions` stayed empty, the tab list rendered as `<ul></ul>`, and no selection was ever dispatched. Because a `pulumi-choosable` only reveals itself when its value matches the current selection, **the content the chooser wrapped stayed hidden too.**

Measured on production before this change: 12 choosers, all with zero tabs, and all 24 choosables at height 0 — **24 of the page's 29 code blocks were invisible.** "1. Back up your state" read:

> Before making any changes, create a backup of your current state file:

…followed by nothing. Anyone following the guide got prose with no commands.

This was never a regression. The switcher arrived in #20001 and that commit changed one file — the markdown. No component or store wiring ever accompanied it. Confirmed against history: zero commits have ever touched `tf-tool` under `theme/stencil/src` or `layouts/`, none of the 24 historical revisions of `chooser.tsx` contain it, and the only `ChooserType` unions that have ever existed are the three without it. There has never been a Terraform/OpenTofu chooser under any name (no `tofu`/`opentofu` commits either).

## The fix

Wire `tf-tool` through the same path as `pythontoolchain`: `TfToolKey` + `supportedTfTools` on the component, cases in `mapOptions`/`setChoice` and both store subscriptions, and a `tfTool` preferences slice (action type, creator, reducer, persisted-state hydration) so the selection persists across pages like every other chooser. No content changes — the markup on the page was already correct.

## The guard

Nothing mechanical caught this for four weeks, and the same silent failure applies to an unrecognized *option* key (`mapOptions` filters it out, leaving no tabs). `lint-markdown.js` now hard-fails on both.

Valid types and per-type option keys are **parsed out of `chooser.tsx`** — the `ChooserType` union, `mapOptions`' switch, and the `supported*` lists — rather than duplicated into a data file, so the guard can't drift from the component it guards. If that parse ever fails it throws rather than quietly passing, since a silently-empty registry would reproduce the exact failure mode the check exists to prevent.

## Verification

- **The fix, in a browser** (local Hugo, real site bundle): all 12 choosers hydrate with Terraform/OpenTofu tabs; visible code blocks go 5 → 17; clicking OpenTofu on one chooser switches all 12 and the command becomes `tofu state pull …`; `tfTool: "opentofu"` persists to localStorage and survives a reload.
- **Dark mode**: tab contrast 16.98/5.57 (light) and 16.26/10.41 (dark) — both well past WCAG AA.
- **The guard catches the original bug**: with `tf-tool` removed from the union again, it flags all 36 call sites on `terraform-state-backend.md`. PR #20001 would have failed lint.
- **No false positives**: clean across all content — 4,000+ `choosable` and 671 `chooser` call sites. Negative tests confirm unknown types and unknown option keys are both caught, with correct line numbers, for all four shortcode delimiter forms.
- `make lint` clean; prettier clean; `stencil build` typechecks.

## Notes for the reviewer

- The guard covers `content/`, not chooser markup emitted from `layouts/` templates.

- **Third commit is an unrelated one-character bug** in the same function, pulled in at Cam's request. `normalizeState` hydrated every preference from `persistedState.preferences` except `backend`, which it read from `persistedState.backend` — one level too high. That key never exists, so the `|| "service"` fallback always won and a saved backend choice silently reset on every page load. Verified as an A/B against production: seed `pulumi_state` with `backend: "self-managed"`, reload, and production comes back `"service"` while this branch comes back `"self-managed"`. (Seed and reload have to happen in the same tick — the store re-persists on a 3s interval, so a slower seed gets clobbered before the reload. My first attempt at this test hit exactly that and produced a false negative.)
- **The Stencil unit tests do not run**, on this branch or on master: the repo declares jest 30 while Stencil 4.43.2 supports only jest 29, so `stencil test` refuses to start. Two consequences worth knowing when reading the diff:
  - `store.spec.ts` is updated for the new `tfTool` slice but **unverified by execution**. The browser testing above covers the same ground end-to-end.
  - That spec's `toStrictEqual` was already asserting a preferences slice with no `backend` key, which `normalizeState` has always emitted — so it could never have passed. I added the missing key. Fixing the jest/Stencil mismatch is out of scope here but would have caught both this and, plausibly, the original `tf-tool` bug.

