### PR TITLE
Recover the July build-time regression: image cache, partialCached menus/cards, duration guardrail

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -103,6 +103,21 @@ jobs:
           restore-keys: |
             meta-images-
 
+      # Persist Hugo's processed-image cache (resources/_gen). Blog templates
+      # process feature images to WebP at several sizes via .Process; without
+      # this cache every CI run re-encodes ~2,400 images from scratch (~4-5
+      # minutes of the build). With a warm cache, .Process is a lookup.
+      - name: Cache Hugo processed images
+        uses: actions/cache@v6
+        with:
+          path: resources
+          key: hugo-resources-${{ github.sha }}
+          restore-keys: |
+            hugo-resources-
+
+      - name: Record build start time
+        run: echo "CI_BUILD_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: Build and deploy
         run: make ci_push
         env:
@@ -115,6 +130,16 @@ jobs:
           ALGOLIA_APP_SEARCH_KEY: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
           ALGOLIA_APP_ADMIN_KEY: ${{  steps.esc-secrets.outputs.ALGOLIA_APP_ADMIN_KEY }}
           NODE_OPTIONS: "--max_old_space_size=8192"
+
+      # Duration guardrail: the July 2026 regression sat unnoticed for three
+      # weeks because nothing watched build time. Warn in Slack when a
+      # successful build runs long so the next regression is caught in days.
+      - name: Alert on slow build
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          BUILD_DURATION_THRESHOLD_MINUTES: '15'
+        run: ./scripts/ci-build-duration-alert.sh
 
       - name: Archive test results
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -78,6 +78,18 @@ jobs:
           restore-keys: |
             meta-images-
 
+      # Persist Hugo's processed-image cache (resources/_gen). Blog templates
+      # process feature images to WebP at several sizes via .Process; without
+      # this cache every CI run re-encodes ~2,400 images from scratch (~4-5
+      # minutes of the build). With a warm cache, .Process is a lookup.
+      - name: Cache Hugo processed images
+        uses: actions/cache@v6
+        with:
+          path: resources
+          key: hugo-resources-${{ github.sha }}
+          restore-keys: |
+            hugo-resources-
+
       - name: Build and deploy
         run: make ci_pull_request
         env:

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -131,6 +131,26 @@ jobs:
           echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
           sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
           rm /tmp/vale.tar.gz
+      # Restore previously generated OpenGraph cards so the build-time generator
+      # only re-renders pages that changed (manifest content-hash skip). The
+      # cards are gitignored; this cache is their only persistence across runs.
+      - name: Cache generated meta images
+        uses: actions/cache@v6
+        with:
+          path: assets/images/generated
+          key: meta-images-${{ github.sha }}
+          restore-keys: |
+            meta-images-
+      # Persist Hugo's processed-image cache (resources/_gen) for the full
+      # `make build` below; without it every run re-encodes ~2,400 WebP images
+      # from scratch (~4-5 minutes).
+      - name: Cache Hugo processed images
+        uses: actions/cache@v6
+        with:
+          path: resources
+          key: hugo-resources-${{ github.sha }}
+          restore-keys: |
+            hugo-resources-
       - run: make ensure
       - name: clean stale generated command pages
         run: |

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -69,6 +69,29 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@v7
 
+      # Restore previously generated OpenGraph cards so the build-time generator
+      # only re-renders pages that changed (manifest content-hash skip). The
+      # cards are gitignored; this cache is their only persistence across runs.
+      - name: Cache generated meta images
+        uses: actions/cache@v6
+        with:
+          path: assets/images/generated
+          key: meta-images-${{ github.sha }}
+          restore-keys: |
+            meta-images-
+
+      # Persist Hugo's processed-image cache (resources/_gen). Blog templates
+      # process feature images to WebP at several sizes via .Process; without
+      # this cache every CI run re-encodes ~2,400 images from scratch (~4-5
+      # minutes of the build). With a warm cache, .Process is a lookup.
+      - name: Cache Hugo processed images
+        uses: actions/cache@v6
+        with:
+          path: resources
+          key: hugo-resources-${{ github.sha }}
+          restore-keys: |
+            hugo-resources-
+
       - name: Build and deploy
         run: make ci_push
         env:

--- a/layouts/_default/term.rows.html
+++ b/layouts/_default/term.rows.html
@@ -12,5 +12,5 @@
 */ -}}
 <meta name="robots" content="noindex">
 {{- range (where .Data.Pages "Section" "blog").ByDate.Reverse -}}
-{{ partial "blog/card/list-row.html" (dict "page" .) }}
+{{ partialCached "blog/card/list-row.html" (dict "page" .) .RelPermalink }}
 {{- end -}}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -18,7 +18,7 @@
             {{ end }}
             {{ with after 1 $featured }}
                 <div class="mb-10 grid grid-cols-1 gap-x-8 lg:gap-x-16 gap-y-6 border-b border-gray-200 pb-10 xl:grid-cols-3">
-                    {{ range . }}{{ partial "blog/card/small.html" (dict "page" .) }}{{ end }}
+                    {{ range . }}{{ partialCached "blog/card/small.html" (dict "page" .) .RelPermalink }}{{ end }}
                 </div>
             {{ end }}
             <div class="mb-6 flex items-start justify-between gap-4">
@@ -30,7 +30,7 @@
         {{ partial "blog/paginator.html" (dict "context" . "position" "top") }}
 
         <div data-post-list class="flex flex-col">
-            {{ range $paginator.Pages }}{{ partial "blog/card/list-row.html" (dict "page" .) }}{{ end }}
+            {{ range $paginator.Pages }}{{ partialCached "blog/card/list-row.html" (dict "page" .) .RelPermalink }}{{ end }}
         </div>
 
         {{ partial "blog/paginator.html" . }}

--- a/layouts/community/team/single.html
+++ b/layouts/community/team/single.html
@@ -64,7 +64,7 @@
             <h2 class="heading-2 mb-2">Recent blog posts</h2>
             <div data-post-list class="flex flex-col">
                 {{ range first 10 (sort $authorPosts "Date" "desc") }}
-                    {{ partial "blog/card/list-row.html" (dict "page" .) }}
+                    {{ partialCached "blog/card/list-row.html" (dict "page" .) .RelPermalink }}
                 {{ end }}
             </div>
         </section>

--- a/layouts/partials/blog/card/featured.html
+++ b/layouts/partials/blog/card/featured.html
@@ -13,7 +13,7 @@
 <article class="group relative flex flex-col overflow-hidden rounded-lg bg-violet-950 lg:min-h-[440px] lg:flex-row">
     {{ if $hasImage }}
     <div class="flex aspect-[16/10] w-full items-center justify-center p-4 sm:aspect-[2/1] lg:aspect-auto lg:w-1/2 lg:p-6">
-        {{ partial "blog/feature-image.html" (dict "page" $page "w" 720 "h" 440 "mode" "fit" "class" "max-h-full w-auto object-contain" "sizes" "(min-width: 1024px) 45vw, 100vw" "eager" true) }}
+        {{ partialCached "blog/feature-image.html" (dict "page" $page "w" 720 "h" 440 "mode" "fit" "class" "max-h-full w-auto object-contain" "sizes" "(min-width: 1024px) 45vw, 100vw" "eager" true) $page.RelPermalink "featured-720x440" }}
     </div>
     {{ end }}
     <div class="flex flex-col items-start justify-center gap-5 p-6 lg:p-10 lg:pr-12 {{ if $hasImage }}lg:w-1/2{{ else }}lg:w-full{{ end }}">

--- a/layouts/partials/blog/card/list-row.html
+++ b/layouts/partials/blog/card/list-row.html
@@ -41,7 +41,7 @@
         </div>
         {{ if partial "blog/has-feature-image.html" $page }}
         <div class="flex size-20 sm:size-28 lg:size-36 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-violet-950">
-            {{ partial "blog/feature-image.html" (dict "page" $page "w" 288 "h" 288 "mode" "fit" "class" "h-full w-auto max-w-none") }}
+            {{ partialCached "blog/feature-image.html" (dict "page" $page "w" 288 "h" 288 "mode" "fit" "class" "h-full w-auto max-w-none") $page.RelPermalink "fit-288x288" }}
         </div>
         {{ end }}
     </div>

--- a/layouts/partials/blog/card/medium.html
+++ b/layouts/partials/blog/card/medium.html
@@ -10,7 +10,7 @@
 <article data-post-card class="group relative flex h-full flex-col gap-4">
     {{ if partial "blog/has-feature-image.html" $page }}
     <div class="flex aspect-[3/2] w-full items-center justify-center overflow-hidden rounded-lg bg-violet-950">
-        {{ partial "blog/feature-image.html" (dict "page" $page "w" 640 "h" 427 "mode" "fit" "class" "h-full w-auto max-w-none" "sizes" "(min-width: 1024px) 30vw, (min-width: 640px) 45vw, 100vw") }}
+        {{ partialCached "blog/feature-image.html" (dict "page" $page "w" 640 "h" 427 "mode" "fit" "class" "h-full w-auto max-w-none" "sizes" "(min-width: 1024px) 30vw, (min-width: 640px) 45vw, 100vw") $page.RelPermalink "fit-640x427" }}
     </div>
     {{ end }}
     <div class="flex flex-col items-start gap-2">

--- a/layouts/partials/blog/card/small.html
+++ b/layouts/partials/blog/card/small.html
@@ -8,7 +8,7 @@
 <article class="group relative flex sm:items-center gap-6">
     {{ if partial "blog/has-feature-image.html" $page }}
     <div class="flex size-[80px] sm:size-[140px] shrink-0 items-center justify-center overflow-hidden rounded-lg bg-violet-950">
-        {{ partial "blog/feature-image.html" (dict "page" $page "w" 240 "h" 160 "mode" "fit" "class" "h-full w-auto max-w-none") }}
+        {{ partialCached "blog/feature-image.html" (dict "page" $page "w" 240 "h" 160 "mode" "fit" "class" "h-full w-auto max-w-none") $page.RelPermalink "fit-240x160" }}
     </div>
     {{ end }}
     <div class="flex min-w-0 flex-col gap-2.5">

--- a/layouts/partials/blog/interleaved-list.html
+++ b/layouts/partials/blog/interleaved-list.html
@@ -30,9 +30,9 @@
 {{- $listPages := after $splitIdx $pages -}}
 {{- with $gridPages }}
 <div data-post-grid class="mb-10 grid grid-cols-1 gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
-    {{ range . }}{{ partial "blog/card/medium.html" (dict "page" .) }}{{ end }}
+    {{ range . }}{{ partialCached "blog/card/medium.html" (dict "page" .) .RelPermalink }}{{ end }}
 </div>
 {{- end }}
 <div data-post-list class="flex flex-col">
-    {{ range $listPages }}{{ partial "blog/card/list-row.html" (dict "page" .) }}{{ end }}
+    {{ range $listPages }}{{ partialCached "blog/card/list-row.html" (dict "page" .) .RelPermalink }}{{ end }}
 </div>

--- a/layouts/partials/blog/related-posts.html
+++ b/layouts/partials/blog/related-posts.html
@@ -21,7 +21,7 @@
     <div class="mx-auto max-w-[1220px] px-4 py-10 lg:py-12">
         <p class="font-overline m-0! mb-6 text-service-black">Related posts</p>
         <div class="flex flex-col">
-            {{ range . }}{{ partial "blog/card/list-row.html" (dict "page" .) }}{{ end }}
+            {{ range . }}{{ partialCached "blog/card/list-row.html" (dict "page" .) .RelPermalink }}{{ end }}
         </div>
     </div>
 </section>

--- a/layouts/partials/blog/series-page.html
+++ b/layouts/partials/blog/series-page.html
@@ -24,7 +24,7 @@
 
     <div class="grid grid-cols-1 gap-x-8 gap-y-8 sm:grid-cols-2 lg:grid-cols-3">
         {{ range $i, $p := $parts }}
-            {{ partial "blog/series-part-card.html" (dict "page" $p "num" (add $i 1) "series" $series) }}
+            {{ partialCached "blog/series-part-card.html" (dict "page" $p "num" (add $i 1) "series" $series) $p.RelPermalink (add $i 1) }}
         {{ end }}
     </div>
 

--- a/layouts/partials/blog/series-part-card.html
+++ b/layouts/partials/blog/series-part-card.html
@@ -17,7 +17,7 @@
 <article class="group relative flex items-center gap-4">
     {{ if partial "blog/has-feature-image.html" $page }}
     <div class="flex size-[140px] shrink-0 items-center justify-center overflow-hidden rounded-lg bg-violet-950">
-        {{ partial "blog/feature-image.html" (dict "page" $page "w" 240 "h" 160 "mode" "fit" "class" "h-full w-auto max-w-none") }}
+        {{ partialCached "blog/feature-image.html" (dict "page" $page "w" 240 "h" 160 "mode" "fit" "class" "h-full w-auto max-w-none") $page.RelPermalink "fit-240x160" }}
     </div>
     {{ end }}
     <div class="flex min-w-0 flex-col items-start gap-2.5">

--- a/layouts/partials/docs/breadcrumb-path.html
+++ b/layouts/partials/docs/breadcrumb-path.html
@@ -1,0 +1,38 @@
+{{- /*
+    Recursive breadcrumb finder: locates the entry whose URL matches targetURL
+    in a menu-entry tree and returns the chain of its ancestors, outermost
+    first. This replaces the breadcrumb collection that used to happen as a
+    side effect of rendering the menu walker — the rendered menu is now cached
+    per section (see docs/menu.html), so a per-page side effect there would
+    only run on cache misses and produce stale breadcrumbs everywhere else.
+
+    Mirrors the old walker's semantics: entries named "Overview" and the menu's
+    own root entry (Identifier == rootMenuID) are skipped, ancestors are the
+    items *above* the match (never the match itself), and a page not found in
+    the tree yields an empty chain.
+
+    Params:
+      entries     (required) the menu entries to search
+      targetURL   (required) the current page's RelPermalink
+      rootMenuID  (required) the menu's root identifier, skipped like the walker does
+
+    Returns: dict with "found" (bool) and "chain" (slice of {name, url} dicts).
+*/ -}}
+{{- $targetURL := .targetURL -}}
+{{- $rootMenuID := .rootMenuID -}}
+{{- $result := dict "found" false "chain" (slice) -}}
+{{- range .entries -}}
+    {{- if and (not $result.found) (ne .Name "Overview") (ne .Identifier $rootMenuID) -}}
+        {{- if and .URL (eq .URL $targetURL) -}}
+            {{- $result = dict "found" true "chain" (slice) -}}
+        {{- else if .Children -}}
+            {{- $sub := partial "docs/breadcrumb-path.html" (dict "entries" .Children "targetURL" $targetURL "rootMenuID" $rootMenuID) -}}
+            {{- if $sub.found -}}
+                {{- $chain := slice (dict "name" .Name "url" .URL) -}}
+                {{- range $sub.chain -}}{{- $chain = $chain | append . -}}{{- end -}}
+                {{- $result = dict "found" true "chain" $chain -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- return $result -}}

--- a/layouts/partials/docs/menu-tree.html
+++ b/layouts/partials/docs/menu-tree.html
@@ -1,0 +1,138 @@
+{{- /*
+    The docs left-nav tree. This partial is PAGE-INDEPENDENT by design: it is
+    invoked via partialCached (see docs/menu.html) keyed on (currentSection,
+    expandedIDs), so Hugo renders it once per section (~20 times per build)
+    instead of once per docs page (~1,700 times). Before this was cached, the
+    recursive walker below ran ~225,000 times per build (~20 cumulative
+    minutes of render time).
+
+    Consequently NOTHING here may read the current page. Per-page state — the
+    active link, its ancestor chain, and their expansion — is stamped
+    client-side by the inline script in docs/menu.html, which runs before
+    first paint. Section-level expansion is still rendered server-side because
+    currentSection is part of the cache key.
+
+    Params:
+      currentSection (required) the top-level docs section of the current page
+      expandedIDs    (required) menu IDs to force-expand server-side
+*/ -}}
+{{- $currentSection := .currentSection }}
+{{- $expandedIDs := default slice .expandedIDs }}
+
+<pulumi-docs-nav expanded-menu-ids="{{ delimit $expandedIDs "," }}">
+    <ul class="list-none pl-0">
+
+        <li class="" data-menu-id="docs-home">
+            <ul class="list-none">
+                <li><a href="/docs/">
+                    <button>{{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}</button>
+                    <span>Docs Home</span>
+                </a></li>
+            </ul>
+        </li>
+
+        {{/* Menu sections driven by data/docs_menu_sections.yml */}}
+        {{- range site.Data.docs_menu_sections }}
+        {{- $menuName := .menu }}
+        {{- $label := .label }}
+        {{- with index site.Menus $menuName }}
+        <li class="expandable expanded{{ if eq $currentSection $menuName }} expanded{{ end }}" data-menu-id="{{ $menuName }}-top">
+            <ul class="list-none">
+                {{- partial "inline/menu/walk.html" (dict "rootMenuID" $menuName "menuEntries" . "forceTopLevelLabel" $label "expandedIDs" $expandedIDs) }}
+            </ul>
+        </li>
+        {{- end }}
+        {{- end }}
+
+        {{/* Tutorials External Link */}}
+        <li class="" data-menu-id="tutorials-external">
+            <ul class="list-none">
+                <li><a href="/tutorials/" target="_blank" rel="noopener noreferrer">
+                    <button>{{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}</button>
+                    <span>Tutorials ↗</span>
+                </a></li>
+            </ul>
+        </li>
+
+        {{/* Registry External Link */}}
+        <li class="" data-menu-id="registry-external">
+            <ul class="list-none">
+                <li><a href="/registry/" target="_blank" rel="noopener noreferrer">
+                    <button>{{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}</button>
+                    <span>Registry ↗</span>
+                </a></li>
+            </ul>
+        </li>
+
+    </ul>
+</pulumi-docs-nav>
+
+{{- define "partials/inline/menu/walk.html" }}
+    {{- $rootMenuID := .rootMenuID }}
+    {{- $expandedIDs := default slice .expandedIDs }}
+
+    {{- range .menuEntries }}
+        {{/* Skip Overview pages since we add them manually */}}
+        {{/* Skip root home items that we've already created manually */}}
+        {{- if and (ne .Name "Overview") (ne .Identifier $rootMenuID) }}
+            {{- $name := .Name }}
+            {{- with .Identifier }}
+                {{- with T . }}
+                    {{- $name = . }}
+                {{- end }}
+            {{- end }}
+
+            {{/* Store the current menu item before entering Children context */}}
+            {{- $currentMenuItem := . }}
+
+            {{/* Expansion here covers only force-expanded IDs; expansion of the
+                 current page's ancestors is applied client-side (the tree is
+                 cached and can't know the current page). */}}
+            {{- $isExpanded := and .Identifier (in $expandedIDs .Identifier) }}
+            <li {{ if (and .Children (ne .Identifier $rootMenuID)) }} class="expandable{{ if $isExpanded }} expanded{{ end }}" {{ end }}
+                {{ if .Identifier }} data-menu-id="{{ .Identifier }}" {{ end }}
+                >
+                {{- if and .Children (ne .Identifier $rootMenuID) }}
+                    {{/* Parent with children - make it clickable for expand/collapse but not navigation */}}
+                    <a href="javascript:void(0)" onclick="this.closest('li').classList.toggle('expanded'); return false;">
+                    <button style="pointer-events: none;">
+                        {{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}
+                    </button>
+                    <span>{{ $name }}</span>
+                    </a>
+                {{- else }}
+                    {{/* Regular link or root menu item */}}
+                    <a{{ with .URL }} href="{{ . }}"{{ end }}>
+                    <button>
+                        {{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}
+                    </button>
+                    <span>{{ $name }}</span>
+                    </a>
+                {{- end }}
+                {{- with .Children }}
+                    <ul class="list-none">
+                        {{/* Add Overview link for parent pages that have a URL */}}
+                        {{- if $currentMenuItem.URL }}
+                            {{- $overviewPage := site.GetPage $currentMenuItem.URL }}
+                            {{- if $overviewPage }}
+                                {{- $overviewLabel := "Introduction" }}
+                                {{- if $overviewPage.Params.docs_home }}
+                                    {{- $overviewLabel = "Overview" }}
+                                {{- end }}
+                                <li data-menu-id="overview">
+                                    <a href="{{ $overviewPage.RelPermalink }}">
+                                    <button>
+                                        {{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}
+                                    </button>
+                                    <span>{{ $overviewLabel }}</span>
+                                    </a>
+                                </li>
+                            {{- end }}
+                        {{- end }}
+                        {{- partial "inline/menu/walk.html" (dict "menuEntries" . "rootMenuID" $rootMenuID "expandedIDs" $expandedIDs) }}
+                    </ul>
+                {{- end }}
+            </li>
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -124,7 +124,10 @@
             if (path.slice(-1) !== "/") {
                 path += "/";
             }
-            var links = menu.querySelectorAll("a[href]");
+
+            var section = path.split("/")[2] || "";
+            var sectionRoot = section ? menu.querySelector('li[data-menu-id="' + section + '-top"]') : null;
+            var links = (sectionRoot || menu).querySelectorAll("a[href]");
             for (var i = 0; i < links.length; i++) {
                 var href = links[i].getAttribute("href");
                 if (!href || href.charAt(0) !== "/" || links[i].getAttribute("target")) {

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -1,24 +1,19 @@
 {{- $page := .page }}
 
 {{/*
-    BREADCRUMB BUILDING
+    This partial is the per-page wrapper around the docs left nav. The
+    expensive part — the recursive menu tree — lives in docs/menu-tree.html
+    and is rendered via partialCached keyed on (currentSection, expandedIDs),
+    so Hugo renders it once per section instead of once per page. Everything
+    page-specific happens out here:
 
-    Breadcrumbs are built as a side effect of rendering the menu. As the menu walker
-    (inline/menu/walk.html) iterates through menu items, it identifies ancestors of the
-    current page using Hugo's .HasMenuCurrent function and adds them to .Scratch.
-
-    After all menus are rendered, we prepend "Docs" root and append the current page.
-    The breadcrumb.html partial retrieves this data from .Scratch and renders it.
+    - Breadcrumbs are computed directly from the menu data by the
+      docs/breadcrumb-path.html finder (they used to be a side effect of
+      rendering the menu walker, which a cached tree can no longer provide).
+    - The active link, its ancestor chain, and their expansion are stamped on
+      the cached tree by the inline script below, which runs before first
+      paint so the menu never flashes or jumps.
 */}}
-
-{{/* Initialize empty breadcrumb list - will be populated as menu renders */}}
-{{ $page.Scratch.Set "breadcrumbs" slice }}
-
-{{/* Build URL lookup maps per menu for performance */}}
-{{ range $menuName, $menuEntries := site.Menus }}
-    {{ $page.Scratch.Set (printf "menuURLs-%s" $menuName) dict }}
-    {{ partial "inline/menu/collecturls" (dict "menuName" $menuName "menuEntries" $menuEntries "page" $page) }}
-{{ end }}
 
 {{/* Detect current section for auto-expansion (driven by data/docs_menu_sections.yml) */}}
 {{ $currentSection := "home" }}
@@ -31,6 +26,41 @@
         {{ end }}
     {{ end }}
 {{ end }}
+
+{{/*
+    BREADCRUMB BUILDING
+
+    Find the current page (by URL) in its section's menu and collect the
+    ancestor chain, outermost first. Only the current section's menu is
+    searched — parent pages can appear in multiple menus (e.g. /docs/iac/cli/
+    is in both iac and reference), and the section menu is the one the reader
+    is navigating. Then complete the chain:
+    1. Prepend "Docs" root at the beginning
+    2. Append the current page at the end
+    Result: Docs → [ancestor1] → [ancestor2] → Current Page
+*/}}
+{{ $ancestors := slice }}
+{{ with index site.Menus $currentSection }}
+    {{ $path := partial "docs/breadcrumb-path.html" (dict "entries" . "targetURL" $page.RelPermalink "rootMenuID" $currentSection) }}
+    {{ if $path.found }}
+        {{ $ancestors = $path.chain }}
+    {{ end }}
+{{ end }}
+{{ $finalBreadcrumbs := slice (dict "name" "Docs" "url" "/docs/") }}
+{{ range $ancestors }}
+    {{ $finalBreadcrumbs = $finalBreadcrumbs | append . }}
+{{ end }}
+
+{{/* Generated OpenAPI schema sub-pages are not in any menu, so inject their
+     ancestor chain manually: Reference → REST API Docs → Schema. */}}
+{{ if and $page.Params.openapi_schema (not $ancestors) }}
+    {{ $finalBreadcrumbs = $finalBreadcrumbs | append (dict "name" "Reference" "url" "/docs/reference/") }}
+    {{ $finalBreadcrumbs = $finalBreadcrumbs | append (dict "name" "REST API Docs" "url" "/docs/reference/cloud-rest-api/") }}
+    {{ $finalBreadcrumbs = $finalBreadcrumbs | append (dict "name" "Schema" "url" "/docs/reference/cloud-rest-api/schema/") }}
+{{ end }}
+
+{{ $finalBreadcrumbs = $finalBreadcrumbs | append (dict "name" $page.LinkTitle "url" $page.RelPermalink) }}
+{{ $page.Scratch.Set "breadcrumbs" $finalBreadcrumbs }}
 
 <nav class="text-sm mt-5 mr-2">
     {{/* Search box moved from top nav */}}
@@ -60,53 +90,9 @@
         {{ $expandedIDs = $expandedIDs | append "iac-cli" | append "iac-cli-commands" }}
     {{ end }}
 
-    <pulumi-docs-nav expanded-menu-ids="{{ delimit $expandedIDs "," }}">
-        <ul class="list-none pl-0">
-
-            <li class="" data-menu-id="docs-home">
-                <ul class="list-none">
-                    <li><a href="/docs/"{{ if eq $page.RelPermalink "/docs/" }} class="active" aria-current="page"{{ end }}>
-                        <button>{{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}</button>
-                        <span>Docs Home</span>
-                    </a></li>
-                </ul>
-            </li>
-
-            {{/* Menu sections driven by data/docs_menu_sections.yml */}}
-            {{- range site.Data.docs_menu_sections }}
-            {{- $menuName := .menu }}
-            {{- $label := .label }}
-            {{- with index site.Menus $menuName }}
-            <li class="expandable expanded{{ if eq $currentSection $menuName }} expanded{{ end }}" data-menu-id="{{ $menuName }}-top">
-                <ul class="list-none">
-                    {{- partial "inline/menu/walk.html" (dict "page" $page "rootMenuID" $menuName "currentSection" $currentSection "menuEntries" . "allMenuEntries" . "forceTopLevelLabel" $label "expandedIDs" $expandedIDs) }}
-                </ul>
-            </li>
-            {{- end }}
-            {{- end }}
-
-            {{/* Tutorials External Link */}}
-            <li class="" data-menu-id="tutorials-external">
-                <ul class="list-none">
-                    <li><a href="/tutorials/" target="_blank" rel="noopener noreferrer">
-                        <button>{{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}</button>
-                        <span>Tutorials ↗</span>
-                    </a></li>
-                </ul>
-            </li>
-
-            {{/* Registry External Link */}}
-            <li class="" data-menu-id="registry-external">
-                <ul class="list-none">
-                    <li><a href="/registry/" target="_blank" rel="noopener noreferrer">
-                        <button>{{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}</button>
-                        <span>Registry ↗</span>
-                    </a></li>
-                </ul>
-            </li>
-
-        </ul>
-    </pulumi-docs-nav>
+    {{/* The nav tree, rendered once per (section, expandedIDs) and reused
+         across every page in that section. */}}
+    {{ partialCached "docs/menu-tree.html" (dict "currentSection" $currentSection "expandedIDs" $expandedIDs) $currentSection (delimit $expandedIDs ",") }}
 
     {{/* Color-theme toggle, pinned to the bottom of the sidebar nav (third flex
          child after pulumi-docs-nav, which is flex:1 and scrolls). Gated to docs
@@ -116,18 +102,60 @@
         {{ partial "docs/theme-toggle.html" . }}
     {{ end }}
 
-    {{/* Scroll the active item into view. Runs inline — before first paint — so the
-         menu never visibly jumps. The expanded classes are rendered server-side above,
-         so the geometry is already final.
+    {{/* Stamp per-page state on the cached tree, then scroll the active item
+         into view. Runs inline — before first paint — so the classes are final
+         before the menu is ever rendered: no flash of collapsed items, no jump.
 
-         The menu's scroll position is carried across page loads via sessionStorage,
-         so navigating between pages whose nav items are already in view (e.g.,
-         siblings) doesn't move the nav at all. Only when the active item falls
-         outside the restored view is it scrolled (centered) into view. */}}
+         The cached tree cannot know the current page, so this script does what
+         the walker used to do server-side: mark the current page's link active,
+         mark and expand its ancestors.
+
+         The menu's scroll position is carried across page loads via
+         sessionStorage, so navigating between pages whose nav items are already
+         in view (e.g., siblings) doesn't move the nav at all. Only when the
+         active item falls outside the restored view is it scrolled (centered)
+         into view. */}}
     <script>
         (function () {
             var menu = document.currentScript.closest("nav").querySelector("pulumi-docs-nav");
             var KEY = "docs-nav-scroll-position";
+
+            var path = window.location.pathname;
+            if (path.slice(-1) !== "/") {
+                path += "/";
+            }
+            var links = menu.querySelectorAll("a[href]");
+            for (var i = 0; i < links.length; i++) {
+                var href = links[i].getAttribute("href");
+                if (!href || href.charAt(0) !== "/" || links[i].getAttribute("target")) {
+                    continue;
+                }
+                if (href.slice(-1) !== "/") {
+                    href += "/";
+                }
+                if (href !== path) {
+                    continue;
+                }
+                var active = links[i];
+                active.classList.add("active");
+                active.setAttribute("aria-current", "page");
+                // Walk up the tree: expand every collapsible ancestor and mark
+                // its toggle link, mirroring the classes the server used to set.
+                var li = active.closest("li");
+                while (li && menu.contains(li)) {
+                    if (li.classList.contains("expandable")) {
+                        li.classList.add("expanded");
+                    }
+                    var toggle = li.querySelector(":scope > a");
+                    if (toggle && toggle !== active && !toggle.classList.contains("active")) {
+                        toggle.classList.add("ancestor");
+                        if (toggle.getAttribute("href") !== "javascript:void(0)") {
+                            toggle.setAttribute("aria-current", "true");
+                        }
+                    }
+                    li = li.parentElement && li.parentElement.closest("li");
+                }
+            }
 
             try {
                 var saved = sessionStorage.getItem(KEY);
@@ -141,15 +169,15 @@
                 // Storage unavailable; fall through to centering below.
             }
 
-            var active = menu.querySelector("a.active");
-            if (!active) {
+            var activeLink = menu.querySelector("a.active");
+            if (!activeLink) {
                 return;
             }
             var menuRect = menu.getBoundingClientRect();
             if (menuRect.height === 0) {
                 return;
             }
-            var itemRect = active.getBoundingClientRect();
+            var itemRect = activeLink.getBoundingClientRect();
             if (itemRect.top < menuRect.top || itemRect.bottom > menuRect.bottom) {
                 // Center the active item vertically within the menu.
                 menu.scrollTop += itemRect.top - menuRect.top - (menuRect.height - itemRect.height) / 2;
@@ -157,152 +185,3 @@
         })();
     </script>
 </nav>
-
-{{/*
-    BREADCRUMB FINALIZATION
-
-    After all menus have been rendered and ancestors collected, complete the breadcrumb chain:
-    1. Prepend "Docs" root at the beginning
-    2. Append the current page at the end
-    Result: Docs → [ancestor1] → [ancestor2] → Current Page
-*/}}
-{{ $existingCrumbs := $page.Scratch.Get "breadcrumbs" }}
-{{ $finalBreadcrumbs := slice (dict "name" "Docs" "url" "/docs/") }}
-{{ range $existingCrumbs }}
-    {{ $finalBreadcrumbs = $finalBreadcrumbs | append . }}
-{{ end }}
-
-{{/* Generated OpenAPI schema sub-pages are not in any menu, so inject their
-     ancestor chain manually: Reference → REST API Docs → Schema. */}}
-{{ if and $page.Params.openapi_schema (not $existingCrumbs) }}
-    {{ $finalBreadcrumbs = $finalBreadcrumbs | append (dict "name" "Reference" "url" "/docs/reference/") }}
-    {{ $finalBreadcrumbs = $finalBreadcrumbs | append (dict "name" "REST API Docs" "url" "/docs/reference/cloud-rest-api/") }}
-    {{ $finalBreadcrumbs = $finalBreadcrumbs | append (dict "name" "Schema" "url" "/docs/reference/cloud-rest-api/schema/") }}
-{{ end }}
-
-{{ $finalBreadcrumbs = $finalBreadcrumbs | append (dict "name" $page.LinkTitle "url" $page.RelPermalink) }}
-{{ $page.Scratch.Set "breadcrumbs" $finalBreadcrumbs }}
-
-{{- define "partials/inline/menu/collecturls" }}
-    {{- $menuName := .menuName }}
-    {{- $page := .page }}
-    {{- range .menuEntries }}
-        {{- if .URL }}
-            {{- $page.Scratch.SetInMap (printf "menuURLs-%s" $menuName) .URL true }}
-        {{- end }}
-        {{- with .Children }}
-            {{- partial "inline/menu/collecturls" (dict "menuName" $menuName "menuEntries" . "page" $page) }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-
-{{- define "partials/inline/menu/walk.html" }}
-    {{- $page := .page }}
-    {{- $rootMenuID := .rootMenuID }}
-    {{- $allMenuEntries := .allMenuEntries }}
-    {{- $expandedIDs := default slice .expandedIDs }}
-
-    {{- range .menuEntries }}
-        {{/* Skip Overview pages since we add them manually */}}
-        {{/* Skip root home items that we've already created manually */}}
-        {{- if and (ne .Name "Overview") (ne .Identifier $rootMenuID) }}
-            {{- $attrs := dict "href" .URL }}
-            {{- if $page.IsMenuCurrent .Menu . }}
-                {{- $attrs = merge $attrs (dict "class" "active" "aria-current" "page") }}
-            {{- else if $page.HasMenuCurrent .Menu .}}
-                {{- $attrs = merge $attrs (dict "class" "ancestor" "aria-current" "true") }}
-            {{- else if eq $page.RelPermalink .URL }}
-                {{/* Fallback for pages without frontmatter menu (e.g., CLI commands) */}}
-                {{- $attrs = merge $attrs (dict "class" "active" "aria-current" "page") }}
-            {{- end }}
-            {{- $name := .Name }}
-            {{- with .Identifier }}
-                {{- with T . }}
-                    {{- $name = . }}
-                {{- end }}
-            {{- end }}
-
-            {{/* Store the current menu item before entering Children context */}}
-            {{- $currentMenuItem := . }}
-
-            {{/*
-                BREADCRUMB COLLECTION
-
-                Only collect breadcrumbs if:
-                1. This menu item is an ancestor of the current page (HasMenuCurrent returns true)
-                2. AND the page is actually in this menu (either in frontmatter OR in menus.yml)
-                3. AND the menu being walked matches the current section
-
-                This prevents collecting breadcrumbs from multiple menus when parent pages
-                are in multiple menus (e.g., /docs/iac/cli/ is in both iac and reference menus).
-            */}}
-            {{- $menuName := .Menu }}
-            {{- $isAncestor := $page.HasMenuCurrent $menuName $currentMenuItem }}
-            {{- $pageHasThisMenu := and $page.Params.menu (index $page.Params.menu $menuName) }}
-            {{- $pageInMenuYML := index ($page.Scratch.Get (printf "menuURLs-%s" $menuName)) $page.RelPermalink }}
-            {{- $menuMatchesSection := eq $rootMenuID $.currentSection }}
-            {{- if and $isAncestor (or $pageHasThisMenu $pageInMenuYML) $menuMatchesSection }}
-                {{- $page.Scratch.Add "breadcrumbs" (dict "name" $currentMenuItem.Name "url" $currentMenuItem.URL) }}
-            {{- end }}
-
-            {{/* Render the expanded state server-side (ancestors of the current page, plus
-                 auto-expanded menu IDs) so the nav paints fully expanded — no flash of
-                 collapsed items while waiting for the pulumi-docs-nav component to load. */}}
-            {{- $isExpanded := or ($page.IsMenuCurrent .Menu .) ($page.HasMenuCurrent .Menu .) (and .Identifier (in $expandedIDs .Identifier)) }}
-            <li {{ if (and .Children (ne .Identifier $rootMenuID)) }} class="expandable{{ if $isExpanded }} expanded{{ end }}" {{ end }}
-                {{ if .Identifier }} data-menu-id="{{ .Identifier }}" {{ end }}
-                >
-                {{- if and .Children (ne .Identifier $rootMenuID) }}
-                    {{/* Parent with children - make it clickable for expand/collapse but not navigation */}}
-                    <a href="javascript:void(0)"{{- if $page.HasMenuCurrent .Menu . }} class="ancestor"{{ end }} onclick="this.closest('li').classList.toggle('expanded'); return false;">
-                    <button style="pointer-events: none;">
-                        {{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}
-                    </button>
-                    <span>{{ $name }}</span>
-                    </a>
-                {{- else }}
-                    {{/* Regular link or root menu item */}}
-                    <a
-                        {{- range $k, $v := $attrs }}
-                            {{- with $v }}
-                                {{- printf " %s=%q" $k $v | safeHTMLAttr }}
-                            {{- end }}
-                        {{- end -}}
-                    >
-                    <button>
-                        {{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}
-                    </button>
-                    <span>{{ $name }}</span>
-                    </a>
-                {{- end }}
-                {{- with .Children }}
-                    <ul class="list-none">
-                        {{/* Add Overview link for parent pages that have a URL */}}
-                        {{- if $currentMenuItem.URL }}
-                            {{- $overviewPage := site.GetPage $currentMenuItem.URL }}
-                            {{- if $overviewPage }}
-                                {{- $overviewLabel := "Introduction" }}
-                                {{- if $overviewPage.Params.docs_home }}
-                                    {{- $overviewLabel = "Overview" }}
-                                {{- end }}
-                                <li data-menu-id="overview">
-                                    <a href="{{ $overviewPage.RelPermalink }}"
-                                        {{- if eq $page.RelPermalink $overviewPage.RelPermalink }}
-                                            class="active" aria-current="page"
-                                        {{- end }}
-                                    >
-                                    <button>
-                                        {{ partial "icon.html" (dict "name" "caret-right" "weight" "bold") }}
-                                    </button>
-                                    <span>{{ $overviewLabel }}</span>
-                                    </a>
-                                </li>
-                            {{- end }}
-                        {{- end }}
-                        {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" . "rootMenuID" $rootMenuID "currentSection" $.currentSection "allMenuEntries" $allMenuEntries "expandedIDs" $expandedIDs) }}
-                    </ul>
-                {{- end }}
-            </li>
-        {{- end }}
-    {{- end }}
-{{- end }}

--- a/layouts/partials/releases/blog-list.html
+++ b/layouts/partials/releases/blog-list.html
@@ -21,7 +21,7 @@
     <div class="flex flex-col">
         {{ range $posts }}
             {{ with site.GetPage . }}
-                {{ partial "blog/card/list-row.html" (dict "page" .) }}
+                {{ partialCached "blog/card/list-row.html" (dict "page" .) .RelPermalink }}
             {{ end }}
         {{ end }}
     </div>

--- a/layouts/taxonomy/author.html
+++ b/layouts/taxonomy/author.html
@@ -22,7 +22,7 @@
         {{ $paginator := .Paginate $posts.ByDate.Reverse }}
         {{ partial "blog/paginator.html" (dict "context" . "position" "top") }}
         <div data-post-list class="flex flex-col">
-            {{ range $paginator.Pages }}{{ partial "blog/card/list-row.html" (dict "page" .) }}{{ end }}
+            {{ range $paginator.Pages }}{{ partialCached "blog/card/list-row.html" (dict "page" .) .RelPermalink }}{{ end }}
         </div>
         {{ partial "blog/paginator.html" . }}
     </div>

--- a/layouts/taxonomy/taxonomy.html
+++ b/layouts/taxonomy/taxonomy.html
@@ -8,7 +8,7 @@
         {{ $paginator := .Paginate .Data.Pages.ByDate.Reverse }}
         {{ partial "blog/paginator.html" (dict "context" . "position" "top") }}
         <div data-post-list class="flex flex-col">
-            {{ range $paginator.Pages }}{{ partial "blog/card/list-row.html" (dict "page" .) }}{{ end }}
+            {{ range $paginator.Pages }}{{ partialCached "blog/card/list-row.html" (dict "page" .) .RelPermalink }}{{ end }}
         </div>
         {{ partial "blog/paginator.html" . }}
     </div>

--- a/scripts/ci-build-duration-alert.sh
+++ b/scripts/ci-build-duration-alert.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Posts a Slack warning when the "Build and deploy" step of a successful run
+# exceeds BUILD_DURATION_THRESHOLD_MINUTES. This is a guardrail against silent
+# build-time regressions (in July 2026 the build grew ~60% over three weeks
+# before anyone noticed): it never fails the build, and it stays quiet when the
+# build is healthy.
+#
+# Expects:
+#   CI_BUILD_START_EPOCH               epoch seconds recorded just before the build step
+#   SLACK_WEBHOOK_URL                  incoming webhook for the alert channel (docs-ops)
+#   BUILD_DURATION_THRESHOLD_MINUTES   alert threshold (default 15)
+
+set -o nounset
+
+if [ -z "${CI_BUILD_START_EPOCH:-}" ]; then
+    echo "CI_BUILD_START_EPOCH not set; skipping build-duration check."
+    exit 0
+fi
+
+threshold_minutes="${BUILD_DURATION_THRESHOLD_MINUTES:-15}"
+elapsed_seconds=$(( $(date +%s) - CI_BUILD_START_EPOCH ))
+elapsed_minutes=$(( elapsed_seconds / 60 ))
+
+echo "Build step took ${elapsed_minutes}m ($((elapsed_seconds))s); threshold is ${threshold_minutes}m."
+
+if [ "$elapsed_seconds" -le $(( threshold_minutes * 60 )) ]; then
+    exit 0
+fi
+
+if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+    echo "Slow build detected but SLACK_WEBHOOK_URL is not set; cannot alert."
+    exit 0
+fi
+
+run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-pulumi/docs}/actions/runs/${GITHUB_RUN_ID:-}"
+message=":hourglass_flowing_sand: Build and deploy took *${elapsed_minutes}m* (threshold: ${threshold_minutes}m). Build time may be regressing — check Hugo's --templateMetrics output in the job log. <${run_url}|View run>"
+
+payload=$(printf '{"channel": "docs-ops", "username": "docsbot", "icon_url": "https://www.pulumi.com/logos/brand/avatar-on-white.png", "text": "%s"}' "$message")
+
+# Best-effort: an alert failure must never fail the deploy.
+curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$SLACK_WEBHOOK_URL" || true


### PR DESCRIPTION
### Proposed changes

CI build time grew ~60% over July: PR builds went from a median of **11.1 → 18.2 min**, production deploys **12.5 → 19.4 min**. Analysis of all 2,724 June–July workflow runs showed queue time at zero and every setup step flat — the whole regression sits inside the Hugo render step (4m16s → 10m11s), introduced almost entirely by the July 8 blog redesign (#20117). Per `--templateMetrics`: `blog/single.html` went from 94 ms to 1.49 s/page across ~800 posts, and the new `feature-image.html` partial's responsive WebP processing raised Hugo's processed-image count from 320 to **2,394 per build**, re-encoded from scratch on every CI run because `resources/_gen` is never persisted.

Four changes, ordered by payoff:

1. **Persist Hugo's image cache in CI** (`pull-request.yml`, `build-and-deploy.yml`, `testing-build-and-deploy.yml`): an `actions/cache` step for `resources/`, mirroring the existing meta-images cache. With a warm cache `.Process` becomes a lookup — locally the full site render drops from 272 s (cold) to 40 s (warm). Estimated **−4–5 min per build**. The testing deploy workflow also gains the **meta-images cache** it never received in June, so it stops re-rendering every OpenGraph card on each master push. First run on this branch is the cache-cold run; the win shows from the second build on.

1. **`partialCached` for the repeated blog partials**, keyed by the post they depict: `feature-image.html` (per size variant), `card/{small,medium,featured,list-row}.html`, and `series-part-card.html`. A post's card now renders once per build instead of once per page that displays it. The post page's own hero stays uncached (unique per page, caching it would only grow memory). Estimated **−1–2 min**.

1. **Cache the docs left-nav per section** instead of re-rendering it on every docs page. The recursive walker ran ~225,000 times per build (~20 cumulative minutes — a hotspot that predates July). The tree now lives in `docs/menu-tree.html`, rendered via `partialCached` keyed on `(currentSection, expandedIDs)` — ~20 renders per build instead of ~1,700. Two decouplings this required:
   - **Breadcrumbs** were a side effect of the menu walk; they're now computed directly from menu data by `docs/breadcrumb-path.html` (same `Scratch` contract, `breadcrumb.html` unchanged).
   - **Per-page nav state** (active link, ancestor marking, expansion of the active chain) is stamped by an inline script that runs before first paint, so there's no flash or jump. Without JS, the nav still renders with all top-level sections expanded; only deep-chain auto-expansion and highlighting need the script.

1. **Duration guardrail** (`scripts/ci-build-duration-alert.sh`): successful production builds that exceed 15 minutes post a warning to #docs-ops with a pointer at the `--templateMetrics` log. July's regression sat unnoticed for three weeks; this makes the next one a same-week fix. Never fails the build; PR and testing builds are excluded to avoid noise.

**Verification.** Built the full site with old and new templates and diffed all 3,020 docs pages and 2,380 blog pages:

- Blog output byte-identical.
- Docs navs identical modulo the classes now applied client-side; all other differences whitespace-only.
- Breadcrumbs identical on 2,397 pages and a **strict superset on 623**: pages whose menu entries are defined in `menus.yml` (URL-only, no page binding) previously rendered `Docs → <page>` because `HasMenuCurrent` can't see URL-bound entries — they now get their full ancestor chain (e.g. `Docs → Administration → Access & Identity → Access tokens`). This is a latent-bug fix that ships with the refactor.
- Browser-tested the nav script on the built site: exactly one `.active` link with `aria-current="page"`, correct ancestor marking and expansion.
- `make lint` passes.

Expected end state: builds return to roughly the June baseline (~12–13 min); the menu-walk win may take them below it.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Follows up the July build-time investigation (PR builds and production deploys slowing since Jul 8); root cause analysis referenced in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQigRE5p8d8AgEc4zW6MMt