### PR TITLE
Add seven 2026 events to the events listing

### DIFF
--- a/content/events/aws-reinvent-2026/index.md
+++ b/content/events/aws-reinvent-2026/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the event, <= 60 characters
+title: AWS re:Invent 2026
+meta_desc: "Visit Pulumi at booth #1432 at AWS re:Invent 2026 in Las Vegas."
+meta_image:
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: https://aws.amazon.com/events/reinvent/
+
+# The event type (workshop, webinar, talk).
+event_type: event
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-11-30T09:00:00-08:00
+
+# Duration of the event.
+duration: 5 days
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: Las Vegas, NV
+
+# Description of the event.
+description: |
+    AWS's flagship conference, bringing together cloud engineers, architects, and enterprise decision-makers. Stop by booth #1432 to see how enterprises build on AWS in real languages — from first stack to org-wide platform — with full AWS coverage, policy, RBAC, and secrets management with Pulumi ESC, proven at Snowflake, BMW, and Mercedes.
+
+# The event presenters
+presenters:
+
+# case-sensitive
+tags:
+    level: # Beginner, Intermediate, Advanced
+    topics: []
+    languages: []
+    clouds: ["AWS"]
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---

--- a/content/events/camp-ai-agents-at-work-2026/index.md
+++ b/content/events/camp-ai-agents-at-work-2026/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the event, <= 60 characters
+title: "Camp AI: Agents at Work"
+meta_desc: Network with startups and leaders building AI technologies at Camp AI in Seattle.
+meta_image:
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: https://luma.com/camp-ai-august-2026
+
+# The event type (workshop, webinar, talk).
+event_type: event
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-08-06T17:30:00-07:00
+
+# Duration of the event.
+duration: 3 hours
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: Seattle, WA
+
+# Description of the event.
+description: |
+    Join us for a chance to network with up-and-coming startups and leaders developing AI technologies.
+
+# The event presenters
+presenters:
+
+# case-sensitive
+tags:
+    level: # Beginner, Intermediate, Advanced
+    topics: ["AI"]
+    languages: []
+    clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---

--- a/content/events/devopsdays-dallas-2026/index.md
+++ b/content/events/devopsdays-dallas-2026/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the event, <= 60 characters
+title: DevOpsDays Dallas 2026
+meta_desc: Meet Pulumi at DevOpsDays Dallas 2026 and see how to write infrastructure in the languages you already use.
+meta_image:
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: https://devopsdays.org/events/2026-dallas/registration
+
+# The event type (workshop, webinar, talk).
+event_type: event
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-09-28T09:00:00-05:00
+
+# Duration of the event.
+duration: 2 days
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: Dallas, TX
+
+# Description of the event.
+description: |
+    Check in with us in Dallas to see how Pulumi lets you write infrastructure in the languages you already use, with no new DSL, across any cloud and Kubernetes.
+
+# The event presenters
+presenters:
+
+# case-sensitive
+tags:
+    level: # Beginner, Intermediate, Advanced
+    topics: ["DevOps"]
+    languages: []
+    clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---

--- a/content/events/enterprise-devops-summit-2026/index.md
+++ b/content/events/enterprise-devops-summit-2026/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the event, <= 60 characters
+title: Enterprise DevOps Summit 2026
+meta_desc: Join Pulumi at the Enterprise DevOps Summit 2026 in Berlin for IaC and GitOps at enterprise scale.
+meta_image:
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: https://www.we-conect.com/events/enterprise-devops-summit-2026/
+
+# The event type (workshop, webinar, talk).
+event_type: event
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-11-30T09:00:00+01:00
+
+# Duration of the event.
+duration: 2 days
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: Berlin, Germany
+
+# Description of the event.
+description: |
+    Join us to see how Pulumi delivers infrastructure as code and GitOps at scale in real programming languages, with policy as code, governed deployments across hybrid infrastructure, and AI- and agent-ready workflows.
+
+# The event presenters
+presenters:
+
+# case-sensitive
+tags:
+    level: # Beginner, Intermediate, Advanced
+    topics: ["DevOps", "Infrastructure as Code", "GitOps"]
+    languages: []
+    clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---

--- a/content/events/fully-connected-2026/index.md
+++ b/content/events/fully-connected-2026/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the event, <= 60 characters
+title: Fully Connected 2026
+meta_desc: Join Pulumi at CoreWeave's Fully Connected 2026, the flagship AI-infrastructure event in San Francisco.
+meta_image:
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: https://coreweave.com/fully-connected-2026
+
+# The event type (workshop, webinar, talk).
+event_type: event
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-09-29T09:00:00-07:00
+
+# Duration of the event.
+duration: 3 days
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: San Francisco, CA
+
+# Description of the event.
+description: |
+    Join us at CoreWeave's flagship AI-infrastructure event to see how Pulumi standardizes the way AI and cloud infrastructure gets built and shipped.
+
+# The event presenters
+presenters:
+
+# case-sensitive
+tags:
+    level: # Beginner, Intermediate, Advanced
+    topics: ["AI", "GPU Infrastructure", "Infrastructure as Code"]
+    languages: []
+    clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---

--- a/content/events/kubecon-north-america-2026/index.md
+++ b/content/events/kubecon-north-america-2026/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the event, <= 60 characters
+title: KubeCon + CloudNativeCon NA 2026
+meta_desc: Meet Pulumi at KubeCon + CloudNativeCon North America 2026 in Salt Lake City.
+meta_image:
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/
+
+# The event type (workshop, webinar, talk).
+event_type: event
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-11-09T09:00:00-07:00
+
+# Duration of the event.
+duration: 4 days
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: Salt Lake City, UT
+
+# Description of the event.
+description: |
+    The premier cloud-native and Kubernetes gathering, bringing together platform engineers, contributors, and vendors from across the CNCF ecosystem. Join us to see how Pulumi manages Kubernetes and the cloud around it in one code-first, policy-as-code workflow.
+
+# The event presenters
+presenters:
+
+# case-sensitive
+tags:
+    level: # Beginner, Intermediate, Advanced
+    topics: ["Kubernetes", "Platform Engineering"]
+    languages: []
+    clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---

--- a/content/events/platform-engineering-day-2026/index.md
+++ b/content/events/platform-engineering-day-2026/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the event, <= 60 characters
+title: Platform Engineering Day 2026
+meta_desc: Join Pulumi at Platform Engineering Day, the CNCF co-located event at KubeCon NA in Salt Lake City.
+meta_image:
+
+# A featured event will display first in the list.
+featured: false
+
+# Events with unlisted as true will not be shown on the event list
+unlisted: false
+
+# Gated events will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# External events will link to an external page instead of an event
+# landing/registration page. If the event is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the event page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the event landing page. If this is an external
+# event, use the external URL as the value here.
+url_slug: https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/platform-engineering-day/
+
+# The event type (workshop, webinar, talk).
+event_type: event
+
+# URL for embedding a URL for ungated events.
+youtube_url:
+
+# Sortable date. The datetime Hugo will use to sort the events in date order.
+sortable_date: 2026-11-09T09:00:00-07:00
+
+# Duration of the event.
+duration: 1 day
+
+# "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+location: Salt Lake City, UT
+
+# Description of the event.
+description: |
+    The CNCF's dedicated day for platform engineers building internal developer platforms and golden paths, co-located with KubeCon NA in Salt Lake City. Join us to see how Pulumi powers IDPs — reusable components and templates, self-service via Pulumi Cloud, and policy guardrails built in.
+
+# The event presenters
+presenters:
+
+# case-sensitive
+tags:
+    level: # Beginner, Intermediate, Advanced
+    topics: ["Platform Engineering", "Kubernetes"]
+    languages: []
+    clouds: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id:
+    salesforce_campaign_id:
+---


### PR DESCRIPTION
### Proposed changes

Adds event pages for seven upcoming 2026 events: AWS re:Invent, Camp AI: Agents at Work, DevOpsDays Dallas, Enterprise DevOps Summit, Fully Connected, KubeCon + CloudNativeCon NA, and Platform Engineering Day. All seven are external events, so each links out to the organizer's registration page and sets `block_external_search_index: true`. No layout or template changes — content only.

### Fact verification

All dates, locations, and durations verified against the organizers' pages; all `url_slug` links return HTTP 200.

| Event | Dates | Location | Source |
| --- | --- | --- | --- |
| AWS re:Invent 2026 | Nov 30 – Dec 4 (5 days) | Las Vegas, NV | [aws.amazon.com/events/reinvent](https://aws.amazon.com/events/reinvent/) |
| Camp AI: Agents at Work | Aug 6, 5:30–8:30 PM (3 hours) | Seattle, WA | [Luma event page](https://luma.com/camp-ai-august-2026) |
| DevOpsDays Dallas 2026 | Sep 28–29 (2 days) | Dallas, TX | [devopsdays.org](https://devopsdays.org/events/2026-dallas/welcome/) |
| Enterprise DevOps Summit 2026 | Nov 30 – Dec 1 (2 days) | Berlin, Germany | [we-conect.com](https://www.we-conect.com/events/enterprise-devops-summit-2026/) |
| Fully Connected 2026 (CoreWeave) | Sep 29 – Oct 1 (3 days) | San Francisco, CA (Moscone) | [coreweave.com](https://www.coreweave.com/fully-connected-2026) |
| KubeCon + CloudNativeCon NA 2026 | Nov 9–12 (4 days) | Salt Lake City, UT | [LF Events](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) |
| Platform Engineering Day 2026 | Nov 9 (1 day, KubeCon co-located) | Salt Lake City, UT | [LF Events](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/platform-engineering-day/) |

Timezone offsets on `sortable_date` match each venue's UTC offset for the event date (PST/MST/CDT/PDT/CET). The re:Invent booth number (#1432) comes from internal event planning and isn't externally verifiable.

Resolves: https://github.com/pulumi/marketing/issues/1787
