### PR TITLE
Add /extend-trial request page

### DIFF
--- a/content/extend-trial/_index.md
+++ b/content/extend-trial/_index.md
@@ -1,0 +1,8 @@
+---
+title: Extend your trial
+meta_desc: Request more time on your Pulumi trial. Tell us what you're still evaluating and we'll extend it. Most requests are approved within one business day.
+type: page
+layout: extend-trial
+# Transactional page reached from the product console trial banner. Keep it out of search.
+block_external_search_index: true
+---

--- a/layouts/page/extend-trial.html
+++ b/layouts/page/extend-trial.html
@@ -1,0 +1,231 @@
+{{ define "main" }}
+{{/*
+  /extend-trial — destination for the Pulumi Cloud console trial-banner
+  "Request an extension" link. Duplicated from the contact page as a starting
+  point (per web team), then swapped to a HubSpot embed so we can prefill
+  account context from the console link. Header/footer come from baseof.html.
+
+  HubSpot form: "Trial Extension" (portal 4429525, form 4b3db916-...).
+  Prefill (visible, editable fields):
+    ?email=  -> email
+    ?org=    -> pulumi_organization_name_s_  (the "Pulumi Organization Name(s)" prop)
+  UTM capture is handled by the form's own hidden last_utm_* fields.
+
+  v1 notes for review:
+    - Right-rail events/posts are hardcoded (flagged). Later: pull from Hugo
+      data/content so they stay current on their own.
+    - Raw hbspt.forms.create is used (not <pulumi-contact-us-form>) specifically
+      to get onFormReady prefill + the in-place confirmation swap.
+*/}}
+
+<style>
+  .et-page{--et-purple:#8A3391;--et-violet:#5F2CC9;--et-violet-dk:#4A1FA6;--et-salmon:#F26B7E;
+    --et-ink:#1A1A21;--et-ink2:#3D3D4A;--et-muted:#6B6B7B;--et-line:#E5E5EC;--et-bg-alt:#F7F7FA;--et-radius:10px;
+    color:var(--et-ink);line-height:1.55;}
+  .et-wrap{max-width:1240px;margin:0 auto;padding:0 24px;}
+  .et-hero{padding:54px 0 12px;}
+  .et-eyebrow{display:inline-flex;align-items:center;gap:8px;font-size:12.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--et-purple);background:#F5EAF6;border-radius:100px;padding:5px 13px;}
+  .et-page h1{font-size:46px;line-height:1.1;letter-spacing:-.028em;margin:18px 0 14px;max-width:16ch;}
+  .et-sub{font-size:18px;color:var(--et-muted);max-width:60ch;margin:0;}
+  .et-cols{display:grid;grid-template-columns:minmax(0,1fr) 360px;gap:44px;align-items:start;padding:36px 0 76px;}
+  @media (max-width:1000px){.et-cols{grid-template-columns:1fr;}.et-page h1{font-size:34px;}}
+  .et-card{border:1px solid var(--et-line);border-radius:var(--et-radius);background:#fff;}
+  .et-card-pad{padding:28px;}
+  .et-form-card{box-shadow:0 1px 2px rgba(20,20,40,.04),0 10px 32px rgba(20,20,40,.055);}
+  .et-footnote{font-size:13px;color:var(--et-muted);margin:16px 0 0;}
+
+  /* ---- HubSpot form, styled at page level (set the form to "Unstyled" in HubSpot) ---- */
+  .et-form-card .hs-form{font-size:15px;}
+  .et-form-card .hs-form-field{margin-bottom:22px;}
+  .et-form-card .hs-form-field > label{display:block;font-size:14.5px;font-weight:600;margin-bottom:6px;color:var(--et-ink);}
+  .et-form-card .hs-form-field > label .hs-form-required{color:var(--et-salmon);margin-left:2px;}
+  .et-form-card .hs-field-desc{font-size:13px;color:var(--et-muted);margin:-2px 0 8px;font-weight:400;}
+  .et-form-card .hs-input:not([type=checkbox]):not([type=radio]){width:100%;font-family:inherit;font-size:15px;color:var(--et-ink);border:1px solid var(--et-line);border-radius:8px;padding:11px 13px;background:#fff;outline:none;transition:.15s;box-sizing:border-box;}
+  .et-form-card textarea.hs-input{min-height:96px;resize:vertical;}
+  .et-form-card select.hs-input{appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%236B6B7B' stroke-width='1.6' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 14px center;padding-right:38px;}
+  .et-form-card .hs-input:focus{border-color:var(--et-violet);box-shadow:0 0 0 3px rgba(95,44,201,.12);}
+  .et-form-card .hs-form-booleancheckbox-display{display:flex;gap:10px;align-items:flex-start;font-size:14.5px;color:var(--et-ink2);font-weight:400;cursor:pointer;}
+  .et-form-card .hs-form-booleancheckbox-display > input{margin-top:3px;flex:none;width:16px;height:16px;accent-color:var(--et-violet);}
+  .et-form-card .hs-error-msg,.et-form-card .hs-error-msgs label{color:var(--et-salmon);font-size:13px;margin-top:5px;display:block;}
+  .et-form-card .hs-button.primary{display:inline-flex;align-items:center;justify-content:center;font-size:15.5px;font-weight:600;border-radius:8px;padding:13px 26px;border:1px solid transparent;cursor:pointer;font-family:inherit;color:#fff;background:linear-gradient(100deg,var(--et-violet),var(--et-purple));transition:filter .15s;margin-top:4px;}
+  .et-form-card .hs-button.primary:hover{filter:brightness(1.08);}
+
+  /* sidebar */
+  .et-side{display:flex;flex-direction:column;gap:18px;position:sticky;top:92px;}
+  .et-side h3{font-size:12.5px;letter-spacing:.07em;text-transform:uppercase;color:var(--et-muted);margin:0 0 14px;font-weight:700;}
+  .et-res{display:block;padding:13px 0;border-bottom:1px solid var(--et-line);}
+  .et-res:first-of-type{padding-top:0;}
+  .et-res:last-of-type{border-bottom:none;padding-bottom:0;}
+  .et-res:hover{text-decoration:none;}
+  .et-res .et-t{font-size:14px;font-weight:600;color:var(--et-ink);line-height:1.35;}
+  .et-res:hover .et-t{color:var(--et-purple);}
+  .et-res .et-m{font-size:12.5px;color:var(--et-muted);margin-top:3px;}
+  .et-tag{display:inline-block;font-size:10.5px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;padding:2px 7px;border-radius:4px;margin-right:7px;vertical-align:1px;background:#F5EAF6;color:var(--et-purple);}
+  .et-datechip{flex:none;width:44px;text-align:center;border:1px solid var(--et-line);border-radius:7px;padding:5px 0;}
+  .et-datechip .et-d{font-size:16px;font-weight:700;line-height:1;}
+  .et-datechip .et-mo{font-size:10.5px;text-transform:uppercase;color:var(--et-muted);font-weight:700;letter-spacing:.04em;}
+  .et-evrow{display:flex;gap:12px;align-items:flex-start;}
+  .et-more{font-size:13.5px;font-weight:600;display:inline-block;margin-top:15px;}
+  .et-side a.et-link{color:var(--et-purple);}
+  /* confirmation */
+  .et-hide{display:none !important;}
+  .et-conf .et-tick{width:46px;height:46px;border-radius:50%;background:#E6F6EF;color:#1F9D6B;display:flex;align-items:center;justify-content:center;font-size:24px;margin-bottom:18px;}
+  .et-conf h2{margin:0 0 8px;font-size:27px;letter-spacing:-.02em;}
+  .et-conf p{margin:0 0 22px;color:var(--et-muted);font-size:16px;}
+  .et-recap{background:var(--et-bg-alt);border:1px solid var(--et-line);border-radius:8px;padding:16px 18px;font-size:14px;margin-bottom:24px;}
+  .et-recap .et-row{display:flex;justify-content:space-between;gap:14px;padding:5px 0;}
+  .et-recap .et-k{color:var(--et-muted);}
+  .et-steps{list-style:none;margin:0 0 26px;padding:0;counter-reset:s;}
+  .et-steps li{counter-increment:s;position:relative;padding:0 0 16px 34px;font-size:14.5px;color:var(--et-ink2);}
+  .et-steps li:last-child{padding-bottom:0;}
+  .et-steps li:before{content:counter(s);position:absolute;left:0;top:0;width:22px;height:22px;border-radius:50%;background:#F3EEFE;color:var(--et-violet-dk);font-size:12px;font-weight:700;display:flex;align-items:center;justify-content:center;}
+  .et-steps li:after{content:"";position:absolute;left:10.5px;top:24px;bottom:6px;width:1px;background:var(--et-line);}
+  .et-steps li:last-child:after{display:none;}
+  .et-steps b{color:var(--et-ink);}
+  .et-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;font-size:15.5px;font-weight:600;border-radius:8px;padding:13px 26px;border:1px solid transparent;cursor:pointer;font-family:inherit;text-decoration:none;}
+  .et-btn-primary{background:linear-gradient(100deg,var(--et-violet),var(--et-purple));color:#fff;}
+  .et-btn-primary:hover{filter:brightness(1.08);text-decoration:none;color:#fff;}
+</style>
+
+<div class="et-page">
+  <div class="et-wrap et-hero">
+    <span class="et-eyebrow">Trial</span>
+    <h1>Need more time with Pulumi?</h1>
+    <p class="et-sub">Tell us what you're still evaluating and we'll extend your trial. Most requests are approved within one business day, and you won't lose your stacks, state, or history.</p>
+  </div>
+
+  <div class="et-wrap et-cols">
+
+    <!-- ============ FORM ============ -->
+    <div>
+      <div id="et-formState" class="et-card et-form-card">
+        <div class="et-card-pad">
+          <!-- HubSpot renders here: email + org (prefilled), reason, comments, SE checkbox, submit -->
+          <div id="extend-trial-form"></div>
+          <p class="et-footnote">Goes straight to the Pulumi team. Typical response: under 1 business day.</p>
+        </div>
+      </div>
+
+      <!-- CONFIRMATION (swapped in after submit) -->
+      <div id="et-confState" class="et-card et-form-card et-hide">
+        <div class="et-card-pad et-conf">
+          <div class="et-tick">&#10003;</div>
+          <h2>Request received. We're on it.</h2>
+          <p>We've notified the Pulumi team and sent a copy to <span class="js-email-conf">your email</span>. Your trial stays active while we review.</p>
+          <div class="et-recap">
+            <div class="et-row"><span class="et-k">Organization</span><span><strong class="js-org-conf">&mdash;</strong></span></div>
+            <div class="et-row"><span class="et-k">Reason</span><span><strong class="js-reason-conf">&mdash;</strong></span></div>
+          </div>
+          <ol class="et-steps">
+            <li><b>Now.</b> Your request is with the Pulumi team, along with your account details.</li>
+            <li><b>Within 1 business day.</b> Someone reviews it and either extends your trial or replies with a question.</li>
+            <li><b>Confirmation.</b> You'll get an email with your new trial end date. Nothing in your account changes in the meantime.</li>
+          </ol>
+          <a class="et-btn et-btn-primary" href="https://app.pulumi.com">Back to dashboard</a>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============ SIDEBAR (v1: hardcoded, see note in template head) ============ -->
+    <aside class="et-side">
+      <div class="et-card et-card-pad">
+        <h3>Live workshops</h3>
+        <a class="et-res" href="https://www.pulumi.com/events/intro-to-pulumi-esc-managing-secrets/">
+          <div class="et-evrow">
+            <div class="et-datechip"><div class="et-d">5</div><div class="et-mo">Aug</div></div>
+            <div><div class="et-t">Best Practices for Managing Secrets: An Introduction to ESC</div><div class="et-m">Virtual workshop &middot; Beginner</div></div>
+          </div>
+        </a>
+        <a class="et-res" href="https://www.pulumi.com/events/getting-started-with-devops-ai-skills-2/">
+          <div class="et-evrow">
+            <div class="et-datechip"><div class="et-d">12</div><div class="et-mo">Aug</div></div>
+            <div><div class="et-t">Getting Started with DevOps AI Skills</div><div class="et-m">Virtual workshop &middot; Beginner</div></div>
+          </div>
+        </a>
+        <a class="et-res" href="https://www.pulumi.com/events/neo-in-a-docker-sandbox/">
+          <div class="et-evrow">
+            <div class="et-datechip"><div class="et-d">16</div><div class="et-mo">Sep</div></div>
+            <div><div class="et-t">Neo in a Docker Sandbox: Pulumi's coding agent, safely</div><div class="et-m">With Docker &middot; Virtual workshop</div></div>
+          </div>
+        </a>
+        <a class="et-more et-link" href="https://www.pulumi.com/events/">All events and workshops &rarr;</a>
+      </div>
+
+      <div class="et-card et-card-pad">
+        <h3>While you're evaluating</h3>
+        <a class="et-res" href="https://www.pulumi.com/blog/best-terraform-alternatives/">
+          <div class="et-t"><span class="et-tag">Guide</span>Best Terraform Alternatives in 2026</div><div class="et-m">Jul 18, 2026</div>
+        </a>
+        <a class="et-res" href="https://www.pulumi.com/blog/preview-esc-environment-changes-with-draft-references/">
+          <div class="et-t"><span class="et-tag">Product</span>Preview ESC Changes with Environment Overrides</div><div class="et-m">Jul 23, 2026</div>
+        </a>
+        <a class="et-res" href="https://www.pulumi.com/blog/kubernetes-agent-sandbox/">
+          <div class="et-t"><span class="et-tag">Tutorial</span>Kubernetes Agent Sandbox: What It Is and How to Deploy It</div><div class="et-m">Jul 21, 2026</div>
+        </a>
+        <a class="et-res" href="https://www.pulumi.com/blog/how-to-test-infrastructure-as-code/">
+          <div class="et-t"><span class="et-tag">Best practices</span>How to Test Infrastructure as Code</div><div class="et-m">Jun 30, 2026</div>
+        </a>
+        <a class="et-more et-link" href="https://www.pulumi.com/blog/">More from the blog &rarr;</a>
+      </div>
+
+      <div class="et-card et-card-pad" style="background:var(--et-bg-alt)">
+        <h3>Need something else?</h3>
+        <p style="font-size:14px;color:var(--et-ink2);margin:0 0 12px">If this isn't about your trial length, these get you there faster:</p>
+        <div style="font-size:14px;display:flex;flex-direction:column;gap:8px">
+          <a class="et-link" href="https://www.pulumi.com/contact/">&rarr; Talk to sales about pricing</a>
+          <a class="et-link" href="https://support.pulumi.com/">&rarr; Open a support ticket</a>
+          <a class="et-link" href="https://slack.pulumi.com/">&rarr; Ask the community on Slack</a>
+        </div>
+      </div>
+    </aside>
+
+  </div>
+</div>
+
+<!-- HubSpot forms embed -->
+<script src="//js.hsforms.net/forms/v2.js"></script>
+<script>
+(function () {
+  var params = new URLSearchParams(window.location.search);
+  function q(sel){ return document.querySelector(sel); }
+
+  function createForm(hbspt) {
+    hbspt.forms.create({
+      region: "na1",
+      portalId: "4429525",
+      formId: "4b3db916-7d44-4178-9f86-1cdf94567bfa",
+      target: "#extend-trial-form",
+      cssClass: "et-hsform",
+      onFormReady: function ($form) {
+        var set = function (name, val) {
+          var el = $form.querySelector('[name="' + name + '"]');
+          if (el && val) { el.value = val; el.dispatchEvent(new Event('input', { bubbles: true })); el.dispatchEvent(new Event('change', { bubbles: true })); }
+        };
+        // Prefill visible, editable account fields from the console link.
+        set('email', params.get('email'));
+        set('pulumi_organization_name_s_', params.get('org'));
+      },
+      onFormSubmitted: function ($form) {
+        var emailEl = document.querySelector('#extend-trial-form [name="email"]');
+        var orgEl = document.querySelector('#extend-trial-form [name="pulumi_organization_name_s_"]');
+        var reasonEl = document.querySelector('#extend-trial-form select[name="trial_extension_reason"]');
+        q('.js-email-conf').textContent = (emailEl && emailEl.value) || params.get('email') || 'your email';
+        q('.js-org-conf').textContent = (orgEl && orgEl.value) || params.get('org') || '—';
+        q('.js-reason-conf').textContent = (reasonEl && reasonEl.selectedOptions.length && reasonEl.value) ? reasonEl.selectedOptions[0].text : '—';
+        q('#et-formState').classList.add('et-hide');
+        q('#et-confState').classList.remove('et-hide');
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    });
+  }
+
+  if (window.hbspt) { createForm(window.hbspt); }
+  else {
+    var t = setInterval(function () {
+      if (window.hbspt) { clearInterval(t); createForm(window.hbspt); }
+    }, 50);
+    setTimeout(function () { clearInterval(t); }, 10000);
+  }
+})();
+</script>
+{{ end }}

--- a/layouts/page/extend-trial.html
+++ b/layouts/page/extend-trial.html
@@ -12,8 +12,9 @@
   UTM capture is handled by the form's own hidden last_utm_* fields.
 
   v1 notes for review:
-    - Right-rail events/posts are hardcoded (flagged). Later: pull from Hugo
-      data/content so they stay current on their own.
+    - Right rail pulls live from the site's own content: the next 3 upcoming
+      events (same sortable_date + unlisted logic as partials/events/list-section)
+      and the 4 most recent blog posts. Self-updating, no hardcoded list.
     - Raw hbspt.forms.create is used (not <pulumi-contact-us-form>) specifically
       to get onFormReady prefill + the in-place confirmation swap.
 */}}
@@ -126,53 +127,58 @@
       </div>
     </div>
 
-    <!-- ============ SIDEBAR (v1: hardcoded, see note in template head) ============ -->
+    <!-- ============ SIDEBAR (dynamic: pulled from the site's own events + blog) ============ -->
     <aside class="et-side">
+
+      {{/* Next 3 upcoming events — mirrors partials/events/list-section.html logic */}}
+      {{ $nowUnix := now.UnixMilli }}
+      {{ $upcoming := slice }}
+      {{ range where site.Pages "Type" "events" }}
+        {{ if eq .Params.unlisted false }}
+          {{ $endUnix := (add (.Params.sortable_date | time.AsTime).UnixMilli (duration "hour" 24).Milliseconds) }}
+          {{ if lt $nowUnix $endUnix }}
+            {{ $upcoming = $upcoming | append . }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+      {{ $upcoming = first 3 (sort $upcoming "Params.sortable_date") }}
+      {{ with $upcoming }}
       <div class="et-card et-card-pad">
         <h3>Live workshops</h3>
-        <a class="et-res" href="https://www.pulumi.com/events/intro-to-pulumi-esc-managing-secrets/">
-          <div class="et-evrow">
-            <div class="et-datechip"><div class="et-d">5</div><div class="et-mo">Aug</div></div>
-            <div><div class="et-t">Best Practices for Managing Secrets: An Introduction to ESC</div><div class="et-m">Virtual workshop &middot; Beginner</div></div>
-          </div>
-        </a>
-        <a class="et-res" href="https://www.pulumi.com/events/getting-started-with-devops-ai-skills-2/">
-          <div class="et-evrow">
-            <div class="et-datechip"><div class="et-d">12</div><div class="et-mo">Aug</div></div>
-            <div><div class="et-t">Getting Started with DevOps AI Skills</div><div class="et-m">Virtual workshop &middot; Beginner</div></div>
-          </div>
-        </a>
-        <a class="et-res" href="https://www.pulumi.com/events/neo-in-a-docker-sandbox/">
-          <div class="et-evrow">
-            <div class="et-datechip"><div class="et-d">16</div><div class="et-mo">Sep</div></div>
-            <div><div class="et-t">Neo in a Docker Sandbox: Pulumi's coding agent, safely</div><div class="et-m">With Docker &middot; Virtual workshop</div></div>
-          </div>
-        </a>
-        <a class="et-more et-link" href="https://www.pulumi.com/events/">All events and workshops &rarr;</a>
+        {{ range . }}
+          {{ $href := .RelPermalink }}{{ if .Params.external }}{{ $href = .Params.url_slug }}{{ end }}
+          {{ $t := (.Params.sortable_date | time.AsTime) }}
+          <a class="et-res" href="{{ $href }}">
+            <div class="et-evrow">
+              <div class="et-datechip"><div class="et-d">{{ $t.Format "2" }}</div><div class="et-mo">{{ $t.Format "Jan" }}</div></div>
+              <div><div class="et-t">{{ .Title }}</div>{{ with .Params.event_type }}<div class="et-m">{{ . | title }}</div>{{ end }}</div>
+            </div>
+          </a>
+        {{ end }}
+        <a class="et-more et-link" href="/events/">All events and workshops &rarr;</a>
       </div>
+      {{ end }}
 
+      {{/* 4 most recent blog posts */}}
+      {{ $recent := first 4 (where site.RegularPages "Section" "blog").ByDate.Reverse }}
+      {{ with $recent }}
       <div class="et-card et-card-pad">
         <h3>While you're evaluating</h3>
-        <a class="et-res" href="https://www.pulumi.com/blog/best-terraform-alternatives/">
-          <div class="et-t"><span class="et-tag">Guide</span>Best Terraform Alternatives in 2026</div><div class="et-m">Jul 18, 2026</div>
-        </a>
-        <a class="et-res" href="https://www.pulumi.com/blog/preview-esc-environment-changes-with-draft-references/">
-          <div class="et-t"><span class="et-tag">Product</span>Preview ESC Changes with Environment Overrides</div><div class="et-m">Jul 23, 2026</div>
-        </a>
-        <a class="et-res" href="https://www.pulumi.com/blog/kubernetes-agent-sandbox/">
-          <div class="et-t"><span class="et-tag">Tutorial</span>Kubernetes Agent Sandbox: What It Is and How to Deploy It</div><div class="et-m">Jul 21, 2026</div>
-        </a>
-        <a class="et-res" href="https://www.pulumi.com/blog/how-to-test-infrastructure-as-code/">
-          <div class="et-t"><span class="et-tag">Best practices</span>How to Test Infrastructure as Code</div><div class="et-m">Jun 30, 2026</div>
-        </a>
-        <a class="et-more et-link" href="https://www.pulumi.com/blog/">More from the blog &rarr;</a>
+        {{ range . }}
+          <a class="et-res" href="{{ .RelPermalink }}">
+            <div class="et-t">{{ with .Params.category }}<span class="et-tag">{{ . | title }}</span>{{ end }}{{ .Title }}</div>
+            <div class="et-m">{{ .Date.Format "Jan 2, 2006" }}</div>
+          </a>
+        {{ end }}
+        <a class="et-more et-link" href="/blog/">More from the blog &rarr;</a>
       </div>
+      {{ end }}
 
       <div class="et-card et-card-pad" style="background:var(--et-bg-alt)">
         <h3>Need something else?</h3>
         <p style="font-size:14px;color:var(--et-ink2);margin:0 0 12px">If this isn't about your trial length, these get you there faster:</p>
         <div style="font-size:14px;display:flex;flex-direction:column;gap:8px">
-          <a class="et-link" href="https://www.pulumi.com/contact/">&rarr; Talk to sales about pricing</a>
+          <a class="et-link" href="/contact/">&rarr; Talk to sales about pricing</a>
           <a class="et-link" href="https://support.pulumi.com/">&rarr; Open a support ticket</a>
           <a class="et-link" href="https://slack.pulumi.com/">&rarr; Ask the community on Slack</a>
         </div>

--- a/layouts/page/extend-trial.html
+++ b/layouts/page/extend-trial.html
@@ -51,6 +51,26 @@
   .et-form-card .hs-button.primary{display:inline-flex;align-items:center;justify-content:center;font-size:15.5px;font-weight:600;border-radius:8px;padding:13px 26px;border:1px solid transparent;cursor:pointer;font-family:inherit;color:#fff;background:linear-gradient(100deg,var(--et-violet),var(--et-purple));transition:filter .15s;margin-top:4px;}
   .et-form-card .hs-button.primary:hover{filter:brightness(1.08);}
 
+  /* ---- Harden against the form's inherited "round" theme ----
+     The cloned form ships a theme + style object (arial font, submitColor
+     #5A30C5, label/help colors), some applied as inline styles. These rules
+     win regardless, so the page renders correctly even if the form is NOT set
+     to "Unstyled" in HubSpot. Scoped to .et-page .et-form-card so nothing
+     else on the site is affected. */
+  .et-page .et-form-card .hs-form,
+  .et-page .et-form-card .hs-form input,
+  .et-page .et-form-card .hs-form select,
+  .et-page .et-form-card .hs-form textarea,
+  .et-page .et-form-card .hs-form label,
+  .et-page .et-form-card .hs-button{font-family:inherit !important;}
+  .et-page .et-form-card .hs-form-field > label{color:var(--et-ink) !important;font-size:14.5px !important;}
+  .et-page .et-form-card .hs-field-desc{color:var(--et-muted) !important;font-size:13px !important;}
+  .et-page .et-form-card input.hs-input:not([type=checkbox]):not([type=radio]),
+  .et-page .et-form-card textarea.hs-input{border:1px solid var(--et-line) !important;border-radius:8px !important;background:#fff !important;color:var(--et-ink) !important;font-size:15px !important;padding:11px 13px !important;}
+  .et-page .et-form-card select.hs-input{border:1px solid var(--et-line) !important;border-radius:8px !important;color:var(--et-ink) !important;font-size:15px !important;padding:11px 38px 11px 13px !important;background-color:#fff !important;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%236B6B7B' stroke-width='1.6' fill='none' stroke-linecap='round'/%3E%3C/svg%3E") !important;background-repeat:no-repeat !important;background-position:right 14px center !important;}
+  .et-page .et-form-card .hs-input:focus{border-color:var(--et-violet) !important;box-shadow:0 0 0 3px rgba(95,44,201,.12) !important;}
+  .et-page .et-form-card .hs-button.primary{background:linear-gradient(100deg,var(--et-violet),var(--et-purple)) !important;background-color:var(--et-violet) !important;color:#fff !important;border:1px solid transparent !important;border-radius:8px !important;padding:13px 26px !important;font-size:15.5px !important;font-weight:600 !important;width:auto !important;}
+
   /* sidebar */
   .et-side{display:flex;flex-direction:column;gap:18px;position:sticky;top:92px;}
   .et-side h3{font-size:12.5px;letter-spacing:.07em;text-transform:uppercase;color:var(--et-muted);margin:0 0 14px;font-weight:700;}


### PR DESCRIPTION
## What

Adds a dedicated **`/extend-trial`** page — the destination for the "Request an extension" link in the Pulumi Cloud console trial banner. A user near the end of their trial lands here, tells us what they're still evaluating, and submits a request that routes to the growth/CS team for a human to approve.

Duplicated the contact page as a starting point (thanks @<web-teammate>), then swapped the form for a HubSpot embed so we can prefill account context from the console link and show an in-place confirmation.

### Files
- `content/extend-trial/_index.md` — content + front matter
- `layouts/page/extend-trial.html` — layout (hero, form card, confirmation state, right rail)

## How it works
- **Header/footer** come from `baseof.html` via `{{ define "main" }}` — real site chrome, not approximations.
- **`noindex`** via `block_external_search_index: true` (same convention as `content/confirmation/`, `content/gads/`, event pages). This is a transactional page reached from the product; it shouldn't compete in search.
- **HubSpot form** "Trial Extension" (portal `4429525`, form `4b3db916-7d44-4178-9f86-1cdf94567bfa`), embedded with raw `hbspt.forms.create` — deliberately *not* the `<pulumi-contact-us-form>` component, because we need `onFormReady` prefill and the in-place confirmation swap.
- **Prefill from the console link** (visible, editable fields): `?email=` → `email`, `?org=` → `pulumi_organization_name_s_`. No params → fields are simply empty for the user to fill; nothing breaks. UTM capture is handled by the form's own hidden `last_utm_*` fields.
- **Right rail is dynamic** — pulls the next 3 upcoming events (same `sortable_date` + `unlisted` logic as `partials/events/list-section.html`) and the 4 most recent blog posts from the site's own content. Self-updating; nothing hardcoded.
- CSS is scoped with an `et-` prefix (no global changes) and also styles the HubSpot form fields at the page level — **set the form to "Unstyled" in HubSpot** so it doesn't inject competing CSS.

## Reviewer notes / follow-ups (not blockers)
1. **Inline `<style>`/`<script>` in the layout** — kept self-contained for a starting point. Happy to move CSS to the theme's pipeline and the embed script wherever you prefer.
2. **Console change is a separate dependency** (different repo): the trial-banner link needs to append `?org=<slug>&email=<url-encoded>&utm_source=console&utm_medium=trial_banner`. Without it the page still works; prefill is what makes it one-click.
3. **CI "test" failure is a fork artifact** — it fails at the "Fetch secrets from ESC" step because fork PRs are denied repo secrets. Running this branch in-repo (which also produces the deploy preview) will authenticate and run the real tests.

Opening as a **draft** for the web team to sanity-check conventions before it goes further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
