### PR TITLE
Exclude queue wait from the slow-build alert

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           # Clear any stale queue-wait record so it can't mask a slow build on a
           # reused workspace; await-in-progress.js rewrites it during the build.
-          rm -f .build-queue-wait-seconds
+          rm -f "${CI_BUILD_QUEUE_WAIT_FILE:-.build-queue-wait-seconds}"
           echo "CI_BUILD_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
 
       - name: Build and deploy

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -116,7 +116,11 @@ jobs:
             hugo-resources-
 
       - name: Record build start time
-        run: echo "CI_BUILD_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+        run: |
+          # Clear any stale queue-wait record so it can't mask a slow build on a
+          # reused workspace; await-in-progress.js rewrites it during the build.
+          rm -f .build-queue-wait-seconds
+          echo "CI_BUILD_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
 
       - name: Build and deploy
         run: make ci_push
@@ -134,6 +138,8 @@ jobs:
       # Duration guardrail: the July 2026 regression sat unnoticed for three
       # weeks because nothing watched build time. Warn in Slack when a
       # successful build runs long so the next regression is caught in days.
+      # Time the step spends queued behind earlier runs of this workflow is
+      # subtracted before the comparison; see the script's header comment.
       - name: Alert on slow build
         if: success()
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ cypress/screenshots
 # Ignore the files we generate during the build and deployment process.
 origin-bucket-metadata.json
 redirects.txt
+# Seconds spent waiting for earlier runs of the deploy workflow to finish
+# (written by scripts/await-in-progress.js, read by the build-duration alert).
+/.build-queue-wait-seconds
 
 # Ignore vendored Hugo modules.
 _vendor/

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -522,7 +522,7 @@ Complete production deployment pipeline.
 1. Build site: `./scripts/build-site.sh`
 2. Sync to S3: `./scripts/sync-and-test-bucket.sh update`
 3. Generate search index
-4. Wait for in-progress operations: `node await-in-progress.js`
+4. Wait for in-progress operations: `node await-in-progress.js` (records the time spent waiting in `.build-queue-wait-seconds`, which `scripts/ci-build-duration-alert.sh` subtracts so a queued run isn't reported as a slow build)
 5. Pulumi infrastructure update: `./scripts/run-pulumi.sh`
 6. Generate S3 redirects: `./scripts/make-s3-redirects.sh`
 

--- a/scripts/await-in-progress.js
+++ b/scripts/await-in-progress.js
@@ -8,8 +8,10 @@ const pollIntervalMs = 60000;
 // Where we record the number of seconds this run spent parked in the queue. The
 // build-duration alert (scripts/ci-build-duration-alert.sh) reads this file and subtracts
 // the wait from the wall-clock time of the "Build and deploy" step, so a backed-up queue
-// doesn't get reported in Slack as a slow build. A missing file means "no wait."
-const queueWaitFile = path.join(__dirname, "..", ".build-queue-wait-seconds");
+// doesn't get reported in Slack as a slow build. A missing file means "no wait." Honors
+// CI_BUILD_QUEUE_WAIT_FILE so the writer and the alert script's reader can't drift apart.
+const queueWaitFile = process.env.CI_BUILD_QUEUE_WAIT_FILE
+    || path.join(__dirname, "..", ".build-queue-wait-seconds");
 
 // Wait for any in-progress runs of the same workflow on this branch to complete before
 // proceeding. In other words, if the current workflow is an instance of the "foo"

--- a/scripts/await-in-progress.js
+++ b/scripts/await-in-progress.js
@@ -1,4 +1,15 @@
+const fs = require("fs");
+const path = require("path");
 const { Octokit } = require("@octokit/rest");
+
+// How long to sleep between checks for other in-progress runs.
+const pollIntervalMs = 60000;
+
+// Where we record the number of seconds this run spent parked in the queue. The
+// build-duration alert (scripts/ci-build-duration-alert.sh) reads this file and subtracts
+// the wait from the wall-clock time of the "Build and deploy" step, so a backed-up queue
+// doesn't get reported in Slack as a slow build. A missing file means "no wait."
+const queueWaitFile = path.join(__dirname, "..", ".build-queue-wait-seconds");
 
 // Wait for any in-progress runs of the same workflow on this branch to complete before
 // proceeding. In other words, if the current workflow is an instance of the "foo"
@@ -25,30 +36,49 @@ async function waitForInProgressRuns() {
     const workflows = await octokit.rest.actions.listRepoWorkflows({ owner, repo });
     const workflow_id = workflows.data.workflows.find(workflow => workflow.name === workflowName).id;
 
-    // Fetch a paginated list of in-progress runs of the current workflow.
-    const runs = await octokit.paginate(
-      octokit.rest.actions.listWorkflowRuns.endpoint.merge({
-        owner,
-        repo,
-        branch,
-        workflow_id,
-        status,
-      })
-    );
+    let waitedMs = 0;
 
-    // Sort in-progress runs descendingly, excluding the current one.
-    const recent = runs
-        .sort((a, b) => b.id - a.id)
-        .filter(run => run.id < currentRunID);
+    while (true) {
+        // Fetch a paginated list of in-progress runs of the current workflow.
+        const runs = await octokit.paginate(
+          octokit.rest.actions.listWorkflowRuns.endpoint.merge({
+            owner,
+            repo,
+            branch,
+            workflow_id,
+            status,
+          })
+        );
 
-    console.log(`Found ${recent.length} other ${workflowName} job(s) running on branch ${branch}.`);
+        // Sort in-progress runs descendingly, excluding the current one.
+        const recent = runs
+            .sort((a, b) => b.id - a.id)
+            .filter(run => run.id < currentRunID);
 
-    if (recent.length > 0) {
+        console.log(`Found ${recent.length} other ${workflowName} job(s) running on branch ${branch}.`);
+
+        if (recent.length === 0) {
+            break;
+        }
+
         const [ mostRecent ] = recent;
         console.log(`Waiting for ${mostRecent.html_url} to complete before continuing.`);
-        await Promise.resolve(setTimeout(waitForInProgressRuns, 60000)); // One minute.
-    } else {
-        console.log("Continuing.");
+        await new Promise(resolve => setTimeout(resolve, pollIntervalMs)); // One minute.
+        waitedMs += pollIntervalMs;
+    }
+
+    const waitedSeconds = Math.round(waitedMs / 1000);
+    console.log(`Continuing. Waited ${waitedSeconds}s for other runs to finish.`);
+    recordQueueWait(waitedSeconds);
+}
+
+// Records the queue wait for the build-duration alert. Best-effort: failing to write this
+// file must never fail the deploy, so we log and move on.
+function recordQueueWait(seconds) {
+    try {
+        fs.writeFileSync(queueWaitFile, `${seconds}\n`);
+    } catch (error) {
+        console.log(`Unable to record the queue wait in ${queueWaitFile}: ${error.message}`);
     }
 }
 

--- a/scripts/ci-build-duration-alert.sh
+++ b/scripts/ci-build-duration-alert.sh
@@ -6,10 +6,18 @@
 # before anyone noticed): it never fails the build, and it stays quiet when the
 # build is healthy.
 #
+# Only time spent actually building and deploying counts toward the threshold.
+# The step also parks in scripts/await-in-progress.js waiting for older runs of
+# this workflow to finish, and when pushes to master stack up that queue wait can
+# add ten-plus minutes to the step without the build itself being any slower.
+# await-in-progress.js records the wait in $CI_BUILD_QUEUE_WAIT_FILE and we
+# subtract it here, so a backed-up queue no longer reads as a slow build.
+#
 # Expects:
 #   CI_BUILD_START_EPOCH               epoch seconds recorded just before the build step
 #   SLACK_WEBHOOK_URL                  incoming webhook for the alert channel (docs-ops)
 #   BUILD_DURATION_THRESHOLD_MINUTES   alert threshold (default 20)
+#   CI_BUILD_QUEUE_WAIT_FILE           queue-wait record (default ./.build-queue-wait-seconds)
 
 set -o nounset
 
@@ -19,12 +27,30 @@ if [ -z "${CI_BUILD_START_EPOCH:-}" ]; then
 fi
 
 threshold_minutes="${BUILD_DURATION_THRESHOLD_MINUTES:-20}"
+queue_wait_file="${CI_BUILD_QUEUE_WAIT_FILE:-./.build-queue-wait-seconds}"
 elapsed_seconds=$(( $(date +%s) - CI_BUILD_START_EPOCH ))
-elapsed_minutes=$(( elapsed_seconds / 60 ))
 
-echo "Build step took ${elapsed_minutes}m ($((elapsed_seconds))s); threshold is ${threshold_minutes}m."
+# A missing or malformed record means no measured wait, which is the safe default:
+# we then compare the full elapsed time against the threshold, as before.
+queue_seconds=0
+if [ -r "$queue_wait_file" ]; then
+    read -r queue_seconds < "$queue_wait_file" || true
+fi
+case "${queue_seconds:-}" in
+    "" | *[!0-9]*) queue_seconds=0 ;;
+esac
 
-if [ "$elapsed_seconds" -le $(( threshold_minutes * 60 )) ]; then
+build_seconds=$(( elapsed_seconds - queue_seconds ))
+if [ "$build_seconds" -lt 0 ]; then
+    build_seconds=0
+fi
+
+build_minutes=$(( build_seconds / 60 ))
+queue_minutes=$(( queue_seconds / 60 ))
+
+echo "Build and deploy took ${build_minutes}m (${build_seconds}s), excluding ${queue_minutes}m (${queue_seconds}s) of queue wait; threshold is ${threshold_minutes}m."
+
+if [ "$build_seconds" -le $(( threshold_minutes * 60 )) ]; then
     exit 0
 fi
 
@@ -33,8 +59,13 @@ if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
     exit 0
 fi
 
+queue_note=""
+if [ "$queue_seconds" -gt 0 ]; then
+    queue_note=" Excludes ${queue_minutes}m spent waiting for an earlier run to finish."
+fi
+
 run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-pulumi/docs}/actions/runs/${GITHUB_RUN_ID:-}"
-message=":hourglass_flowing_sand: Build and deploy took *${elapsed_minutes}m*, longer than usual (threshold: ${threshold_minutes}m). Hugo's --templateMetrics output in the job log can help identify what was slow. <${run_url}|View run>"
+message=":hourglass_flowing_sand: Build and deploy took *${build_minutes}m*, longer than usual (threshold: ${threshold_minutes}m).${queue_note} Hugo's --templateMetrics output in the job log can help identify what was slow. <${run_url}|View run>"
 
 payload=$(printf '{"channel": "docs-ops", "username": "docsbot", "icon_url": "https://www.pulumi.com/logos/brand/avatar-on-white.png", "text": "%s"}' "$message")
 


### PR DESCRIPTION
### Proposed changes

docsbot has been firing runs of "Build and deploy took *N*m, longer than usual" in #docs-ops with steadily climbing durations (21m, 23m, 25m, 28m, 31m…). That climb is the signature of a queue backing up, not of a build getting slower.

The cause: the "Build and deploy" step doesn't only build and deploy. Partway through `make ci_push`, `scripts/await-in-progress.js` parks and polls once a minute until any older run of the same workflow on the same branch finishes (`scripts/ci-push.sh:12`). When pushes to `master` stack up, each run waits longer than the one before it. The duration alert timed the whole step — `CI_BUILD_START_EPOCH` is stamped just before `make ci_push` and read after it — so that wait counted as build time and tripped the 20-minute threshold.

This change makes the alert measure only the build and deploy work:

- **`scripts/await-in-progress.js`** records the seconds it spent waiting to `.build-queue-wait-seconds` (gitignored). Recording it required restructuring the `setTimeout` recursion into a `while` loop so the poller has a terminating frame to report from; as a side effect the workflow ID is now resolved once instead of on every poll.
- **`scripts/ci-build-duration-alert.sh`** subtracts that wait from the step's wall-clock time and compares the remainder against `BUILD_DURATION_THRESHOLD_MINUTES`. When the wait is non-zero, the Slack message notes how much was excluded ("Excludes 14m spent waiting for an earlier run to finish."). A missing or malformed record falls back to timing the whole step, so nothing regresses if the file is never written.
- **`.github/workflows/build-and-deploy.yml`** clears a stale record before stamping the start time, so a reused workspace can't mask a genuinely slow build.

The threshold stays at 20 minutes; only what's being measured against it changes. Genuine regressions still alert — a 26m build behind a 5m queue is still reported as 26m.

Verified by running the alert script against synthetic start times and queue records (queued-but-fast stays quiet; slow-with-queue and slow-without-record both alert; malformed, absent, newline-less, and larger-than-elapsed records all handled), and by running the poller against a stubbed Octokit to confirm the loop terminates and writes the wait it actually observed.