### PR TITLE
Raise build-duration alert threshold to 20m and soften wording

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -138,7 +138,7 @@ jobs:
         if: success()
         env:
           SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
-          BUILD_DURATION_THRESHOLD_MINUTES: '15'
+          BUILD_DURATION_THRESHOLD_MINUTES: '20'
         run: ./scripts/ci-build-duration-alert.sh
 
       - name: Archive test results

--- a/scripts/ci-build-duration-alert.sh
+++ b/scripts/ci-build-duration-alert.sh
@@ -9,7 +9,7 @@
 # Expects:
 #   CI_BUILD_START_EPOCH               epoch seconds recorded just before the build step
 #   SLACK_WEBHOOK_URL                  incoming webhook for the alert channel (docs-ops)
-#   BUILD_DURATION_THRESHOLD_MINUTES   alert threshold (default 15)
+#   BUILD_DURATION_THRESHOLD_MINUTES   alert threshold (default 20)
 
 set -o nounset
 
@@ -18,7 +18,7 @@ if [ -z "${CI_BUILD_START_EPOCH:-}" ]; then
     exit 0
 fi
 
-threshold_minutes="${BUILD_DURATION_THRESHOLD_MINUTES:-15}"
+threshold_minutes="${BUILD_DURATION_THRESHOLD_MINUTES:-20}"
 elapsed_seconds=$(( $(date +%s) - CI_BUILD_START_EPOCH ))
 elapsed_minutes=$(( elapsed_seconds / 60 ))
 
@@ -34,7 +34,7 @@ if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
 fi
 
 run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-pulumi/docs}/actions/runs/${GITHUB_RUN_ID:-}"
-message=":hourglass_flowing_sand: Build and deploy took *${elapsed_minutes}m* (threshold: ${threshold_minutes}m). Build time may be regressing — check Hugo's --templateMetrics output in the job log. <${run_url}|View run>"
+message=":hourglass_flowing_sand: Build and deploy took *${elapsed_minutes}m*, longer than usual (threshold: ${threshold_minutes}m). Hugo's --templateMetrics output in the job log can help identify what was slow. <${run_url}|View run>"
 
 payload=$(printf '{"channel": "docs-ops", "username": "docsbot", "icon_url": "https://www.pulumi.com/logos/brand/avatar-on-white.png", "text": "%s"}' "$message")
 


### PR DESCRIPTION
### Proposed changes

The docsbot build-duration alert has a hair trigger: with the threshold at 15 minutes, it fires on nearly every successful build (recent runs cluster at 15–16m), which turns the alert into noise.

- Raise the threshold from 15 to 20 minutes, both in the workflow env (`.github/workflows/build-and-deploy.yml`) and the script's default (`scripts/ci-build-duration-alert.sh`).
- Reword the Slack message from "Build time may be regressing" to describe a longer-than-usual build instead — the check compares a single run against a fixed threshold and doesn't track any trend, so the message shouldn't imply a pattern. The pointer to Hugo's `--templateMetrics` output stays, since that's still the right place to look.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJsvakcDFu5HuerwpNNwDf

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJsvakcDFu5HuerwpNNwDf)_