### PR TITLE
Replace the animated docs link underline with a plain hover underline

### DIFF
--- a/theme/src/scss/docs/_docs-main.scss
+++ b/theme/src/scss/docs/_docs-main.scss
@@ -54,18 +54,11 @@ body.section-registry {
         p a:not(.btn),
         ul li a[href]  {
             color: var(--docs-link, var(--color-violet-primary));
-            background: linear-gradient(90deg,rgba(142, 143, 151, 0),rgba(142, 143, 151, 0)),linear-gradient(90deg,var(--color-gray-500),var(--color-gray-500));
-            background-position: 100% 100%,0 100%;
-            background-repeat: no-repeat;
-            background-size: 100% 0.1em,0 0.1em;
-            padding-bottom: 0.2rem;
-            transition: background-size .3s;
-            transition-timing-function: ease-in;
 
             &:hover {
                 color: var(--color-violet-800);
-                text-decoration: none;
-                background-size: 0 0.1em,100% 0.1em;
+                text-decoration: underline;
+                text-underline-offset: 2px;
             }
         }
 


### PR DESCRIPTION
### Proposed changes

Docs content links (`section.docs-content p a` / `ul li a[href]`) used a two-layer `linear-gradient` background animated via `background-size` to sweep a gray underline in from the left on hover. This replaces that effect with a standard `text-decoration: underline` and a 2px `text-underline-offset`, and drops the `padding-bottom` that reserved space for the animated rule. Link colors are unchanged in both light and dark mode — the dark-mode override in `_docs-theme.scss` only sets `color`, so it carries through untouched.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A