### PR TITLE
Serve markdown for the homepage, /what-is/, /product/, and /pricing/

### DIFF
--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -859,16 +859,22 @@ Hugo generates:
 - Sitemap.xml
 - robots.txt
 - Meta-refresh redirect pages (from aliases)
-- Markdown output (`.md`) for `/docs/` pages (for content negotiation)
+- Markdown output (`.md`) for `/docs/` pages, the homepage, `/what-is/`, `/product/`, and `/pricing/` (for content negotiation)
 - LLM sitemap JSON (`llmsitemap`) — hierarchical JSON index of docs navigation, served at `/docs/llm-sitemap.json`
 - LLM index (`llms`) — curated text overview at `/llms.txt` for AI agents
 
 **Markdown output format:** Hugo generates clean markdown versions of documentation pages alongside HTML. These are served via CloudFront content negotiation when clients send `Accept: text/markdown`. The conversion is handled by an 8-phase pipeline in `layouts/partials/docs/markdown-pipeline.md` that converts rendered HTML back to markdown (Chroma → fenced code blocks, HTML tags → markdown syntax, choosable options → chooser comment blocks, etc.).
 
+The same negotiation covers the marketing front door: the homepage, `/what-is/`, `/product/`, and `/pricing/` emit `index.md` artifacts (enabled via `outputs`/`cascade` front matter), served by a second viewer-request CloudFront Function on the default cache behavior (`marketing-markdown-negotiation` in `infrastructure/cloudfrontFunctions.ts`). That function rewrites only an allowlist of prefixes — a rewrite on a path with no `.md` artifact would 404, so extending coverage to a new section means BOTH enabling the `markdown` output for that section AND adding its prefix to the function. Template-driven pages (frontmatter `sections:` arrays) render markdown via `layouts/partials/markdown/sections.md`, a type-agnostic walker over the sections' textual fields.
+
 **Layout files:**
 
 - `layouts/docs/single.md` — Markdown output for single pages
 - `layouts/docs/list.md` — Markdown output for list pages
+- `layouts/index.md` — Markdown output for the homepage
+- `layouts/page/template-page.md` — Markdown output for template-driven pages (frontmatter `sections:`)
+- `layouts/page/pricing.md` — Markdown output for `/pricing/` (tiers, edition comparison, FAQ)
+- `layouts/_default/single.md`, `layouts/_default/list.md` — generic markdown fallbacks for markdown-enabled sections whose pages use bespoke layouts
 - `layouts/docs/list.llmsitemap.json` — Hierarchical JSON sitemap
 - `layouts/index.llms.txt` — Curated text overview at `/llms.txt`
 

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -82,6 +82,7 @@ outputs:
     - HTML
     - JSON
     - llms
+    - markdown
   section:
     - HTML
   page:

--- a/content/pricing/_index.md
+++ b/content/pricing/_index.md
@@ -5,6 +5,9 @@ type: page
 layout: pricing
 schema_type: product
 include_floqer: true
+outputs:
+    - HTML
+    - markdown
 menu:
     header:
         weight: 2

--- a/content/product/_index.md
+++ b/content/product/_index.md
@@ -5,6 +5,13 @@ meta_image: /images/product/overview/overview-meta.png
 type: page
 layout: template-page
 include_floqer: true
+outputs:
+  - HTML
+  - markdown
+cascade:
+  outputs:
+    - HTML
+    - markdown
 
 aliases:
   - /product/pulumi-cloud/

--- a/content/what-is/_index.md
+++ b/content/what-is/_index.md
@@ -2,4 +2,11 @@
 title: "Cloud Engineering Concepts Explained"
 page_title: "Cloud Engineering Concepts Explained"
 meta_desc: "Plain-English explainers of infrastructure as code, DevOps, CI/CD, Kubernetes, platform engineering, secrets management, and other cloud engineering topics."
+outputs:
+- HTML
+- markdown
+cascade:
+  outputs:
+  - HTML
+  - markdown
 ---

--- a/infrastructure/cloudfrontFunctions.ts
+++ b/infrastructure/cloudfrontFunctions.ts
@@ -49,6 +49,63 @@ export function getMarkdownNegotiationFunctionAssociation(): aws.types.input.clo
     };
 }
 
+// Same negotiation for the marketing pages that ride the default cache behavior.
+// Unlike /docs/* — where every page emits an index.md artifact — the default
+// behavior serves many paths with no markdown variant, so this function rewrites
+// only an allowlist of prefixes known to emit index.md (via `outputs`/`cascade`
+// front matter in content/): the homepage, /what-is/, /product/, and /pricing/.
+// Rewriting a path with no artifact would turn a valid HTML page into a 404 for
+// markdown-accepting clients, so extend the allowlist only together with the
+// corresponding Hugo output changes.
+const marketingMarkdownNegotiationFunctionCode = `
+function handler(event) {
+    var request = event.request;
+    var accept = request.headers['accept'] ? request.headers['accept'].value : '';
+    var uri = request.uri;
+
+    var eligible = uri === '/' || uri === '/index.html' ||
+        uri === '/what-is.md' || uri === '/product.md' || uri === '/pricing.md' ||
+        uri.indexOf('/what-is/') === 0 ||
+        uri.indexOf('/product/') === 0 ||
+        uri.indexOf('/pricing/') === 0;
+    if (!eligible) {
+        return request;
+    }
+
+    // .md URL-suffix convention (header-free). /product/neo.md → /product/neo/index.md.
+    if (uri.endsWith('.md') && !uri.endsWith('/index.md')) {
+        request.uri = uri.replace(/\\.md$/, '/index.md');
+        return request;
+    }
+
+    // Accept: text/markdown content negotiation.
+    if (accept.indexOf('text/markdown') !== -1) {
+        if (uri === '/') {
+            request.uri = '/index.md';
+        } else if (uri.endsWith('/index.html')) {
+            request.uri = uri.replace(/index\\.html$/, 'index.md');
+        } else if (uri.endsWith('/')) {
+            request.uri = uri + 'index.md';
+        }
+    }
+
+    return request;
+}
+`;
+
+const marketingMarkdownNegotiationFunction = new aws.cloudfront.Function("marketing-markdown-negotiation", {
+    runtime: "cloudfront-js-2.0",
+    code: marketingMarkdownNegotiationFunctionCode,
+    comment: "Serves index.md for the homepage, /what-is/, /product/, and /pricing/ via Accept: text/markdown or .md URL suffix.",
+});
+
+export function getMarketingMarkdownNegotiationFunctionAssociation(): aws.types.input.cloudfront.DistributionDefaultCacheBehaviorFunctionAssociation {
+    return {
+        eventType: "viewer-request",
+        functionArn: marketingMarkdownNegotiationFunction.arn,
+    };
+}
+
 // CloudFront Function that stamps the correct Content-Type on the RFC 9727 API
 // catalog. The catalog is served from S3 as the extensionless object
 // /.well-known/api-catalog, so S3 hands it back as binary/octet-stream; agents

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
 
 import { getAIRedirectAndGoneAssociation, getEdgeRedirectAssociation } from "./cloudfrontLambdaAssociations";
-import { getMarkdownNegotiationFunctionAssociation, getApiCatalogContentTypeFunctionAssociation } from "./cloudfrontFunctions";
+import { getMarkdownNegotiationFunctionAssociation, getMarketingMarkdownNegotiationFunctionAssociation, getApiCatalogContentTypeFunctionAssociation } from "./cloudfrontFunctions";
 
 const stackConfig = new pulumi.Config();
 
@@ -983,9 +983,16 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     defaultCacheBehavior: {
         ...baseCacheBehavior,
         cachePolicyId: tenMinuteCacheKeyPolicy.id,
-        // Stamps Content-Type on /.well-known/api-catalog, which falls through to
-        // the default behavior. No-op for every other path.
-        functionAssociations: [getApiCatalogContentTypeFunctionAssociation()],
+        functionAssociations: [
+            // Serves index.md for the homepage, /what-is/, /product/, and /pricing/
+            // via Accept: text/markdown or the .md URL suffix. The viewer-request
+            // rewrite lands before the cache lookup, so the rewritten URI is the
+            // cache key and no cache policy changes are needed.
+            getMarketingMarkdownNegotiationFunctionAssociation(),
+            // Stamps Content-Type on /.well-known/api-catalog, which falls through to
+            // the default behavior. No-op for every other path.
+            getApiCatalogContentTypeFunctionAssociation(),
+        ],
     },
 
     orderedCacheBehaviors: [

--- a/layouts/_default/list.md
+++ b/layouts/_default/list.md
@@ -1,0 +1,13 @@
+---
+title: {{ .Title }}
+{{ with or .Params.meta_desc .Description }}description: {{ replaceRE `\s+` " " (replaceRE `<[^>]+>` "" (trim . " \n")) }}
+{{ end }}url: {{ .RelPermalink }}
+---
+{{- $content := .RenderShortcodes -}}
+{{- $content = partial "docs/markdown-pipeline.md" $content -}}
+
+{{ $content }}
+{{- partial "markdown/sections.md" . }}
+{{ range .Pages }}
+- [{{ .Title }}]({{ .RelPermalink }}){{ with .Params.meta_desc }} — {{ replaceRE `\s+` " " (replaceRE `<[^>]+>` "" (trim . " \n")) }}{{ end }}
+{{- end }}

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -1,0 +1,10 @@
+---
+title: {{ .Title }}
+{{ with or .Params.meta_desc .Description }}description: {{ replaceRE `\s+` " " (replaceRE `<[^>]+>` "" (trim . " \n")) }}
+{{ end }}url: {{ .RelPermalink }}
+---
+{{- $content := .RenderShortcodes -}}
+{{- $content = partial "docs/markdown-pipeline.md" $content -}}
+
+{{ $content }}
+{{- partial "markdown/sections.md" . -}}

--- a/layouts/index.md
+++ b/layouts/index.md
@@ -1,0 +1,9 @@
+---
+title: {{ .Title }}
+{{ with .Params.meta_desc }}description: {{ replaceRE `\s+` " " (trim . " \n") }}
+{{ end }}url: {{ .RelPermalink }}
+---
+{{ with .Params.meta_desc }}> {{ replaceRE `\s+` " " (trim . " \n") }}
+{{ end }}
+Pulumi documentation lives at [/docs/](/docs/); every docs page (and this page) supports `Accept: text/markdown` content negotiation and the `.md` URL suffix. A curated index for agents is at [/llms.txt](/llms.txt), and a machine-readable docs sitemap at [/docs/llm-sitemap.json](/docs/llm-sitemap.json).
+{{ partial "markdown/sections.md" . }}

--- a/layouts/page/pricing.md
+++ b/layouts/page/pricing.md
@@ -1,0 +1,57 @@
+---
+title: {{ .Title }}
+{{ with .Params.meta_desc }}description: {{ replaceRE `\s+` " " (trim . " \n") }}
+{{ end }}url: {{ .RelPermalink }}
+---
+{{ with .Params.meta_desc }}{{ replaceRE `\s+` " " (trim . " \n") }}
+{{ end }}
+{{- /* Editions: the tiers frontmatter that pricing.html renders as cards. */}}
+{{ range .Params.tiers.trialed.items }}
+{{- $item := . }}
+## {{ .title }}
+{{ with .subtitle }}
+{{ . }}
+{{ end }}
+**{{ .price }}{{ with .price_label }} {{ . }}{{ end }}**{{ with .unit }} — {{ . }}{{ end }}{{ with .note }} ({{ . }}){{ end }}
+{{ with $item.features }}
+{{ with $item.features_intro }}{{ . }}{{ end }}
+{{- range . }}
+- {{ . }}
+{{- end }}
+{{ end }}
+{{- end }}
+{{- /* Edition comparison: mirror the comparison_table frontmatter as markdown
+       tables, one per product area, with the tier names as columns. */}}
+{{- $tierNames := slice }}
+{{- range .Params.tiers.trialed.items }}{{ $tierNames = $tierNames | append .title }}{{ end }}
+{{- with .Params.comparison_table }}
+## Edition comparison
+{{ range .sections }}
+{{- range .tables }}
+
+### {{ .header }}
+
+| | {{ delimit $tierNames " | " }} |
+|---|{{ range $tierNames }}---|{{ end }}
+{{- range .rows }}
+| {{ replace .title "|" "\\|" }} |
+{{- range .items }} {{ with .content }}
+{{- /* _check/_blank are sentinels the HTML table renders as icons. */ -}}
+{{- if eq . "_check" }}✓{{ else if eq . "_blank" }}—{{ else }}{{ replace (replace . "\n" " ") "|" "\\|" }}{{ end }}{{ end }}{{ with .subtext }} ({{ replace . "|" "\\|" }}){{ end }} |{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- /* FAQ: high-value for agents; answers are markdown in frontmatter. */}}
+{{- with .Params.faq }}
+
+## Frequently asked questions
+{{ range . }}
+### {{ .category }}
+{{ range .items }}
+**{{ .question }}**
+
+{{ trim .answer " \n" }}
+{{ end }}
+{{- end }}
+{{- end }}

--- a/layouts/page/template-page.md
+++ b/layouts/page/template-page.md
@@ -1,0 +1,6 @@
+---
+title: {{ .Title }}
+{{ with or .Params.meta_desc .Description }}description: {{ replaceRE `\s+` " " (replaceRE `<[^>]+>` "" (trim . " \n")) }}
+{{ end }}url: {{ .RelPermalink }}
+---
+{{ partial "markdown/sections.md" . }}

--- a/layouts/partials/markdown/sections.md
+++ b/layouts/partials/markdown/sections.md
@@ -1,0 +1,90 @@
+{{- /* Renders a template-driven page's frontmatter `sections:` array as markdown,
+       for the text/markdown output format (Accept: text/markdown negotiation).
+       Shared by the homepage (layouts/index.md), template pages
+       (layouts/page/template-page.md), and the generic fallbacks
+       (layouts/_default/single.md, list.md).
+
+       Rather than dispatching on section type (as template-page-content.html
+       does for HTML), this walks the textual fields the section types share —
+       headings, descriptions, cards, columns, features, quotes — so new
+       section types degrade gracefully. Purely visual sections (logo
+       carousels, image grids, code overlays, social embeds) contribute
+       nothing. Section descriptions are authored as markdown in frontmatter
+       and pass through unmodified. */ -}}
+{{- range .Params.sections -}}
+{{- if .quote -}}
+{{- /* Testimonials: .title is the speaker's role here, not a heading. */}}
+> {{ replace (trim .quote " \n") "\n" " " }}
+{{- $attribution := slice -}}
+{{- with .author }}{{ $attribution = $attribution | append . }}{{ end -}}
+{{- with or .role .title }}{{ $attribution = $attribution | append . }}{{ end -}}
+{{- with .company }}{{ $attribution = $attribution | append . }}{{ end -}}
+{{- with $attribution }}
+>
+> — {{ delimit . ", " }}
+{{- end }}
+{{ else -}}
+{{- /* Heroes split the heading across title_primary/title_secondary;
+       title_reversed renders secondary before primary. */ -}}
+{{- $heading := or .heading .title "" -}}
+{{- with .title_line_2 }}{{ $heading = printf "%s %s" $heading . }}{{ end -}}
+{{- $primary := trim (or .title_primary "") " \n" -}}
+{{- $secondary := trim (or .title_secondary "") " \n" -}}
+{{- if or $primary $secondary -}}
+{{- if .title_reversed -}}
+{{- $heading = trim (printf "%s %s" $secondary $primary) " " -}}
+{{- else -}}
+{{- $heading = trim (printf "%s %s" $primary $secondary) " " -}}
+{{- end -}}
+{{- end -}}
+{{- with replaceRE `\s+` " " $heading }}
+
+## {{ . }}
+{{ end -}}
+{{- with .subtitle }}
+{{ trim . " \n" }}
+{{ end -}}
+{{- with .description }}
+{{ trim . " \n" }}
+{{ end -}}
+{{- with .text }}
+{{ trim . " \n" }}
+{{ end -}}
+{{- $cards := slice -}}
+{{- with .cards }}{{ $cards = $cards | append . }}{{ end -}}
+{{- with .large_cards }}{{ $cards = $cards | append . }}{{ end -}}
+{{- with .small_cards }}{{ $cards = $cards | append . }}{{ end -}}
+{{- with .features }}{{ $cards = $cards | append . }}{{ end -}}
+{{- $items := slice -}}
+{{- range $cards -}}
+{{- $card := . -}}
+{{- if $card.number -}}
+{{- $items = $items | append (printf "- **%s** %s" $card.number (or $card.label "")) -}}
+{{- else if $card.title -}}
+{{- $cardTitle := replace $card.title "\n" " " -}}
+{{- $title := printf "**%s**" $cardTitle -}}
+{{- with $card.cta_link }}{{ $title = printf "**[%s](%s)**" $cardTitle . }}{{ end -}}
+{{- $line := printf "- %s" $title -}}
+{{- with $card.description }}{{ $line = printf "%s — %s" $line (replace (trim . " \n") "\n" " ") }}{{ end -}}
+{{- $items = $items | append $line -}}
+{{- end -}}
+{{- end -}}
+{{- with $items }}
+{{ delimit . "\n" }}
+{{ end -}}
+{{- range .columns }}
+
+### {{ with .label }}{{ . }}: {{ end }}{{ replace (or .title "") "\n" " " }}
+{{- with .subheader }}
+{{ . }}
+{{- end }}
+{{- with .description }}
+{{ trim . " \n" }}
+{{- end }}
+{{- end -}}
+{{- $videoTitle := or .title "Video" -}}
+{{- with .youtube_id }}
+[Watch: {{ $videoTitle }}](https://www.youtube.com/watch?v={{ . }})
+{{ end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
### Proposed changes

Extends the existing `/docs/*` `Accept: text/markdown` content negotiation to the marketing front door: the homepage, `/what-is/` (all 63 explainers), `/product/` (all 11 pages), and `/pricing/`. Agent-readiness scanners (e.g. Cloudflare's [isitagentready.com](https://blog.cloudflare.com/agent-readiness/)) probe `www.pulumi.com/` with `Accept: text/markdown` and currently fail us because only `/docs/*` negotiates markdown; this makes the front door pass, and gives agents clean markdown for the marketing pages they most plausibly read.

**No hand-maintained markdown anywhere** — every artifact is derived at build time from frontmatter and content that marketing already maintains, exactly like the HTML:

- **Hugo outputs**: the four surfaces emit per-page `index.md` artifacts via `outputs`/`cascade` front matter, mirroring the `/docs/` setup. The non-docs build emits exactly 76 new artifacts (1 + 63 + 11 + 1); `/docs/` output is byte-for-byte unchanged.
- **`layouts/partials/markdown/sections.md`**: renders template-driven pages (frontmatter `sections:` arrays — the homepage and `template-page` product pages) as markdown via a type-agnostic walker over the sections' shared textual fields (headings incl. split hero titles, descriptions, cards, columns, features, testimonials), so new section types degrade gracefully instead of breaking.
- **`layouts/page/pricing.md`**: renders the pricing tiers, the full edition-comparison as markdown tables (`_check`/`_blank` icon sentinels mapped to ✓/—), and the complete FAQ.
- **`layouts/_default/{single,list}.md`**: generic fallbacks (docs markdown pipeline + sections walker + child-page index) covering the `/what-is/` prose pages, the `/what-is/` section index, and the five bespoke-layout product pages (thin-but-valid output rather than a 404).
- **Infrastructure**: a second viewer-request CloudFront Function (`marketing-markdown-negotiation`) on the default cache behavior rewrites `Accept: text/markdown` and `.md`-suffix requests to the `index.md` artifacts. It's allowlisted to exactly the prefixes that emit artifacts, because a rewrite without an artifact would turn a valid HTML page into a 404 — the function comment documents that extending coverage means enabling the Hugo output *and* adding the prefix. It sits alongside the viewer-response api-catalog function from #20568 (different event type, same behavior). The viewer-request URI rewrite happens before the cache lookup, so the rewritten URI is the cache key and no cache-policy changes are needed — same mechanism as the existing `/docs/*` function.
- **Docs**: `BUILD-AND-DEPLOY.md` markdown-output section updated to cover the marketing extension and the new layout files.

Sample outputs (from a local build): the homepage renders as a short agent-oriented intro plus the sections content; `/product/neo/index.md` carries the full Neo pitch as headings/bullets/quotes; `/pricing/index.md` includes all four editions, the complete feature-comparison tables, and the 27-question FAQ; `/what-is/*` pages get the same docs-pipeline treatment docs pages already have.

Verified locally: Hugo build succeeds, all 76 artifacts render as expected, docs artifacts unchanged, `make lint` passes, `infrastructure/` type-checks.

Related follow-up to the agent-discovery work in #20567 and #20568.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Builds on #20567 and #20568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tgaejgmbg6H9m4zWLAHrWe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tgaejgmbg6H9m4zWLAHrWe)_