### PR TITLE
Second hcl/terraform workshop that's EU friendly

### DIFF
--- a/content/events/pulumi-for-all-your-iac-terraform-hcl-eu/index.md
+++ b/content/events/pulumi-for-all-your-iac-terraform-hcl-eu/index.md
@@ -1,6 +1,6 @@
 ---
 # Name of the event, <= 60 characters
-title: "Pulumi for All Your IaC: Including Terraform and HCL (EU-Friendly)"
+title: "Pulumi for All Your IaC: Including Terraform and HCL (EMEA)"
 
 meta_desc: Connect existing Terraform workloads to Pulumi Cloud, reuse Terraform modules in Pulumi programs, and write IaC in OpenTofu-compatible HCL — live workshop.
 

--- a/content/events/pulumi-for-all-your-iac-terraform-hcl-eu/index.md
+++ b/content/events/pulumi-for-all-your-iac-terraform-hcl-eu/index.md
@@ -1,0 +1,72 @@
+---
+# Name of the event, <= 60 characters
+title: "Pulumi for All Your IaC: Including Terraform and HCL (EU-Friendly)"
+
+meta_desc: Connect existing Terraform workloads to Pulumi Cloud, reuse Terraform modules in Pulumi programs, and write IaC in OpenTofu-compatible HCL — live workshop.
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# External events will link to an external page instead of an event
+# landing/registration page.
+external: false
+block_external_search_index: false
+allow_long_title: true
+
+# The url slug for the event landing page.
+url_slug: pulumi-for-all-your-iac-terraform-hcl-eu
+
+# The event type (workshop, webinar, talk).
+event_type: workshop
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-08-26T07:00:00.000-07:00
+
+# Duration of the event.
+duration: 60 minutes
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: virtual
+
+# Description of the event.
+description: |
+    Your platform team spent a decade building production Terraform, and you can't just throw it all away because you want to embrace the agentic future of infrastructure. Here's the thing: you don't have to choose because Pulumi Cloud now supports the Terraform estate you already have. There's no migration project, no rewrite and no new deployment pattern to learn.
+
+    In this live demo, Daniel walks through three scenarios: pointing an existing Terraform Enterprise workload at Pulumi Cloud and watching remote plans, approvals, and deployments keep working exactly as they did before; reusing existing Terraform modules inside a brand-new Pulumi program; and writing infrastructure in HCL as a fully OpenTofu-compatible, first-class Pulumi language.
+learn:
+    - How to turn on guardrails Terraform alone doesn't give you using Neo AI code review.
+    - How to reuse existing Terraform modules inside a new Pulumi program.
+    - How to write Pulumi IaC in HCL. 100% OpenTofu-compatible, with access to the full Pulumi provider ecosystem.
+
+# The event presenters
+presenters:
+    - name: Daniel Perlovsky
+      role: Principal Product Manager, Pulumi
+      photo: /images/team/daniel-perlovsky.jpg
+    - name: Engin Diri
+      role: Senior Solutions Architect, Pulumi
+      photo: /images/team/engin-diri.jpg
+
+# case-sensitive
+tags:
+    level: Beginner # Beginner, Intermediate, Advanced
+    topics: ["Pulumi Neo", "Infrastructure as Code", "DevOps"]
+    languages: [HCL]
+    clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: 6c17ee84-c999-481c-8f5f-86c348bfa063
+    salesforce_campaign_id: 701PQ00000ygwGQYAY
+---

--- a/data/announcements.yml
+++ b/data/announcements.yml
@@ -63,7 +63,7 @@ announcements:
       href: "/events/autonomous-agents-need-guardrails-openclaw/?utm_source=announcement-banner&utm_medium=website&utm_campaign=openclaw-guardrails-webinar"
     dismissible: true
   - id: event-intro-to-esc-secrets-2026-08-Wt3pL9
-    active: true
+    active: false
     display: both
     badge: Event
     text: "**Live workshop · Aug 5:** Best practices for managing secrets — an introduction to Pulumi ESC."


### PR DESCRIPTION
### Proposed changes

Adds the event landing page for the second/EU friendly timezone for the hcl and terraform workshop on 2026-08-26, 7:00 AM PT (60 min), presented by Daniel Perlovsky

Slug: /events/pulumi-for-all-your-iac-terraform-hcl-eu/
Gated, virtual, level Beginner, topics: AI · DevOps · Developer Productivity

### Unreleased product version (optional)

N/A

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

pulumi/marketing#1814
