### PR TITLE
infra: grant the DWH reader role read access to the social-post state bucket

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -298,21 +298,21 @@ new aws.s3.BucketPublicAccessBlock("content-review-ledger-public-access-block", 
     restrictPublicBuckets: true,
 });
 
-// Grant the data warehouse's Snowpipe reader role read access so the ledger can
-// be synced into Snowflake (pulumi/data#873). Only when DWH access is enabled.
+// Grant the data warehouse's Snowpipe reader role read access to the buckets it
+// ingests, so their contents can be synced into Snowflake (pulumi/data#873,
+// pulumi/data#921). Only when DWH access is enabled.
 if (config.enableDataWarehouseAccess) {
     const prodBucketsStack = new pulumi.StackReference("pulumi/dwh-workflows-loader-prodbuckets/production");
     const dwhBucketReaderRole = prodBucketsStack.getOutput("dwhBucketReaderRole");
 
-    new aws.s3.BucketPolicy("content-review-ledger-dwh-read-policy", {
-        bucket: contentReviewLedgerBucket.bucket,
-        policy: pulumi.all([contentReviewLedgerBucket.arn, dwhBucketReaderRole])
+    // Data warehouse (Snowpipe) read access. GetObjectVersion is included
+    // because both buckets are versioned and the per-object history — a
+    // review's or a post's — lives in S3 object versions.
+    const dwhReadPolicy = (bucket: aws.s3.Bucket) =>
+        pulumi.all([bucket.arn, dwhBucketReaderRole])
             .apply(([bucketArn, roleArn]) => JSON.stringify({
                 Version: "2012-10-17",
                 Statement: [
-                    // Data warehouse (Snowpipe) read access. GetObjectVersion is
-                    // included because the ledger bucket is versioned and the
-                    // per-review history lives in S3 object versions.
                     {
                         Sid: "DataWarehouseReadObjects",
                         Effect: "Allow",
@@ -341,7 +341,18 @@ if (config.enableDataWarehouseAccess) {
                         }
                     }
                 ]
-            })),
+            }));
+
+    new aws.s3.BucketPolicy("content-review-ledger-dwh-read-policy", {
+        bucket: contentReviewLedgerBucket.bucket,
+        policy: dwhReadPolicy(contentReviewLedgerBucket),
+    });
+
+    // The social-post state objects (posted.json, posted-social.json) are the
+    // only record of which post went out on which platform and when.
+    new aws.s3.BucketPolicy("social-post-state-dwh-read-policy", {
+        bucket: socialStateBucket.bucket,
+        policy: dwhReadPolicy(socialStateBucket),
     });
 }
 


### PR DESCRIPTION
Adds the same DWH read policy the content-review ledger bucket already carries to the social-post state bucket (`social-post-state-f3a03a1`), so its objects can be ingested into Snowflake. Requested by the data team in [pulumi/data#921](https://github.com/pulumi/data/issues/921#issuecomment-5148144359) (item 4).

`posted.json` / `posted-social.json` are the only record of which post went out on which platform and when.

### What changed

The ledger policy document is extracted into a small `dwhReadPolicy(bucket)` helper and applied to both buckets. The policy JSON literal is untouched, so `content-review-ledger-dwh-read-policy` renders byte-identical and is not modified — the only resource change is one new `BucketPolicy` on `social-post-state`.

Both buckets are versioned, so `GetObjectVersion` comes along with `GetObject`; the TLS-only deny is part of the same document.

### Verification

- `tsc --noEmit` clean in `infrastructure/`.
- Confirmed against the live account (`388588623842`): `social-post-state-f3a03a1` currently returns `NoSuchBucketPolicy`; the ledger bucket has the policy this copies.
- Gated on `enableDataWarehouseAccess`, which is set only on `www-production`.
- A local `pulumi preview` against `www-production` isn't possible (the program needs the origin-bucket metadata the CI build produces), so the preview in PR CI is the real check.