### PR TITLE
lint: throw when a chooser type's option keys can't be parsed

### DIFF
--- a/scripts/lint/lint-markdown.js
+++ b/scripts/lint/lint-markdown.js
@@ -906,6 +906,22 @@ const parseChooserRegistry = (function () {
             }
         });
 
+        // Fail loudly here for the same reason the union parse does above: an
+        // unresolved type leaves the option-key check with nothing to compare
+        // against, so it quietly passes everything. A regex that stops matching
+        // (a reformat moving the closing `];`, a renamed supported* list, a
+        // restructured mapOptions switch) would otherwise disable half the guard.
+        types.forEach(function (type) {
+            if (!optionsByType[type]) {
+                const listName = typeToList[type];
+                const where = listName ? `(list: ${listName})` : "(no matching case in mapOptions)";
+                throw new Error(
+                    `Could not parse option keys for chooser type '${type}' ${where} from ${CHOOSER_COMPONENT_PATH}. ` +
+                        `If the component was refactored, update parseChooserRegistry in this file to match.`,
+                );
+            }
+        });
+
         cached = { types, optionsByType };
         return cached;
     };


### PR DESCRIPTION
### Proposed changes

Implements @nyobe's review feedback on #20574. Targets that PR's branch, so merging this folds the change into #20574.

`parseChooserRegistry` threw when the `ChooserType` union couldn't be read, but the option-key path didn't. If a `supported*` regex stopped matching — a reformat moving the closing `];`, a renamed list, a restructured `mapOptions` switch — `optionsByType` came back missing that type and every option check for it hit `if (!valid) continue`. Half the guard silently became a no-op, which is the exact failure mode the guard exists to prevent.

Every type in the union must now resolve to a non-empty key list or the parse throws, naming the type and the list it couldn't read (or noting that `mapOptions` had no matching case). That covers both regexes rather than only the `supported*` one: the review's suggested loop was over the parsed `mapOptions` cases, so a break in the case regex itself would have left an empty map and nothing to iterate.

On the second (explicitly non-blocking) comment — moving the type list and per-type option keys into a shared `.js` data file importable by both the linter and the component — no change here. The throw covers the gap, and the restructuring is a larger change than belongs in a fix PR.

Verification:

- Full lint clean: 1,832 files parsed, 0 errors.
- Negative test 1 — reindent a `supported*` list's closing `];`: throws `Could not parse option keys for chooser type 'pythontoolchain' (list: supportedPythonToolchains) …`.
- Negative test 2 — reformat the `mapOptions` case so the assignment wraps: throws `Could not parse option keys for chooser type 'tf-tool' (no matching case in mapOptions) …`.
- Prettier clean.

### Unreleased product version (optional)

N/A

### Related issues (optional)

Addresses review feedback on #20574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTYuhNFFx8LYMG31gbrhYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTYuhNFFx8LYMG31gbrhYi)_