### PR TITLE
[registry] Drop the local-conversion fallback for unconverted module versions

### DIFF
--- a/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
+++ b/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
@@ -94,13 +94,7 @@ pulumi package add <name>-<system> [<version>]
 
 A module published as `acme-corp/vpc/aws` installs as `vpc-aws`. This is the same as any other Pulumi package: you get a generated SDK in your language, an [API reference](/docs/idp/concepts/private-registry/#api-documentation) on the package's page, and [usage tracking](/docs/idp/concepts/private-registry/#usage-tracking) showing which of your stacks depend on it and which are behind the latest version. Installing a converted package requires Pulumi CLI 3.248.0 or newer; see [Download & Install Pulumi](/docs/install/) to upgrade.
 
-The package's page in Pulumi Cloud shows whether a given version has converted. If a version you need has no package, you can convert the module locally instead, against the module address rather than the package name:
-
-```bash
-pulumi package add hcl module tf.pulumi.com/<namespace>/<name>/<system> [<version>]
-```
-
-This converts the module on your machine and generates an SDK for your project. Nothing is published to the registry, so this route has no package page, API reference, or usage tracking, and a module the registry could not convert may well fail here for the same reason. The version is optional; omit it to resolve the latest published version. Self-hosted Pulumi Cloud installations use their own host (`<your-pulumi-host>/<namespace>/<name>/<system>`).
+The package's page in Pulumi Cloud shows whether a given version has converted.
 
 See [Terraform Modules in the Pulumi Cloud Registry](/docs/idp/concepts/terraform-modules/) for the publishing side and the broader module workflow.
 

--- a/content/docs/idp/concepts/terraform-modules.md
+++ b/content/docs/idp/concepts/terraform-modules.md
@@ -90,6 +90,8 @@ Publishing a module version also converts it into a Pulumi package, with no extr
 
 Conversion runs per version, so a module can have some versions with packages and some without. The package's page in Pulumi Cloud shows which versions have converted and gives you the command to install one.
 
+Under the hood, the conversion job derives the package schema by reading the module through Pulumi's [`hcl`](https://github.com/pulumi/pulumi-hcl) parameterized provider (`pulumi package get-schema hcl module <address>`) and publishes that schema as a package version. SDKs and API documentation come from the schema, the same as for any other package.
+
 ## Consume from a Pulumi program
 
 Once a version has converted, install it by package name:
@@ -108,19 +110,7 @@ Usage tracking only counts consumption through the converted package. A stack or
 Installing a converted package requires Pulumi CLI 3.248.0 or newer. See [Download & Install Pulumi](/docs/install/) to install or upgrade.
 {{% /notes %}}
 
-### If a version has no package
-
-Installing by package name is the path to reach for. If a version you need has no package, you can convert the module locally instead, against the module address rather than the package name:
-
-```bash
-pulumi package add hcl module tf.pulumi.com/<namespace>/<name>/<system> [<version>]
-```
-
-`hcl` is a parameterized provider. The `module` keyword selects module mode, followed by the module address and an optional version. Omit the version to resolve the latest published version; pass one to pin it.
-
-This converts the module on your machine, using your local `hcl` provider, and generates an SDK for your project. Nothing is published: there is no package in the registry, and so no package page, no API reference, and no usage tracking, and a teammate who needs the module runs the same command rather than installing what you produced. A module the registry could not convert may well fail here for the same reason.
-
-Both commands resolve using your Pulumi credentials. See [Use a Terraform Module in Pulumi](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) for examples.
+The install resolves using your Pulumi credentials. See [Use a Terraform Module in Pulumi](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) for examples.
 
 ## Consume from OpenTofu or Terraform
 


### PR DESCRIPTION
Daniel asked in Slack when the "if a version has no package" case actually happens. It's a transient state of the conversion job: the package row exists with no versions yet, or the first version's conversion is still running or failed. That isn't a workflow readers should be routed into, and the section shouldn't have shipped.

- Removes the `### If a version has no package` section from `/docs/idp/concepts/terraform-modules/` and the equivalent paragraph in the Terraform module guide.
- Stops presenting `pulumi package add hcl module tf.pulumi.com/<namespace>/<name>/<system> [<version>]` as something a reader runs.
- Mentions the `hcl` provider once, in "What happens when you publish", as what the conversion job uses under the hood. Per `pulumi-service` (`pkg/tfmodules/conversionworker/schema.go`), the job derives the schema with `pulumi package get-schema hcl@<version> module <source> <version>` and publishes it as a package version, so the docs now say that rather than `package add`.

The only path documented for consuming a converted module is now `pulumi package add <name>-<system> [<version>]`.

Note: the `#if-a-version-has-no-package` anchor goes away. Existing links to it land at the top of the page.
