### PR TITLE
Fix clipped presenter byline on square event cards

### DIFF
--- a/.claude/commands/event-meta-image/SKILL.md
+++ b/.claude/commands/event-meta-image/SKILL.md
@@ -26,7 +26,7 @@ Everything below applies to both modes **except** the bundle/frontmatter writes 
 Orthogonal to event-bound/standalone, pick how much to prompt. **Default to searching, not asking:** in both modes you still auto-resolve people and logos via the ladders in Steps 3–4 (including `WebSearch`/`WebFetch`). The modes differ only in what happens when something can't be resolved or is genuinely ambiguous.
 
 - **Unattended — never ask.** Trigger when `$ARGUMENTS` contains `-y`, `--yes`, `--non-interactive`, `--no-input`, `no questions`, or "just do it" (and automatically whenever you're running non-interactively, e.g. under `claude -p` or the eval, where `AskUserQuestion` can't be answered). Skip **every** `AskUserQuestion`. Derive all inputs automatically:
-  - **overline** = `event_type`; **title** = frontmatter `title`; **speakers** = frontmatter `presenters[].photo`; **additionalText** = the derived "With …" line.
+  - **overline** = `event_type`; **title** = frontmatter `title`; **speakers** = frontmatter `presenters[].photo`; **additionalText** = the derived "With …" line, with **additionalTextShort** = its names-only form.
   - **people** = frontmatter presenters **plus** any external co-presenter named in the title/body.
   - **logos** = `["pulumi"]` **plus** any partner company named in the title/body.
   - Auto-resolve each derived photo/logo via the Step 3 / Step 4 ladders. **On a resolution miss, skip that one asset with a warning and keep going — never block.** No button, no secondary title.
@@ -48,7 +48,7 @@ Pull from frontmatter:
 - **event_type** → the default **overline** (uppercased automatically).
 - **presenters**: `presenters: [{ name, role, photo }]` — the in-frontmatter speakers. Each `photo` (e.g. `/images/people/<x>.jpg` or `/images/team/<x>.jpg`) resolves under `static/`.
 
-The build default already uses exactly these. If the user only wants the default look in all five sizes (no new people/logos), you can skip straight to Step 6 with `overline`, `title`, the presenters' `photo` paths as `speakers`, the `"With …"` line as `additionalText`, and `["pulumi"]` as `logos`.
+The build default already uses exactly these. If the user only wants the default look in all five sizes (no new people/logos), you can skip straight to Step 6 with `overline`, `title`, the presenters' `photo` paths as `speakers`, the `"With …"` line as `additionalText` (plus its names-only form as `additionalTextShort`), and `["pulumi"]` as `logos`.
 
 ## [Step 3/6] Add people not in frontmatter (external co-presenters)
 
@@ -103,6 +103,7 @@ Write **one** config JSON (e.g. `.context/event-images/<slug>/config.json`), the
   "title": "Advanced CI/CD for AWS using Pulumi and GitHub Actions",
   "secondaryTitle": "",
   "additionalText": "With Jane Doe - Staff Engineer, Acme and John Roe",
+  "additionalTextShort": "With Jane Doe and John Roe",
   "showButton": false,
   "buttonText": "Register",         // opt-in only — see below; leave showButton false unless explicitly requested
   "speakers": ["/images/people/jane.jpg", ".context/event-images/<slug>/john-roe.jpg"],
@@ -111,6 +112,7 @@ Write **one** config JSON (e.g. `.context/event-images/<slug>/config.json`), the
 ```
 
 - `additionalText` is the literal "With …" line. Compose it yourself: one presenter → `With {name} - {role}`; many → names only, Oxford comma (`With A, B, and C`). (Omit to let the CLI derive it from a `presenters: [{name, role}]` array instead.)
+- `additionalTextShort` is the names-only byline (`With A and B`) used by the two **square** sizes, whose text column is too narrow for full "Name - Role, Company" runs. Optional: supply it whenever `additionalText` carries roles, or omit it and let a `presenters` array derive both. The other three sizes always use `additionalText`.
 - `showButton` is **off unless the user explicitly asked for a button** (see Step 5). Omit it or leave `false` in every default and unattended run.
 - `speakers` / `logos` resolve as: `data:` URI → path relative to the config file → repo path (`/images/…`, `static/`, `assets/fingerprinted/`, `static/logos/**`) → absolute path. Unresolved entries are skipped with a warning.
 

--- a/scripts/generate-meta-images.mjs
+++ b/scripts/generate-meta-images.mjs
@@ -61,6 +61,14 @@ const MANIFEST = join(OUT_ROOT, ".manifest.json")
 //     no photo halo, 2-up gap (no overlap), role/company in the 1–2 person byline.
 const OG_TEMPLATE_VERSION = "6"
 
+// Per-template revision. Bump one of these — instead of OG_TEMPLATE_VERSION —
+// when a change is confined to a single card template, so only that template's
+// cards re-render and every other section keeps its cache.
+//   events r2: byline measured/fitted rather than -webkit-line-clamp'd (it used
+//     to be sliced mid-glyph), 3-line budget on square/portrait, names-only
+//     byline on square.
+const TEMPLATE_REVISION = { events: 2 }
+
 const SAMPLE = !!process.env.OG_SAMPLE // one card per sampleGroupBy group
 const ONLY = (process.env.OG_ONLY || "").split(",").map((s) => s.trim()).filter(Boolean)
 
@@ -270,9 +278,11 @@ function pageId(file) {
   return rel.replace(/\/_index$/, "")
 }
 // The manifest/cache key is per-OUTPUT (mid = id + variant suffix), and folds in
-// the rendered size so the two variants of one page never collide.
+// the rendered size so the two variants of one page never collide. `r` is the
+// template's own revision; JSON.stringify drops it when undefined, so templates
+// without one hash exactly as they did before TEMPLATE_REVISION existed.
 function cacheKey(page) {
-  return createHash("sha1").update(JSON.stringify({ t: page.template, f: page.fields, v: OG_TEMPLATE_VERSION, w: page.w, h: page.h })).digest("hex")
+  return createHash("sha1").update(JSON.stringify({ t: page.template, f: page.fields, v: OG_TEMPLATE_VERSION, r: TEMPLATE_REVISION[page.template], w: page.w, h: page.h })).digest("hex")
 }
 function listPages() {
   const pages = []

--- a/scripts/meta-images/events.mjs
+++ b/scripts/meta-images/events.mjs
@@ -19,7 +19,8 @@
 
 import { join } from "path"
 import {
-  REPO_ROOT, ASSET_DIR, clean, h, fitTitle, clampText, titleTextStyle, titleFont, svgDataUri, fileToImage,
+  REPO_ROOT, ASSET_DIR, clean, h, fitTitle, clampText, wrapLines, titleTextStyle, titleFont, bodyFont,
+  svgDataUri, fileToImage,
 } from "./lib.mjs"
 
 // --- Brand tokens (from the Figma frames / Pulumi palette) -------------------
@@ -48,7 +49,7 @@ function specFor(w, height) {
     return {
       family: "portrait", s: 1, bg: "portrait", padding: 40, mainGap: 23, textGap: 8,
       overline: { font: 20, ls: 1 }, secondary: { font: 30 }, title: { max: 40, min: 24, maxLines: 3 },
-      additional: { font: 20 }, divider: 2, logoH: 40, speaker: 216, speakersRowH: 359,
+      additional: { font: 20, maxLines: 3 }, divider: 2, logoH: 40, speaker: 216, speakersRowH: 359,
       button: { h: 72, px: 20, font: 24 },
     }
   }
@@ -58,14 +59,14 @@ function specFor(w, height) {
     return {
       family: "square", s, bg: "square", padding: r(40), mainGap: r(16), textGap: r(8),
       overline: { font: r(20), ls: s }, secondary: { font: r(30) }, title: { max: r(40), min: r(24), maxLines: 3 },
-      additional: { font: r(20) }, divider: Math.max(2, r(2)), logoH: r(44), speaker: r(224),
+      additional: { font: r(20), maxLines: 3, namesOnly: true }, divider: Math.max(2, r(2)), logoH: r(44), speaker: r(224),
       button: { h: r(72), px: r(20), font: r(24) },
     }
   }
   return {
     family: "landscape", s: 1, bg: "landscape", padding: 40, mainGap: 29, textGap: 16, columnGap: 40,
     overline: { font: 24, ls: 1.2 }, secondary: { font: 36 }, title: { max: 64, min: 34, maxLines: 3 },
-    additional: { font: 28 }, divider: 2, logoH: 44, speaker: 224,
+    additional: { font: 28, maxLines: 2 }, divider: 2, logoH: 44, speaker: 224,
     // Right gutter that keeps full-width (speaker-less) text clear of the
     // decorative accent lines in the top-right corner (they begin ~x1017).
     lineGutter: 220,
@@ -152,11 +153,34 @@ function buttonNode(text, spec) {
 // title is sized to the leftover vertical space (columnH minus every other row),
 // so it never clips in the tighter square / portrait stacks. ------------------
 const ADDITIONAL_LH = 1.2
-function mainColumn(fields, spec, font, textW, columnH) {
+const ADDITIONAL_MIN_LINES = 2 // the design's byline slot; a shorter byline doesn't grow the title
+const ADDITIONAL_MIN_F = 0.75 // shrink the byline this far to win a line back before clamping
+// Byline ("With Name - Role, Company and …"). Satori's -webkit-line-clamp does
+// NOT bound the box inside a fixed-height flex column: an over-long byline is
+// squeezed by the flex layout and sliced through the middle of a glyph. So
+// measure it here, shrink the font a little if that saves a line, and hard-clamp
+// the string — then render at the height we measured, so nothing can squeeze it.
+function fitAdditional(font, text, { fontSize, boxW, maxLines }) {
+  const words = text.split(/\s+/).filter(Boolean)
+  const min = Math.max(12, Math.round(fontSize * ADDITIONAL_MIN_F))
+  for (let f = fontSize; f >= min; f--) {
+    const lines = wrapLines(font, words, f, boxW, 0)
+    if (lines.length <= maxLines) return { fontSize: f, lines: lines.length, text }
+  }
+  return { fontSize: min, lines: maxLines, text: clampText(font, text, min, boxW, maxLines, 0) }
+}
+
+function mainColumn(fields, spec, font, bodyF, textW, columnH) {
   const g = spec.mainGap
+  // The tight square stack prefers the names-only byline when one is supplied.
+  const bylineText = clean((spec.additional.namesOnly && fields.additionalTextShort) || fields.additionalText)
+  const byline = bylineText
+    ? fitAdditional(bodyF, bylineText, { fontSize: spec.additional.font, boxW: textW, maxLines: spec.additional.maxLines })
+    : null
   const overlineH = fields.overline ? Math.ceil(spec.overline.font * 1.1) : 0
   const secondaryH = fields.secondaryTitle ? Math.ceil(spec.secondary.font * 1.1) : 0
-  const additionalH = fields.additionalText ? Math.ceil(spec.additional.font * ADDITIONAL_LH * 2) : 0 // reserve 2 lines
+  const bylineH = byline ? Math.ceil(byline.fontSize * ADDITIONAL_LH * byline.lines) : 0
+  const additionalH = byline ? Math.ceil(byline.fontSize * ADDITIONAL_LH * Math.max(ADDITIONAL_MIN_LINES, byline.lines)) : 0
   const logosH = fields.logos && fields.logos.length ? spec.logoH : 0
   const buttonH = fields.showButton ? spec.button.h : 0
   // Gaps between visible blocks: title + divider are always present.
@@ -178,8 +202,8 @@ function mainColumn(fields, spec, font, textW, columnH) {
     : null
   const titleEl = h("div", { style: { ...titleTextStyle(fit.fontSize, fit.lineClamp), color: C.title, width: "100%" } }, titleStr)
   const textBlock = h("div", { style: { display: "flex", flexDirection: "column", height: titleBoxH + (secondaryH ? secondaryH + spec.textGap : 0), justifyContent: "center", gap: spec.textGap, overflow: "hidden", width: "100%" } }, secondaryEl, titleEl)
-  const additionalEl = fields.additionalText
-    ? h("div", { style: { fontFamily: "Inter", fontWeight: 400, fontSize: spec.additional.font, lineHeight: ADDITIONAL_LH, color: C.title, display: "-webkit-box", WebkitBoxOrient: "vertical", WebkitLineClamp: 2, overflow: "hidden", width: "100%" } }, fields.additionalText)
+  const additionalEl = byline
+    ? h("div", { style: { fontFamily: "Inter", fontWeight: 400, fontSize: byline.fontSize, lineHeight: ADDITIONAL_LH, color: C.title, height: bylineH, flexShrink: 0, overflow: "hidden", width: "100%" } }, byline.text)
     : null
   const dividerEl = h("div", { style: { width: "100%", height: spec.divider, backgroundColor: C.divider } })
   const logosEl = logosRow(fields.logos, spec.logoH, spec.s, textW)
@@ -199,11 +223,12 @@ function frame(w, height, spec, content) {
     content)
 }
 
-// fields: { overline, title, secondaryTitle?, additionalText?, logos:[{uri,iw,ih}],
-//           speakers:[{uri}], showButton?, buttonText? }
+// fields: { overline, title, secondaryTitle?, additionalText?, additionalTextShort?,
+//           logos:[{uri,iw,ih}], speakers:[{uri}], showButton?, buttonText? }
+// additionalTextShort is the names-only byline; the square card uses it when present.
 export async function eventsTree(fields, { w, h: height }) {
   const spec = specFor(w, height)
-  const font = await titleFont()
+  const [font, bodyF] = await Promise.all([titleFont(), bodyFont()])
   const innerW = w - 2 * spec.padding
   const innerH = height - 2 * spec.padding
   const speakers = (fields.speakers || []).filter((sp) => sp && sp.uri).slice(0, MAX_SPEAKERS)
@@ -218,7 +243,7 @@ export async function eventsTree(fields, { w, h: height }) {
     // With no speakers, reserve a gutter so the title clears the top-right lines.
     const shift = n ? landscapeShift(n) : 0
     const textW = n ? innerW - shift - spec.columnGap - colW : innerW - spec.lineGutter
-    const main = mainColumn(fields, spec, font, textW, innerH)
+    const main = mainColumn(fields, spec, font, bodyF, textW, innerH)
     const right = n
       ? h("div", { style: { display: "flex", flexDirection: "column", justifyContent: "center", height: innerH, flexShrink: 0 } }, speakerCluster(speakers, sS, spec.s, "column"))
       : null
@@ -236,7 +261,7 @@ export async function eventsTree(fields, { w, h: height }) {
     // divider/logo lockup never overlaps the accent lines curving in from the
     // bottom-right (spec.padding already provides part of the clearance).
     const bottomH = n ? rowH + padTop : Math.round(190 * spec.s) - spec.padding
-    const main = mainColumn(fields, spec, font, innerW, innerH - bottomH)
+    const main = mainColumn(fields, spec, font, bodyF, innerW, innerH - bottomH)
     const bottom = n
       ? h("div", { style: { display: "flex", alignItems: "center", width: innerW, height: bottomH, paddingTop: padTop, flexShrink: 0 } }, speakerCluster(speakers, sS, spec.s))
       : null
@@ -253,7 +278,7 @@ export async function eventsTree(fields, { w, h: height }) {
   const top = n
     ? h("div", { style: { display: "flex", alignItems: "center", width: innerW, height: topH, flexShrink: 0 } }, speakerCluster(speakers, sS, spec.s))
     : h("div", { style: { width: innerW, height: topH, flexShrink: 0 } })
-  const main = mainColumn(fields, spec, font, innerW, innerH - topH - portraitGap)
+  const main = mainColumn(fields, spec, font, bodyF, innerW, innerH - topH - portraitGap)
   return frame(w, height, spec,
     h("div", { style: { display: "flex", flexDirection: "column", width: innerW, height: innerH, justifyContent: "space-between" } }, top, main))
 }
@@ -263,13 +288,14 @@ const MAX_SPEAKERS = 5 // photos shown; the byline lists every name regardless
 
 // Byline. One or two presenters include their role/company ("Name - Role, Company"),
 // since those fit; three or more list names only (with an Oxford comma, never
-// "and N others"). The byline clamps to two lines if it runs long.
-export function presentersLine(presenters) {
+// "and N others"). Pass { roles: false } for the names-only form the square card
+// uses — its text column is too narrow for two full "Name - Role, Company" runs.
+export function presentersLine(presenters, { roles = true } = {}) {
   const named = (presenters || []).filter((p) => p && clean(p.name))
   if (!named.length) return ""
-  const withRole = (p) => { const r = clean(p.role); return r ? `${clean(p.name)} - ${r}` : clean(p.name) }
-  if (named.length === 1) return `With ${withRole(named[0])}`
-  if (named.length === 2) return `With ${withRole(named[0])} and ${withRole(named[1])}`
+  const label = (p) => { const r = roles ? clean(p.role) : ""; return r ? `${clean(p.name)} - ${r}` : clean(p.name) }
+  if (named.length === 1) return `With ${label(named[0])}`
+  if (named.length === 2) return `With ${label(named[0])} and ${label(named[1])}`
   const names = named.map((p) => clean(p.name))
   return `With ${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`
 }
@@ -289,6 +315,7 @@ export function eventFieldsFromFrontmatter(fm, _id) {
     title: clean(fm.title),
     secondaryTitle: "",
     additionalText: presentersLine(presenters),
+    additionalTextShort: presentersLine(presenters, { roles: false }),
     logos: [resolveLogo("pulumi")].filter(Boolean),
     speakers,
     showButton: false,

--- a/scripts/meta-images/lib.mjs
+++ b/scripts/meta-images/lib.mjs
@@ -173,10 +173,13 @@ export const FONT_SPECS = [
 ]
 export const loadFonts = once(() => FONT_SPECS.map((s) => ({ name: s.name, data: readFileSync(s.file), weight: s.weight, style: s.style })))
 
-// Inter Semibold parsed for title measurement (lazy: parsed on first render).
-// once() caches the in-flight promise so the font is parsed exactly once.
-export const titleFont = once(async () => {
+// Inter Semibold / Regular parsed for text measurement (lazy: parsed on first
+// render). once() caches the in-flight promise so each font is parsed exactly
+// once. Measure with the weight you render: semibold runs a few percent wider.
+const parseFont = (file) => once(async () => {
   const { default: opentype } = await import("opentype.js")
-  const b = readFileSync(join(FONT_DIR, "inter-semibold.woff"))
+  const b = readFileSync(join(FONT_DIR, file))
   return opentype.parse(b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength))
 })
+export const titleFont = parseFont("inter-semibold.woff")
+export const bodyFont = parseFont("inter-regular.woff")

--- a/scripts/meta-images/render-event.mjs
+++ b/scripts/meta-images/render-event.mjs
@@ -12,6 +12,7 @@
 //     "title": "Advanced CI/CD for AWS",     // required
 //     "secondaryTitle": "",                  // hidden unless set
 //     "additionalText": "With Jane Doe - Staff Engineer, Acme",
+//     "additionalTextShort": "With Jane Doe",  // names-only byline, used by the square card
 //     "showButton": false,                   // "Register" pill, hidden by default
 //     "buttonText": "Register",
 //     "speakers": ["/images/people/jane.jpg", "/abs/path.png", "data:image/png;base64,..."],
@@ -68,8 +69,13 @@ const logos = (cfg.logos && cfg.logos.length ? cfg.logos : ["pulumi"])
 for (const p of cfg.logos || []) if (!resolveLogo(p, [cfgDir])) console.error(`  warning: could not resolve logo: ${p}`)
 
 // additionalText may be supplied directly, or derived from a presenters list.
+// A presenters list also yields the names-only byline the square card prefers;
+// additionalTextShort can be supplied directly alongside a literal additionalText.
 const additionalText = cfg.additionalText != null ? cfg.additionalText
   : cfg.presenters ? presentersLine(cfg.presenters)
+  : ""
+const additionalTextShort = cfg.additionalTextShort != null ? cfg.additionalTextShort
+  : cfg.presenters ? presentersLine(cfg.presenters, { roles: false })
   : ""
 
 const fields = {
@@ -77,6 +83,7 @@ const fields = {
   title: (cfg.title || "").toString().trim(),
   secondaryTitle: (cfg.secondaryTitle || "").toString().trim(),
   additionalText,
+  additionalTextShort,
   logos,
   speakers,
   showButton: !!cfg.showButton,


### PR DESCRIPTION
### Proposed changes

On the square event/workshop social card, a long presenter byline was cut through the middle of a glyph — Satori's `-webkit-line-clamp` doesn't bound a box inside a fixed-height flex column, so a byline that ran past its 2-line reservation got squeezed by the flex layout and sliced (portrait had the same bug). The byline is now measured with `wrapLines` (against Inter Regular, via a new `bodyFont` export), shrunk up to 25% if that wins back a line, hard-clamped at a word boundary as a last resort, and rendered at an explicit height with `flexShrink: 0`, so it can't be clipped mid-glyph at any size. Square and portrait also get a 3-line byline budget, and the square sizes now use a names-only byline (`With A and B` — new optional `additionalTextShort` field, derived automatically from a `presenters` array) since their text column is too narrow for two full "Name - Role, Company" runs; the other three sizes are unchanged.

Cache invalidation is scoped with a new per-template `TEMPLATE_REVISION` map instead of bumping the global `OG_TEMPLATE_VERSION`, so only events cards re-render and every other section keeps its cache — verified against a baseline built with the old code (120 events cards re-rendered; the 97 tutorials/case-studies cards and the events index card stayed cached, and unaffected cards were byte-identical).