### PR TITLE
Resolve window.Intercom at call time so Intercom identification survives the widget swap

### DIFF
--- a/theme/src/ts/intercom-identity.ts
+++ b/theme/src/ts/intercom-identity.ts
@@ -197,11 +197,16 @@ function tryRun(): void {
     if (ran) {
         return;
     }
-    const intercom = (window as { Intercom?: unknown }).Intercom;
-    if (typeof intercom === "function") {
-        ran = true;
-        run(intercom as IntercomFn);
+    if (typeof (window as { Intercom?: unknown }).Intercom !== "function") {
+        return;
     }
+    ran = true;
+    // Intercom's loader replaces window.Intercom (pre-boot queue stub -> real
+    // widget) moments after boot, discarding the stub's queue as it goes. A
+    // reference captured before that swap is dead by the time the awaited
+    // settings fetch resolves, and calling it throws, so resolve the global on
+    // every call rather than holding one.
+    run((cmd, arg) => (window as unknown as { Intercom: IntercomFn }).Intercom(cmd, arg));
 }
 
 const analytics = (window as any).analytics;


### PR DESCRIPTION
### Proposed changes

Signed-in Pulumi Cloud users are anonymous to Intercom on www.pulumi.com. `intercom-identity.ts` captures `window.Intercom` in `tryRun()` and holds that reference across the awaited settings fetch, but Intercom's loader replaces the global partway through startup — the snippet installs a queue stub, Segment calls `boot`, and the real widget then takes over `window.Intercom` and discards the stub's queue.

Measured on a cold load of www.pulumi.com:

```
t=   0ms  window.Intercom undefined
t= 978ms  window.Intercom = fn        <- pre-boot queue stub (i.q = [])
t=1139ms  Intercom("boot")            <- Segment boots it, ok
t=1156ms  window.Intercom = fn        <- real widget replaces the stub
t=1309ms  Intercom("update", {jwt})   <- THREW: Cannot read properties of
                                         undefined (reading 'push')
```

The swap lands ~17ms after boot while the fetch to `app.pulumi.com` takes 130–200ms, so the captured reference is reliably dead by the time `identify()` runs. Three symptoms follow from that single throw:

- The `.catch(() => {})` on the promise chain swallows it, so nothing reaches the console.
- The throw precedes the `localStorage.setItem` in `identify()`, so the `identified` marker is never written and every subsequent page load retries and fails the same way.
- `pulumi_intercom_jwt` *is* written, because `cacheJwt()` runs first — cache present with the marker absent is the fingerprint.

Resolving the global per call fixes `identify()`, the switched-user `shutdown`, and `signedOutCleanup()` together, since all three route through the same `IntercomFn`.

### Verification

A/B on the same production page load, against the naturally booted widget (no forced `boot`, `app_id: m6iw8kx0` confirmed from the ping request):

| Path | Result |
|---|---|
| Current code, fetch path | throws; marker unwritten; `role: "visitor_role"` |
| Call-time resolution, real 194ms fetch | no throw; marker written; `role: "user_role"` |
| Cached-JWT path (synchronous, no await) | `role: "user_role"` — unaffected either way |

That last row is why this passed local end-to-end testing: with no await between capture and call the stub is still live, so the call queues and the widget replays it. A localhost console resolves fast enough to land in the same window, and once any load populates `sessionStorage`, every later load in that tab takes the synchronous path unconditionally.

### Notes for reviewers

- **No regression test.** `theme/src/ts` has no unit-test runner (Prettier and webpack only; Jest is confined to `theme/stencil`, and Cypress e2e can't reach a console backend). The durable test is a small one — resolve the fetch, swap `window.Intercom`, assert the update lands on the current global — but it needs a runner added to `theme/`. Happy to do that as a follow-up if reviewers want it.
- The blanket `.catch(() => {})` is what turned a hard TypeError into a silent no-op in production. Left as-is to keep this focused; a `console.debug` there would make the next failure a two-minute diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
