### PR TITLE
Fix the version syntax for installing converted Terraform module packages

### DIFF
--- a/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
+++ b/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
@@ -89,7 +89,7 @@ Any directory containing `.tf` files and optionally `variables.tf` and `outputs.
 If your organization publishes Terraform modules to the [Pulumi Cloud registry](/docs/idp/concepts/terraform-modules/), every published version is converted into a Pulumi package for you. Install it by package name, which is the module's name and system joined with a hyphen. The system is the last segment of the module's address, naming what the module provisions, such as `aws` or `azurerm`:
 
 ```bash
-pulumi package add <name>-<system> [<version>]
+pulumi package add <name>-<system>[@<version>]
 ```
 
 A module published as `acme-corp/vpc/aws` installs as `vpc-aws`. This is the same as any other Pulumi package: you get a generated SDK in your language, an [API reference](/docs/idp/concepts/private-registry/#api-documentation) on the package's page, and [usage tracking](/docs/idp/concepts/private-registry/#usage-tracking) showing which of your stacks depend on it and which are behind the latest version. Installing a converted package requires Pulumi CLI 3.248.0 or newer; see [Download & Install Pulumi](/docs/install/) to upgrade.

--- a/content/docs/idp/concepts/terraform-modules.md
+++ b/content/docs/idp/concepts/terraform-modules.md
@@ -97,7 +97,7 @@ Under the hood, the conversion job derives the package schema by reading the mod
 Once a version has converted, install it by package name:
 
 ```bash
-pulumi package add <name>-<system> [<version>]
+pulumi package add <name>-<system>[@<version>]
 ```
 
 The module is a [multi-language component](https://github.com/pulumi/pulumi-hcl/blob/master/docs/mlc.md): its `variable` blocks become typed inputs, its `output` blocks become typed outputs, and Pulumi generates an SDK in the language your project uses. The version you pass is persisted in `Pulumi.yaml`, so `pulumi install` regenerates the same pinned version.


### PR DESCRIPTION
`pulumi package add` takes a package reference as `PLUGIN[@VERSION]`, so a
version must be joined to the package name with `@`. Two pages documented the
Pulumi Cloud registry install as `pulumi package add <name>-<system> [<version>]`,
where the trailing argument would be parsed as a provider parameter rather
than a version pin.

The separate-argument form elsewhere is correct and unchanged: those are
parameterized providers (`terraform-provider`, `terraform-module`, `hcl`)
whose trailing arguments really are provider parameters.

## Test plan

1. Automated checks
   - `node scripts/lint/lint-markdown.js`: 1840 files parsed, 0 errors
2. Manual checks
   - Grepped every `pulumi package add` occurrence in the repo; the only two
     using a bare positional version for a package name were the two fixed here