### PR TITLE
Add HCL examples to resource option pages

### DIFF
--- a/content/docs/iac/concepts/resources/options/additionalsecretoutputs.md
+++ b/content/docs/iac/concepts/resources/options/additionalsecretoutputs.md
@@ -20,7 +20,7 @@ The `additionalSecretOutputs` resource option specifies a list of named output p
 
 This example ensures that the password generated for a database resource is an encrypted secret:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -75,6 +75,21 @@ resources:
       additionalSecretOutputs:
         - password
 ```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "database" "db" {
+  # ...
+
+  pulumi {
+    additional_secret_outputs = [password]
+  }
+}
+```
+
+In HCL, each entry is a bare attribute name (in the provider's `snake_case` form), not a quoted string.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/resources/options/aliases.md
+++ b/content/docs/iac/concepts/resources/options/aliases.md
@@ -23,7 +23,7 @@ Aliases are frequently used when refactoring Pulumi programs.
 
 For example, imagine we change a database resource’s name from `old-name-for-db` to `new-name-for-db`. By default, when we run `pulumi up`, we see that the old resource is deleted and the new one created. If we annotate that resource with the aliases option, however, the resource is updated in-place. Pulumi identifies resources by their [URN](/docs/iac/concepts/resources/names/#urns), which encodes the resource name, so the alias tells Pulumi to treat the old URN as equivalent to the new one:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -84,6 +84,21 @@ resources:
 ```
 
 {{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "database" "new_name_for_db" {
+  # ...
+
+  pulumi {
+    aliases = [{ name = "old-name-for-db" }]
+  }
+}
+```
+
+HCL also supports Terraform's standard `moved` blocks for renaming resources.
+
+{{% /choosable %}}
 
 {{< /chooser >}}
 
@@ -91,7 +106,7 @@ The aliases option accepts a list of old identifiers. If a resource has been ren
 
 The above example used objects of type `Alias` with the old resource names. These values may specify any combination of the old name, type, parent, stack, and/or project values. Alternatively, you can just specify the URN directly:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -151,6 +166,21 @@ resources:
 ```
 
 {{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "database" "new_name_for_db" {
+  # ...
+
+  pulumi {
+    aliases = ["urn:pulumi:stackname::projectname::aws:rds/database:Database::old-name-for-db"]
+  }
+}
+```
+
+In HCL, a plain string alias must be a full URN; to alias by name alone, use the object form `{ name = "..." }`.
+
+{{% /choosable %}}
 
 {{< /chooser >}}
 
@@ -158,7 +188,7 @@ resources:
 
 If a resource was moved to a different parent component resource, use the `parent` field to reference the old parent resource so that Pulumi can map the old URN to the new one:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -221,6 +251,21 @@ resources:
 ```
 
 {{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "database" "db" {
+  # ...
+
+  pulumi {
+    aliases = [{ parent_urn = "urn:pulumi:stackname::projectname::my:component:Type::old-parent" }]
+  }
+}
+```
+
+In HCL, the old parent is identified by its URN (`parent_urn`) rather than by a resource reference. Use `{ no_parent = true }` to alias a resource that previously had no parent.
+
+{{% /choosable %}}
 
 {{< /chooser >}}
 
@@ -228,7 +273,7 @@ resources:
 
 If a resource was moved from another stack or project, use the `stack` and/or `project` fields to refer to the old identity:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -291,6 +336,19 @@ resources:
 ```
 
 {{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "database" "db" {
+  # ...
+
+  pulumi {
+    aliases = [{ stack = "old-stack", project = "old-project" }]
+  }
+}
+```
+
+{{% /choosable %}}
 
 {{< /chooser >}}
 
@@ -298,7 +356,7 @@ resources:
 
 If a resource's type was changed (for example, when migrating to a different provider resource type), use the `type` field to specify the old type:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -356,6 +414,19 @@ resources:
     options:
       aliases:
         - type: aws:rds/database:Database
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "aws_db_instance" "db" {
+  # ...
+
+  pulumi {
+    aliases = [{ type = "aws:rds/database:Database" }]
+  }
+}
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/concepts/resources/options/customtimeouts.md
+++ b/content/docs/iac/concepts/resources/options/customtimeouts.md
@@ -22,7 +22,7 @@ For the most part, Pulumi automatically waits for operations to complete and tim
 
 This example specifies that the create operation should wait up to 30 minutes to complete before timing out:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -82,6 +82,21 @@ resources:
       customTimeouts:
         create: "30m"
 ```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "database" "db" {
+  # ...
+
+  timeouts {
+    create = "30m"
+  }
+}
+```
+
+In HCL, custom timeouts use the standard Terraform `timeouts` block rather than a `pulumi` option.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/resources/options/deletebeforereplace.md
+++ b/content/docs/iac/concepts/resources/options/deletebeforereplace.md
@@ -22,7 +22,7 @@ Setting the `deleteBeforeReplace` option to true means that Pulumi will delete t
 
 This example deletes a database entirely before its replacement is created:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -78,6 +78,23 @@ resources:
     type: Database
     options:
       deleteBeforeReplace: true
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+# HCL follows Terraform's replacement semantics: resources are deleted
+# before their replacement is created by default. Set
+# create_before_destroy = true to opt into Pulumi's default
+# create-first behavior instead.
+resource "database" "db" {
+  # ...
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/concepts/resources/options/deletedwith.md
+++ b/content/docs/iac/concepts/resources/options/deletedwith.md
@@ -22,7 +22,7 @@ Pulumi will normally call the provider's delete action for every resource during
 
 For example, if you are deleting a Kubernetes cluster or Kubernetes namespace, you might want to speed up deletion by skipping delete on any Pulumi managed resources created in that Kubernetes cluster or namespace since they will be deleted implicitly.
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -95,6 +95,23 @@ resources:
     name: res2
     options:
       deletedWith: ${ns}
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "kubernetes_namespace" "ns" {
+  # ...
+}
+
+resource "kubernetes_deployment" "dep" {
+  # ...
+
+  pulumi {
+    deleted_with = kubernetes_namespace.ns
+  }
+}
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/concepts/resources/options/dependson.md
+++ b/content/docs/iac/concepts/resources/options/dependson.md
@@ -22,7 +22,7 @@ Pulumi automatically tracks dependencies between resources when you supply an in
 
 This example demonstrates how to make `res2` dependent on `res1`, even if there is no property-level dependency:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -81,6 +81,23 @@ resources:
       dependsOn:
         - ${res1}
 ```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "my_resource" "res1" {
+  # ...
+}
+
+resource "my_resource" "res2" {
+  # ...
+
+  depends_on = [my_resource.res1]
+}
+```
+
+In HCL, explicit dependencies use the standard Terraform `depends_on` meta-argument rather than a `pulumi` option.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/resources/options/envvarmappings.md
+++ b/content/docs/iac/concepts/resources/options/envvarmappings.md
@@ -29,7 +29,7 @@ Use this option when:
 
 The following example shows how to remap `CUSTOM_ARM_CLIENT_SECRET` to `ARM_CLIENT_SECRET` so the provider reads from your custom environment variable:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -121,6 +121,21 @@ resources:
 ```
 
 {{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+provider "azurerm" {
+  # ...
+
+  pulumi {
+    env_var_mappings = {
+      CUSTOM_ARM_CLIENT_SECRET = "ARM_CLIENT_SECRET"
+    }
+  }
+}
+```
+
+{{% /choosable %}}
 
 {{< /chooser >}}
 
@@ -128,7 +143,7 @@ resources:
 
 A common use case is running two providers targeting different cloud accounts. Here's an example with two AWS providers for production and staging environments:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -336,6 +351,44 @@ resources:
     type: aws:s3:Bucket
     options:
       provider: ${aws-staging}
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+# Production provider reads from PROD_AWS_ACCESS_KEY_ID and PROD_AWS_SECRET_ACCESS_KEY
+provider "aws" {
+  alias = "prod"
+
+  pulumi {
+    env_var_mappings = {
+      PROD_AWS_ACCESS_KEY_ID     = "AWS_ACCESS_KEY_ID"
+      PROD_AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
+    }
+  }
+}
+
+# Staging provider reads from STAGING_AWS_ACCESS_KEY_ID and STAGING_AWS_SECRET_ACCESS_KEY
+provider "aws" {
+  alias = "staging"
+
+  pulumi {
+    env_var_mappings = {
+      STAGING_AWS_ACCESS_KEY_ID     = "AWS_ACCESS_KEY_ID"
+      STAGING_AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
+    }
+  }
+}
+
+# Use the providers explicitly
+resource "aws_s3_bucket" "prod" {
+  provider = aws.prod
+}
+
+resource "aws_s3_bucket" "staging" {
+  provider = aws.staging
+}
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/concepts/resources/options/hidediffs.md
+++ b/content/docs/iac/concepts/resources/options/hidediffs.md
@@ -38,7 +38,7 @@ This is useful when working with properties that generate large or verbose diffs
 
 ## Example usage
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -102,6 +102,21 @@ resources:
 ```
 
 {{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "my_resource" "res" {
+  prop = "new-value"
+
+  pulumi {
+    hide_diffs = [prop]
+  }
+}
+```
+
+In HCL, each entry is a bare attribute name (in the provider's `snake_case` form), not a quoted string.
+
+{{% /choosable %}}
 
 {{< /chooser >}}
 
@@ -111,7 +126,7 @@ In addition to passing simple property names, nested properties can also be supp
 
 For example, to hide diffs for all weights in an AWS load balancer listener's target groups:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -259,6 +274,40 @@ resources:
       hideDiffs:
         - defaultActions[*].forward.targetGroups[*].weight
 ```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "aws_lb_listener" "listener" {
+  # ... other configuration ...
+
+  default_action {
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.blue.arn
+        weight = 80
+      }
+
+      target_group {
+        arn    = aws_lb_target_group.green.arn
+        weight = 20
+      }
+    }
+  }
+
+  pulumi {
+    hide_diffs = [
+      default_action[0].forward[0].target_group[0].weight,
+      default_action[0].forward[0].target_group[1].weight,
+    ]
+  }
+}
+```
+
+In HCL, each entry is a bare traversal rather than a quoted string, so wildcard paths like `[*]` are not available; list each element by index instead.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/resources/options/ignorechanges.md
+++ b/content/docs/iac/concepts/resources/options/ignorechanges.md
@@ -46,7 +46,7 @@ When you skip `pulumi refresh` (or `pulumi up --refresh`) after `ignoreChanges` 
 
 For instance, in this example, the resource’s prop property "new-value" will be set when Pulumi initially creates the resource, but from then on, any updates will ignore it:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -110,6 +110,21 @@ resources:
 ```
 
 {{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "my_resource" "res" {
+  prop = "new-value"
+
+  lifecycle {
+    ignore_changes = [prop]
+  }
+}
+```
+
+In HCL, ignored properties use the standard Terraform `ignore_changes` lifecycle argument rather than a `pulumi` option.
+
+{{% /choosable %}}
 
 {{< /chooser >}}
 
@@ -123,7 +138,7 @@ Some common reasons to use the `ignoreChanges` option are:
 
 Consider an AWS Application Load Balancer listener whose target group weights are managed by an external traffic controller. You can let Pulumi create the listener and target groups while preventing future updates to the weights by adding the property path to `ignoreChanges`:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -415,6 +430,51 @@ resources:
       ignoreChanges:
         - defaultActions[*].forward.targetGroups[*].weight
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```hcl
+resource "aws_lb" "front_end" {}
+
+resource "aws_lb_target_group" "front_end_blue" {}
+
+resource "aws_lb_target_group" "front_end_green" {}
+
+resource "aws_lb_listener" "front_end_listener" {
+  load_balancer_arn = aws_lb.front_end.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"
+
+  default_action {
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.front_end_blue.arn
+        weight = 100
+      }
+
+      target_group {
+        arn    = aws_lb_target_group.front_end_green.arn
+        weight = 0
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      default_action[0].forward[0].target_group[0].weight,
+      default_action[0].forward[0].target_group[1].weight,
+    ]
+  }
+}
+```
+
+HCL `ignore_changes` entries are attribute paths with constant indices; wildcard (`[*]`) paths are not supported.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/resources/options/import.md
+++ b/content/docs/iac/concepts/resources/options/import.md
@@ -22,7 +22,7 @@ To import a resource, first specify the `import` option with the resource’s ID
 
 This example imports an existing EC2 security group with ID `sg-04aeda9a214730248` and an EC2 instance with ID `i-06a1073de86f4adef`:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -190,6 +190,39 @@ resources:
     options:
       import: i-06a1073de86f4adef
 ```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "aws_security_group" "group" {
+  name        = "web-sg-62a569b"
+  description = "Enable HTTP access"
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  pulumi {
+    import_id = "sg-04aeda9a214730248"
+  }
+}
+
+resource "aws_instance" "server" {
+  ami             = "ami-6869aa05"
+  instance_type   = "t2.micro"
+  security_groups = [aws_security_group.group.name]
+
+  pulumi {
+    import_id = "i-06a1073de86f4adef"
+  }
+}
+```
+
+HCL also supports Terraform's standard top-level `import` blocks as an alternative.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/resources/options/parent.md
+++ b/content/docs/iac/concepts/resources/options/parent.md
@@ -27,7 +27,7 @@ By default, resources are parented to the implicitly created `pulumi:pulumi:Stac
 
 The following example shows a simple parent/child relationship between two resources:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -84,6 +84,23 @@ resources:
     type: MyResource
     options:
       parent: ${parent}
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "my_resource" "parent" {
+  # ...
+}
+
+resource "my_resource" "child" {
+  # ...
+
+  pulumi {
+    parent = my_resource.parent
+  }
+}
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/concepts/resources/options/protect.md
+++ b/content/docs/iac/concepts/resources/options/protect.md
@@ -27,7 +27,7 @@ Once the resource is unprotected, it can be deleted as part of a following updat
 
 The default is to inherit this value from the parent resource, and `false` for resources without a parent.
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -80,6 +80,19 @@ resources:
 ```
 
 {{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "database" "db" {
+  # ...
+
+  pulumi {
+    protect = true
+  }
+}
+```
+
+{{% /choosable %}}
 
 {{< /chooser >}}
 
@@ -89,7 +102,7 @@ Child resources inherit the `protect` option from their [parent resource](/docs/
 
 The following example creates a protected parent resource alongside a child resource with protection explicitly disabled:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -155,6 +168,24 @@ resources:
     options:
       parent: ${parent}
       protect: false
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "my_resource" "parent" {
+  pulumi {
+    protect = true
+  }
+}
+
+resource "my_resource" "child" {
+  pulumi {
+    parent  = my_resource.parent
+    protect = false
+  }
+}
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/concepts/resources/options/provider.md
+++ b/content/docs/iac/concepts/resources/options/provider.md
@@ -18,7 +18,7 @@ The `provider` resource option sets a provider for the resource. For more inform
 
 {{< resource-option-scope "provider" >}}
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -82,6 +82,22 @@ resources:
     options:
       provider: ${provider}
 ```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+provider "aws" {
+  alias  = "usw2"
+  region = "us-west-2"
+}
+
+resource "aws_vpc" "vpc" {
+  provider = aws.usw2
+}
+```
+
+In HCL, explicit providers use the standard Terraform `provider` meta-argument with an aliased `provider` block.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/resources/options/providers.md
+++ b/content/docs/iac/concepts/resources/options/providers.md
@@ -30,7 +30,7 @@ The first match wins. So a child resource created with a component as its parent
 
 A component can be instantiated multiple times against different sets of providers. Suppose `MyComponent` deploys a regional AWS database alongside a Helm chart on a Kubernetes cluster in the same region. To run the component in two regions from a single Pulumi program, declare a separate AWS provider and Kubernetes provider for each region, then pass the matching pair into each component instance via the `providers` map.
 
-{{< chooser language "typescript,python,go,csharp,java" >}}
+{{< chooser language "typescript,python,go,csharp,java,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -174,6 +174,39 @@ var east = new MyComponent("east", new MyComponentArgs(),
 var west = new MyComponent("west", new MyComponentArgs(),
     ComponentResourceOptions.builder().providers(awsWest, k8sWest).build());
 ```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+provider "aws" {
+  alias  = "east"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "west"
+  region = "us-west-2"
+}
+
+module "east" {
+  source = "./my-component"
+
+  providers = {
+    aws = aws.east
+  }
+}
+
+module "west" {
+  source = "./my-component"
+
+  providers = {
+    aws = aws.west
+  }
+}
+```
+
+In HCL, components are modules, and explicit providers are passed with the standard Terraform `providers` map on the module block.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/resources/options/replacementtrigger.md
+++ b/content/docs/iac/concepts/resources/options/replacementtrigger.md
@@ -20,7 +20,7 @@ For example, you might want to rotate cryptographic keys monthly by using a `YYY
 
 {{< resource-option-scope "replacementTrigger" >}}
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -97,6 +97,30 @@ resources:
     type: example:components:KeyManager
     options:
       replacementTrigger: ${rotationPeriod}
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+variable "rotation_period" {
+  type    = string
+  default = "01-2026"
+}
+
+resource "terraform_data" "rotation" {
+  input = var.rotation_period
+}
+
+resource "key_manager_resource" "key_manager" {
+  # ...
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.rotation]
+  }
+}
+```
+
+In HCL, use the standard Terraform `replace_triggered_by` lifecycle argument, which references other resources rather than taking an arbitrary value. To trigger on an arbitrary value, route it through a `terraform_data` resource as shown.
+
 {{% /choosable %}}
 
 {{< /chooser >}}

--- a/content/docs/iac/concepts/resources/options/replaceonchanges.md
+++ b/content/docs/iac/concepts/resources/options/replaceonchanges.md
@@ -20,7 +20,7 @@ For example, with Kubernetes `CustomResource` resources, the Kubernetes resource
 
 {{< resource-option-scope "replaceOnChanges" >}}
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -102,6 +102,27 @@ var widget = new com.pulumi.kubernetes.apiextensions.CustomResource("widget",
 # YAML doesn't support kubernetes:apiextensions.k8s.io:CustomResource
 # See https://github.com/pulumi/pulumi-yaml/issues/161 for details.
 ```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "kubernetes_manifest" "widget" {
+  manifest = {
+    apiVersion = "acmecorp.com/v1alpha1"
+    kind       = "Widget"
+    spec = {
+      input = "something"
+    }
+  }
+
+  pulumi {
+    replace_on_changes = [manifest]
+  }
+}
+```
+
+In HCL, each entry is a bare attribute name (in the provider's `snake_case` form), not a quoted string.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/concepts/resources/options/replacewith.md
+++ b/content/docs/iac/concepts/resources/options/replacewith.md
@@ -22,7 +22,7 @@ In these cases, you can use `replaceWith` to make these relationships explicit t
 
 {{< resource-option-scope "replaceWith" >}}
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -124,6 +124,23 @@ resources:
     options:
       replaceWith:
         - ${database}
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "aws_db_instance" "database" {
+  # ...
+}
+
+resource "aws_instance" "application" {
+  # ...
+
+  pulumi {
+    replace_with = [aws_db_instance.database]
+  }
+}
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/concepts/resources/options/retainOnDelete.md
+++ b/content/docs/iac/concepts/resources/options/retainOnDelete.md
@@ -29,7 +29,7 @@ Once the resource is no longer marked retained, it can be fully deleted as part 
 
 The default is to inherit this value from the parent resource, and `false` for resources without a parent.
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -79,6 +79,19 @@ resources:
     type: Database
     options:
       retainOnDelete: true
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "database" "db" {
+  # ...
+
+  pulumi {
+    retain_on_delete = true
+  }
+}
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/concepts/resources/options/version.md
+++ b/content/docs/iac/concepts/resources/options/version.md
@@ -18,7 +18,7 @@ The `version` resource option specifies a provider version to use when operating
 
 {{< resource-option-scope "version" >}}
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -69,6 +69,21 @@ resources:
     options:
       version: "2.10.0"
 ```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+```hcl
+resource "aws_vpc" "vpc" {
+  # ...
+
+  pulumi {
+    version = "2.10.0"
+  }
+}
+```
+
+This pins the version of the Pulumi provider plugin that operates on the resource. To pin the version of a Terraform provider itself, use the standard `required_providers` block instead.
 
 {{% /choosable %}}
 


### PR DESCRIPTION
## Summary

Adds an HCL (Terraform-syntax) example to each resource option page under `content/docs/iac/concepts/resources/options/` that the pulumi-hcl runtime supports — 19 pages in total. Pulumi-only options use the nested `pulumi {}` block; options that map directly to a Terraform construct (`ignoreChanges`, `deleteBeforeReplace`, `customTimeouts`, `dependsOn`, `provider`/`providers`, `replacementTrigger`) use the native `lifecycle`/meta-argument syntax.

`hooks`, `transforms`, and `transformations` are left unchanged: no HCL surface exists for them.

## Verification

- Every example was verified by deploying a real program (S3 bucket via the AWS provider, Pulumi Cloud backend) with the pulumi-hcl dev build — not just parsed.
- Divergences found during verification were reported upstream rather than worked around: pulumi-labs/pulumi-hcl#500, #501, #502 (failing tests) and #503 (language-reference fixes, merged into the wording used here).
- Notable HCL-specific wording added where behavior differs from other SDKs: traversal-list options (`additionalSecretOutputs`, `hideDiffs`, `replaceOnChanges`) take bare `snake_case` attribute names, not quoted strings, and have no `[*]` wildcard; `aliases` needs the object form `{ name = "old-name" }` since a plain string is treated as a URN.
- `make build` and `make lint` pass.