### PR TITLE
Add a releases ticker to the blog homepage

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,6 +1,4 @@
 {{ define "main" }}
-    {{ partial "blog/header.html" (dict "context" .) }}
-
     {{- /* Featured slots (hero + 3 small cards) and the feed below the fold, from
         the shared partial. head.html paginates the SAME $feed first, so the
         section paginator is set to the feed collection and the featured/helper
@@ -10,6 +8,12 @@
     {{ $feed := $bf.feed }}
     {{ $paginator := .Paginate $feed }}
     {{ $isFirst := eq $paginator.PageNumber 1 }}
+
+    {{ partial "blog/header.html" (dict "context" .) }}
+
+    {{- /* Releases/changelog ticker — page 1 only, where it reads as part of the
+        masthead rather than as a stray strip above a paginated feed. */ -}}
+    {{ if $isFirst }}{{ partialCached "blog/releases-marquee.html" . "blog-releases-marquee" }}{{ end }}
 
     <div class="container mx-auto px-4 py-8 lg:py-10">
         {{ if $isFirst }}

--- a/layouts/partials/blog/releases-marquee.html
+++ b/layouts/partials/blog/releases-marquee.html
@@ -1,0 +1,77 @@
+{{- /*
+    Blog homepage releases ticker — a scrolling marquee of the newest entries in
+    the /releases section (both full releases and individual changelog items),
+    pinned along the top of /blog/ under the header. Pauses on hover; falls back
+    to a plain horizontally scrollable strip under prefers-reduced-motion.
+    Styles: theme/src/scss/_blog.scss.
+
+    The track holds $copies identical copies of the item list side by side, so
+    animating it by -(100 / $copies)% advances exactly one copy and lands the
+    next clone where the original started — a seamless loop. Three copies (not
+    two) keep the track wider than the viewport on ultrawide displays, where one
+    copy of the list wouldn't fill the strip and the loop would show a gap.
+
+    Clones are aria-hidden and their links tabindex="-1" so the ticker exposes
+    each entry to assistive tech and the tab order exactly once.
+
+    Changelog items open in the same modal as /releases/: the shared shell is
+    rendered below the strip and theme/src/ts/releases.ts (already in the global
+    bundle) picks up the data-changelog-link rows. Only changelog items carry
+    that attribute — full release pages have no <article data-changelog-article>
+    fragment to inject, so they stay plain links.
+
+    Takes no params; reads the /releases section directly.
+*/ -}}
+{{- $limit := 12 -}}
+{{- $copies := 3 -}}
+{{- /* Seconds of travel per item, at the fixed linear rate — the whole cycle
+    covers one copy, so the duration scales with the item count. */ -}}
+{{- $secondsPerItem := 9 -}}
+{{- with site.GetPage "/releases" -}}
+{{- $items := first $limit (.RegularPagesRecursive.ByDate.Reverse) -}}
+{{- if $items -}}
+{{- /* The wrapper exists so CSS can reach the track from the modal's open
+    state: the modal renders after the strip, and sibling combinators only look
+    forward, so the pause rule hangs a :has() off a common ancestor. */ -}}
+<div data-blog-releases>
+<div class="blog-releases-marquee border-b border-gray-200 bg-gray-50">
+    <div class="container mx-auto flex items-center px-4">
+        <a href="{{ .RelPermalink }}" data-track="blog-marquee-releases" class="group flex shrink-0 items-center gap-1.5 self-stretch border-r border-gray-200 pr-4 no-underline hover:no-underline">
+            <span class="font-overline-sm whitespace-nowrap text-gray-700 transition-colors group-hover:text-violet-primary">What's new</span>
+            {{ partial "icon.html" (dict "name" "arrow-right" "class" "size-3 shrink-0 text-gray-400 transition-colors group-hover:text-violet-primary") }}
+        </a>
+
+        <div data-releases-marquee style="--marquee-duration: {{ mul (len $items) $secondsPerItem }}s" class="relative min-w-0 flex-1 overflow-hidden" role="region" aria-label="Latest releases and changelog entries">
+            <div data-marquee-track class="flex w-max">
+                {{- range $copy := seq $copies }}
+                {{- $isClone := gt $copy 1 }}
+                <ul data-marquee-copy {{ if $isClone }}aria-hidden="true"{{ end }} class="m-0 flex shrink-0 list-none items-center p-0">
+                    {{- range $items }}
+                    <li class="m-0 flex items-center">
+                        <a href="{{ .RelPermalink }}" {{ if eq .Type "changelog" }}data-changelog-link{{ end }} {{ if $isClone }}tabindex="-1"{{ end }} data-track="blog-marquee-item" class="group/mq flex items-center gap-2 whitespace-nowrap px-4 py-2.5 no-underline hover:no-underline">
+                            <span aria-hidden="true" class="size-1 shrink-0 rounded-full bg-gray-300 transition-colors group-hover/mq:bg-violet-primary"></span>
+                            {{- if eq .Type "releases" }}
+                            <span class="badge badge-secondary badge-sm">Release</span>
+                            {{- end }}
+                            <span class="body-sm text-service-black transition-colors group-hover/mq:text-violet-primary">{{ .Title }}</span>
+                            <time datetime="{{ .Date.Format "2006-01-02" }}" class="body-sm text-gray-500">{{ .Date.Format "Jan 2" }}</time>
+                        </a>
+                    </li>
+                    {{- end }}
+                </ul>
+                {{- end }}
+            </div>
+            {{- /* Fade the trailing edge so items dissolve into the strip
+                instead of popping across a hard clip. Left edge needs none —
+                the label's divider already reads as the boundary. */}}
+            <div data-marquee-fade aria-hidden="true" class="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-r from-transparent to-gray-50"></div>
+        </div>
+    </div>
+</div>
+{{- /* Modal shell for the changelog rows above. Must stay inside <main> —
+    releases.ts injects the fetched article here and the content styles it
+    relies on are scoped to main. */}}
+{{ partial "releases/changelog-modal.html" . }}
+</div>
+{{- end -}}
+{{- end -}}

--- a/theme/src/scss/_blog.scss
+++ b/theme/src/scss/_blog.scss
@@ -127,6 +127,71 @@
     }
 }
 
+// Latest-releases ticker along the top of the blog homepage
+// (partials/blog/releases-marquee.html). The track holds three identical copies
+// of the item list side by side, so translateX(-33.3333%) advances by exactly
+// one copy and the loop is seamless. Duration comes from --marquee-duration,
+// set inline by the partial from the item count so the scroll rate stays
+// constant no matter how many entries are in the strip.
+[data-releases-marquee] {
+    [data-marquee-track] {
+        animation: blog-releases-marquee var(--marquee-duration, 60s) linear infinite;
+    }
+
+    // Pause on hover only — deliberately NOT on :focus-within. Closing the
+    // changelog modal restores focus to the ticker link that opened it, which
+    // left the strip frozen until the next click moved focus elsewhere.
+    // :focus-visible doesn't fix it either: it's sticky across programmatic
+    // focus (the modal's close button inherits it from the trigger on open and
+    // hands it back on close), so it matched on every close path. CSS can't
+    // tell "tabbed here" from "focus restored here", and a permanently stuck
+    // ticker is the worse failure. Matches the announcement banner marquee,
+    // which likewise pauses only for prefers-reduced-motion. Keyboard users can
+    // still Tab to any row and press Enter — activation doesn't depend on where
+    // the row currently sits — and the reduced-motion branch below serves the
+    // static, fully readable version.
+    &:hover [data-marquee-track] {
+        animation-play-state: paused;
+    }
+}
+
+// Also hold still while a changelog item is open, so the strip isn't drifting
+// behind the modal's translucent backdrop and the row you clicked is still
+// where you left it on close. Safe where the focus-based pause wasn't: this
+// keys off the modal's own .hidden class, which closeModal() always restores,
+// so it can't latch on the way restored focus did.
+[data-blog-releases]:has([data-changelog-modal]:not(.hidden)) [data-marquee-track] {
+    animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    [data-releases-marquee] {
+        // No motion: a plain scrollable strip of the entries, shown once. The
+        // clones exist only to make the animation loop.
+        @apply overflow-x-auto;
+
+        [data-marquee-track] {
+            animation: none;
+        }
+
+        [data-marquee-copy]:not(:first-child) {
+            @apply hidden;
+        }
+
+        // The trailing fade is absolutely positioned inside what is now a
+        // scroll container, so it'd travel with the content instead of staying
+        // pinned to the strip's edge. It only sells the motion anyway.
+        [data-marquee-fade] {
+            @apply hidden;
+        }
+    }
+}
+
+@keyframes blog-releases-marquee {
+    0%   { transform: translateX(0); }
+    100% { transform: translateX(-33.3333%); }
+}
+
 // Outline-button option for HubSpot newsletter forms. The `!` beats the
 // .btn-primary the button @extends in _hubspot.scss (which imports after this).
 .hs-form.newsletter-btn-outline input.hs-button {

--- a/theme/src/scss/_blog.scss
+++ b/theme/src/scss/_blog.scss
@@ -168,14 +168,20 @@
     [data-releases-marquee] {
         // No motion: a plain scrollable strip of the entries, shown once. The
         // clones exist only to make the animation loop.
-        @apply overflow-x-auto;
+        //
+        // `!` on both overrides: this file is imported into @layer components,
+        // which loses to Tailwind's @layer utilities no matter the specificity,
+        // so the markup's `overflow-hidden` here and `flex` on each copy would
+        // otherwise win — leaving the strip clipped with no way to scroll and
+        // all three copies visible.
+        @apply overflow-x-auto!;
 
         [data-marquee-track] {
             animation: none;
         }
 
         [data-marquee-copy]:not(:first-child) {
-            @apply hidden;
+            @apply hidden!;
         }
 
         // The trailing fade is absolutely positioned inside what is now a

--- a/theme/src/ts/releases.ts
+++ b/theme/src/ts/releases.ts
@@ -53,6 +53,19 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
+    // Which row to hand focus back to when the modal closes. The blog ticker
+    // (layouts/partials/blog/releases-marquee.html) repeats the item list in
+    // aria-hidden clone copies to make its marquee loop, and those rows are
+    // still clickable — so restoring focus to a clicked clone would drop focus
+    // into a subtree assistive tech can't see, with nothing to announce.
+    // Resolve to the one canonical row with the same href. On /releases/ there
+    // are no clones, so the aria-hidden test never matches and this is a no-op.
+    function canonicalTrigger(link: HTMLAnchorElement): HTMLElement {
+        if (!link.closest('[aria-hidden="true"]')) return link;
+        const rows = Array.from(document.querySelectorAll<HTMLAnchorElement>("[data-changelog-link]"));
+        return rows.find(row => row.href === link.href && !row.closest('[aria-hidden="true"]')) ?? link;
+    }
+
     async function fetchArticle(url: string): Promise<Element | null> {
         const cached = cache.get(url);
         if (cached) return cached;
@@ -131,7 +144,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!link) return;
         e.preventDefault();
         history.pushState({ changelogUrl: link.href }, "", link.href);
-        void show(link.href, link);
+        void show(link.href, canonicalTrigger(link));
     });
 
     closeButton.addEventListener("click", requestClose);


### PR DESCRIPTION

<img width="1348" height="200" alt="Screenshot 2026-08-03 at 3 01 35 PM" src="https://github.com/user-attachments/assets/02a13966-27ea-4ef5-8fe2-6616b6264d30" />

---

### Proposed changes

Surfaces the release notes and changelog on the blog homepage: a new `layouts/partials/blog/releases-marquee.html` renders the 12 newest `/releases` entries (full releases plus individual changelog items) as a scrolling ticker pinned under the blog header, on page 1 only. Changelog rows reuse the existing `/releases/` modal (`releases/changelog-modal.html` + `theme/src/ts/releases.ts`), while full release pages stay plain links. Styles live in `theme/src/scss/_blog.scss`: the track holds three copies of the list so the loop is seamless, the scroll rate is constant regardless of item count, and the strip pauses on hover and while the modal is open. Under `prefers-reduced-motion` it degrades to a static, horizontally scrollable strip, and marquee clones are `aria-hidden` with `tabindex="-1"` so each entry appears exactly once for assistive tech and tab order.

### Related issues (optional)

Fixes #20585