### PR TITLE
Cover the module and registry paths in the Terraform-user docs

### DIFF
--- a/content/blog/terraform-to-pulumi-cloud-hands-on/index.md
+++ b/content/blog/terraform-to-pulumi-cloud-hands-on/index.md
@@ -316,7 +316,7 @@ Resources:
 
 Having a language-specific, locally managed SDK at hand comes with many benefits, including IDE support, typed inputs and outputs, and more — but there may be times when you'll prefer a simpler or more dynamic option. In these situations, you can instead choose to load the module at runtime.
 
-In TypeScript, you'd do that with the `@pulumi/hcl` module. Try that now by installing it in your project:
+In TypeScript, you'd do that with the [`@pulumi/hcl`](/registry/packages/hcl/) module. Try that now by installing it in your project:
 
 ```bash
 $ npm install @pulumi/hcl

--- a/content/docs/iac/comparisons/cdktf.md
+++ b/content/docs/iac/comparisons/cdktf.md
@@ -41,7 +41,7 @@ CDK for Terraform (CDKTF) was a HashiCorp project, released in 2020 and [depreca
 | Feature | Pulumi | CDKTF |
 | --- | --- | --- |
 | Language support | Python, TypeScript, JavaScript, Go, C#, Java, and YAML | TypeScript, Python, Go, C#, Java |
-| Cloud and service support | [Pulumi Registry](/registry/) of packages, including [bridged, native, parameterized, and dynamic providers](/docs/iac/concepts/providers/#types-of-providers); first-party native providers for [Kubernetes](/registry/packages/kubernetes/) and [Azure Native](/registry/packages/azure-native/); [any Terraform provider](/docs/iac/concepts/providers/any-terraform-provider/) can be adapted into a Pulumi provider, and [Terraform modules](/docs/iac/using-pulumi/extending-pulumi/use-terraform-module/) can be consumed directly | Terraform providers only, accessed through project-specific SDKs generated on demand by `cdktf get` |
+| Cloud and service support | [Pulumi Registry](/registry/) of packages, including [bridged, native, parameterized, and dynamic providers](/docs/iac/concepts/providers/#types-of-providers); first-party native providers for [Kubernetes](/registry/packages/kubernetes/) and [Azure Native](/registry/packages/azure-native/); [any Terraform provider](/docs/iac/concepts/providers/any-terraform-provider/) can be adapted into a Pulumi provider, and [Terraform modules](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) can be consumed directly | Terraform providers only, accessed through project-specific SDKs generated on demand by `cdktf get` |
 | Transpiled to another format? | No — programs run directly in their host language | Yes — programs are synthesized into Terraform JSON and deployed by the Terraform CLI |
 | State management | [Managed by Pulumi Cloud by default](/docs/iac/concepts/state-and-backends/); self-managed backends include Amazon S3, Azure Blob Storage, Google Cloud Storage, local files, and others | Local, remote, or cloud-hosted (the Terraform state model) |
 | Secrets management | [Encrypted in transit and at rest](/docs/iac/concepts/secrets/) in the state file by default, with per-stack encryption keys; pluggable KMS providers (AWS KMS, Azure Key Vault, Google Cloud KMS, HashiCorp Vault) | No built-in secrets primitive |
@@ -62,7 +62,7 @@ Pulumi and CDKTF both let you author infrastructure in general-purpose languages
 
 ### Cloud and service coverage
 
-CDKTF supported Terraform providers through project-specific SDKs generated on demand by `cdktf get`. Pulumi supports the [Pulumi Registry](/registry/) of pre-built providers — including native providers for [Kubernetes](/registry/packages/kubernetes/) and [Azure Native](/registry/packages/azure-native/) generated directly from each platform's API schema for same-day coverage of new resources — and can additionally [generate typed SDKs on demand](/docs/iac/get-started/terraform/terraform-providers/) for any Terraform provider. Pulumi also supports referencing [Terraform modules directly](/docs/iac/using-pulumi/extending-pulumi/use-terraform-module/) without rewriting them, so existing module investment is preserved during migration.
+CDKTF supported Terraform providers through project-specific SDKs generated on demand by `cdktf get`. Pulumi supports the [Pulumi Registry](/registry/) of pre-built providers — including native providers for [Kubernetes](/registry/packages/kubernetes/) and [Azure Native](/registry/packages/azure-native/) generated directly from each platform's API schema for same-day coverage of new resources — and can additionally [generate typed SDKs on demand](/docs/iac/get-started/terraform/terraform-providers/) for any Terraform provider. Pulumi also supports referencing [Terraform modules directly](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) without rewriting them, so existing module investment is preserved during migration.
 
 ### Execution and rollbacks
 
@@ -103,7 +103,7 @@ The [Automation API](/docs/iac/concepts/automation-api/) lets a host application
 There are several common paths for migrating from CDKTF to Pulumi, and they can be combined:
 
 1. **Use Terraform/CDKTF state alongside Pulumi.** Pulumi can [reference local or remote Terraform state](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/) — including the state produced by a CDKTF deployment — from a Pulumi program. This lets you continue managing a subset of your infrastructure with CDKTF (or Terraform) while incrementally moving the rest to Pulumi.
-1. **Consume Terraform modules directly.** Pulumi can [reference Terraform modules directly](/docs/iac/using-pulumi/extending-pulumi/use-terraform-module/) by generating language-specific SDKs on demand, so existing module investment is preserved.
+1. **Consume Terraform modules directly.** Pulumi can [reference Terraform modules directly](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) by generating language-specific SDKs on demand, so existing module investment is preserved.
 1. **Convert with `pulumi convert --from terraform`.** Run `cdktf synth` to produce Terraform JSON, then convert that JSON to Pulumi with `pulumi convert --from terraform`. For state, [`pulumi-terraform-migrate`](https://github.com/pulumi/pulumi-tool-terraform-migrate) translates Terraform state into Pulumi state.
 1. **Import existing resources.** [`pulumi import`](/docs/iac/guides/migration/import/) and the [`import` resource option](/docs/iac/concepts/resources/options/import/) bring already-provisioned resources under Pulumi management and generate the corresponding code in your chosen language.
 1. **Automated migration with Pulumi Neo (recommended).** [Pulumi Neo](/product/neo/) automates code conversion and state migration, then runs `pulumi preview` to verify zero changes before you commit. See [Migrating from Terraform/CDKTF to Pulumi](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/).
@@ -130,7 +130,7 @@ Yes. [`pulumi-terraform-migrate`](https://github.com/pulumi/pulumi-tool-terrafor
 
 ### Does Pulumi support Terraform modules and providers?
 
-Yes. Pulumi can [adapt any Terraform provider](/docs/iac/concepts/providers/any-terraform-provider/) and can [reference Terraform modules directly](/docs/iac/using-pulumi/extending-pulumi/use-terraform-module/) by generating language-specific SDKs on demand. Many of Pulumi's most popular registry providers are also derived from upstream Terraform provider schemas, so resource models often map one-to-one with CDKTF code.
+Yes. Pulumi can [adapt any Terraform provider](/docs/iac/concepts/providers/any-terraform-provider/) and can [reference Terraform modules directly](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) by generating language-specific SDKs on demand. Many of Pulumi's most popular registry providers are also derived from upstream Terraform provider schemas, so resource models often map one-to-one with CDKTF code.
 
 ### Can Pulumi coexist with existing Terraform or CDKTF deployments?
 

--- a/content/docs/iac/comparisons/terraform-cloud.md
+++ b/content/docs/iac/comparisons/terraform-cloud.md
@@ -51,7 +51,7 @@ That matters for two groups: teams who prefer HCL and shouldn't have to trade it
 
 ### Reuse your Terraform modules
 
-Pulumi programs in any language can [consume Terraform modules natively](/docs/iac/get-started/terraform/terraform-modules/) with `pulumi package add terraform-module <source> <version> <name>`, resolving from the Terraform Registry, a private registry, or a local path. The module itself doesn't change.
+Pulumi programs in any language can [consume Terraform modules natively](/docs/iac/get-started/terraform/terraform-modules/) with `pulumi package add hcl module <source> <version> <name>`, resolving from the Terraform Registry, a private registry, or a local path. The module itself doesn't change.
 
 [Pulumi Cloud's registry also hosts your Terraform modules](/docs/idp/concepts/terraform-modules/) alongside Pulumi packages, so your teams have one place to look for reusable building blocks rather than two. The publish API is wire-compatible with HCP Terraform's private registry: point your existing go-tfe or `hashicorp/tfe` provider pipelines at `tf.pulumi.com`, supply a Pulumi access token, and they run unchanged. Every version you publish is also converted into a Pulumi package with typed inputs and outputs and a generated SDK, while your existing `.tf` consumers keep resolving the module over the Terraform protocol.
 
@@ -89,7 +89,7 @@ Mercedes-Benz Research & Development adopted Pulumi specifically to unify applic
 | --- | --- | --- |
 | Language | Python, TypeScript, JavaScript, Go, C#, and Java, plus YAML — general-purpose languages with native testing, IDE support, and package management — and [HCL](/docs/iac/languages-sdks/hcl/) via `runtime: hcl`, a superset of Terraform HCL that is fully OpenTofu compatible | HCL, a configuration-focused DSL; `terraform test` covers native unit testing, but reuse and abstraction are limited to the module system |
 | Terraform and OpenTofu state | [Pulumi Cloud implements the Terraform remote backend API](/docs/iac/get-started/terraform/terraform-state-backend/) as a drop-in target, with [remote execution](/docs/iac/get-started/terraform/terraform-remote-execution/) and approval gates for VCS-triggered applies, alongside Pulumi's own state | Native, but state and runs are scoped to HCP Terraform workspaces |
-| Terraform module reuse | [`pulumi package add terraform-module`](/docs/iac/get-started/terraform/terraform-modules/) pulls existing modules into a Pulumi program in any language, and [Pulumi Cloud's registry hosts them](/docs/idp/concepts/terraform-modules/) alongside Pulumi packages via an HCP-compatible publish API | Native to Terraform and OpenTofu only |
+| Terraform module reuse | [`pulumi package add hcl module`](/docs/iac/get-started/terraform/terraform-modules/) pulls existing modules into a Pulumi program in any language, and [Pulumi Cloud's registry hosts them](/docs/idp/concepts/terraform-modules/) alongside Pulumi packages via an HCP-compatible publish API | Native to Terraform and OpenTofu only |
 | Pricing model | One Pulumi Cloud plan bundles IaC, secrets, estate visibility, and AI usage under a single credit allotment, with on-demand pricing for usage beyond it; the Individual tier is free with no resource cap | Resources Under Management (RUM)---billed by the count of resources tracked in state, in addition to plan tier |
 | Free tier | Individual tier is free with no resource cap for personal use | Enhanced Free tier caps out at 500 managed resources per organization |
 | Policy as code | [Pulumi Policies](/docs/insights/policy/), written in Python, TypeScript, or OPA Rego, enforced on every `pulumi up` and — for [remotely executed](/docs/iac/get-started/terraform/terraform-remote-execution/) Terraform stacks — against Terraform plans, as part of the same platform | Sentinel or OPA policy checks, run as a distinct step in the HCP Terraform run pipeline |
@@ -124,7 +124,7 @@ Yes. [HCL is a first-class Pulumi language](/docs/iac/languages-sdks/hcl/): set 
 
 ### Can I use my existing Terraform modules in Pulumi?
 
-Yes, without modifying them. `pulumi package add terraform-module <source> <version> <name>` makes a module available to a Pulumi program in any language, resolving from the Terraform Registry, a private registry, or a local path. See [Using Terraform modules in Pulumi](/docs/iac/get-started/terraform/terraform-modules/).
+Yes, without modifying them. `pulumi package add hcl module <source> <version> <name>` makes a module available to a Pulumi program in any language, resolving from the Terraform Registry, a private registry, or a local path. See [Using Terraform modules in Pulumi](/docs/iac/get-started/terraform/terraform-modules/).
 
 You can also [host your own modules in the Pulumi Cloud registry](/docs/idp/concepts/terraform-modules/). Its publish API is wire-compatible with HCP Terraform's, so existing go-tfe or `hashicorp/tfe` provider pipelines migrate by changing the host to `tf.pulumi.com`. Published modules stay usable from both Pulumi and Terraform programs.
 

--- a/content/docs/iac/comparisons/terraform-cloud.md
+++ b/content/docs/iac/comparisons/terraform-cloud.md
@@ -51,7 +51,7 @@ That matters for two groups: teams who prefer HCL and shouldn't have to trade it
 
 ### Reuse your Terraform modules
 
-Pulumi programs in any language can [consume Terraform modules natively](/docs/iac/get-started/terraform/terraform-modules/) with `pulumi package add hcl module <source> <version> <name>`, resolving from the Terraform Registry, a private registry, or a local path. The module itself doesn't change.
+Pulumi programs in any language can [consume Terraform modules natively](/docs/iac/get-started/terraform/terraform-modules/) with `pulumi package add hcl module <source> [version]`, resolving from the Terraform Registry, a private registry, or a local path. The module itself doesn't change.
 
 [Pulumi Cloud's registry also hosts your Terraform modules](/docs/idp/concepts/terraform-modules/) alongside Pulumi packages, so your teams have one place to look for reusable building blocks rather than two. The publish API is wire-compatible with HCP Terraform's private registry: point your existing go-tfe or `hashicorp/tfe` provider pipelines at `tf.pulumi.com`, supply a Pulumi access token, and they run unchanged. Every version you publish is also converted into a Pulumi package with typed inputs and outputs and a generated SDK, while your existing `.tf` consumers keep resolving the module over the Terraform protocol.
 
@@ -124,7 +124,7 @@ Yes. [HCL is a first-class Pulumi language](/docs/iac/languages-sdks/hcl/): set 
 
 ### Can I use my existing Terraform modules in Pulumi?
 
-Yes, without modifying them. `pulumi package add hcl module <source> <version> <name>` makes a module available to a Pulumi program in any language, resolving from the Terraform Registry, a private registry, or a local path. See [Using Terraform modules in Pulumi](/docs/iac/get-started/terraform/terraform-modules/).
+Yes, without modifying them. `pulumi package add hcl module <source> [version]` makes a module available to a Pulumi program in any language, resolving from the Terraform Registry, a private registry, or a local path. See [Using Terraform modules in Pulumi](/docs/iac/get-started/terraform/terraform-modules/).
 
 You can also [host your own modules in the Pulumi Cloud registry](/docs/idp/concepts/terraform-modules/). Its publish API is wire-compatible with HCP Terraform's, so existing go-tfe or `hashicorp/tfe` provider pipelines migrate by changing the host to `tf.pulumi.com`. Published modules stay usable from both Pulumi and Terraform programs.
 

--- a/content/docs/iac/get-started/terraform/_index.md
+++ b/content/docs/iac/get-started/terraform/_index.md
@@ -22,11 +22,13 @@ This step-by-step tutorial focuses on coexistence patterns that let you leverage
 
 Through progressive examples, you'll discover how to:
 
+* Run your existing `.tf` files unchanged on [Pulumi HCL](/docs/iac/languages-sdks/hcl/)
 * Reference existing Terraform state files from Pulumi
 * Use any Terraform provider in Pulumi programs
 * Import and use Terraform modules directly
 * Convert HCL code to Pulumi when beneficial
 * Orchestrate both Terraform and Pulumi deployments together
+* Use Pulumi Cloud as your Terraform state backend, with plans and applies running remotely
 
 ## Overview of examples
 
@@ -36,10 +38,11 @@ Starting with simple state referencing, you'll progressively add complexity whil
 The examples demonstrate:
 
 1. **Coexistence**: Reading Terraform state from Pulumi
-2. **Provider sharing**: Using Terraform providers in Pulumi
-3. **Module reuse**: Leveraging existing Terraform modules
-4. **Selective conversion**: Converting specific HCL when advantageous
-5. **Orchestration**: Managing both tools in unified workflows
+1. **Provider sharing**: Using Terraform providers in Pulumi
+1. **Module reuse**: Leveraging existing Terraform modules
+1. **Selective conversion**: Converting specific HCL when advantageous
+1. **Orchestration**: Managing both tools in unified workflows
+1. **State and execution**: Moving Terraform state and runs onto Pulumi Cloud
 
 ## Prerequisites
 

--- a/content/docs/iac/get-started/terraform/convert-hcl.md
+++ b/content/docs/iac/get-started/terraform/convert-hcl.md
@@ -13,14 +13,18 @@ menu:
 
 ## Do you need to convert?
 
-Converting is not the only way to run Terraform configuration with Pulumi. Pulumi's [HCL runtime](/docs/iac/languages-sdks/hcl/) runs your existing `.tf` files directly: set `runtime: hcl` in `Pulumi.yaml` and `pulumi up` deploys the configuration you already have, unchanged.
+Converting is one of several ways to bring Terraform configuration to Pulumi, and often not the one you want. Three alternatives leave your HCL where it is:
 
-Which path you take comes down to what you want out of the move:
+* **Run your HCL natively.** Pulumi's [HCL runtime](/docs/iac/languages-sdks/hcl/) runs your existing `.tf` files directly: set `runtime: hcl` in `Pulumi.yaml` and `pulumi up` deploys the configuration you already have, unchanged. Reach for this when you want to keep writing HCL and are after Pulumi's engine, state management, secrets, and cloud platform.
+* **Consume a module as a package.** The [Any HCL Module](/registry/packages/hcl/) package turns any Terraform or OpenTofu module into a Pulumi component with a generated, strongly typed SDK, so a Pulumi program in any language can use the module without it being rewritten. See [Import Terraform Modules](/docs/iac/get-started/terraform/terraform-modules/).
 
-* **Run your HCL natively** when you want to keep writing HCL and are after Pulumi's engine, state management, secrets, and cloud platform.
-* **Convert** when you want the infrastructure code itself in a general-purpose language, for the testing, abstraction, and IDE support that comes with TypeScript, Python, Go, C#, or Java.
+  ```bash
+  $ pulumi package add hcl module terraform-aws-modules/s3-bucket/aws 4.1.2
+  ```
 
-The rest of this page covers converting.
+* **Publish your modules to the Pulumi Cloud registry.** Pulumi Cloud hosts your team's Terraform modules and converts every published version into a Pulumi package automatically, with no conversion step on your part. Existing `.tf` consumers keep resolving the module over the Terraform protocol. Publishing requires the Enterprise or Business Critical plan; reading and listing modules works on any plan. See [Terraform modules in the Pulumi Cloud registry](/docs/idp/concepts/terraform-modules/).
+
+Convert when you want the infrastructure code itself in a general-purpose language, for the testing, abstraction, and IDE support that comes with TypeScript, Python, Go, C#, or Java. The rest of this page covers converting.
 
 ## When to convert
 

--- a/content/docs/iac/get-started/terraform/terraform-modules.md
+++ b/content/docs/iac/get-started/terraform/terraform-modules.md
@@ -16,7 +16,7 @@ aliases:
 ## Leverage the module ecosystem
 
 Pulumi can directly use existing Terraform modules from the Terraform Registry, private registries, or local sources. This allows you to access thousands of existing modules without rewriting them in Pulumi.
-It's powered by the [Any HCL Module](/registry/packages/hcl/) package, which turns any Terraform or OpenTofu module into a Pulumi component, either as a strongly typed SDK or loaded dynamically at runtime.
+It's powered by the [Any HCL Module](/registry/packages/hcl/) package, which turns any Terraform or OpenTofu module into a Pulumi component, either generated as a strongly typed SDK or loaded dynamically at runtime.
 
 ## Add Terraform modules
 
@@ -333,7 +333,7 @@ Add the Any HCL Module package to your project:
 $ pulumi package add hcl
 ```
 
-Then use its `Module` resource to load your desired module. The constructor takes a module `source`, an optional `version`, and a map of `inputs`, and exposes the module's outputs as an untyped map:
+Then use its `Module` resource to load the module you want. The constructor takes a module `source`, an optional `version`, and a map of `inputs`, and exposes the module's outputs as an untyped map:
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 

--- a/content/docs/iac/get-started/terraform/terraform-modules.md
+++ b/content/docs/iac/get-started/terraform/terraform-modules.md
@@ -64,11 +64,11 @@ const myVpc = new vpc.Module("my-vpc", {
     cidr: "10.0.0.0/16",
 
     azs: ["us-west-2a", "us-west-2b", "us-west-2c"],
-    public_subnets: ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"],
-    private_subnets: ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"],
+    publicSubnets: ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"],
+    privateSubnets: ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"],
 
-    enable_nat_gateway: true,
-    enable_vpn_gateway: true,
+    enableNatGateway: true,
+    enableVpnGateway: true,
 
     tags: {
         Terraform: "true",
@@ -81,7 +81,7 @@ const myVpc = new vpc.Module("my-vpc", {
 const webSg = new aws.ec2.SecurityGroup("web-sg", {
     name: "web-sg",
     description: "Security group for web servers",
-    vpcId: myVpc.vpc_id.apply(id => id!),
+    vpcId: myVpc.vpcId.apply(id => id!),
     ingress: [
         {
             description: "HTTP",
@@ -124,7 +124,7 @@ const amazonLinux = aws.ec2.getAmiOutput({
 const webServer = new aws.ec2.Instance("web-server", {
     ami: amazonLinux.id,
     instanceType: "t3.micro",
-    subnetId: myVpc.public_subnets.apply(subnets => subnets![0]),
+    subnetId: myVpc.publicSubnets.apply(subnets => subnets![0]),
     vpcSecurityGroupIds: [webSg.id],
     associatePublicIpAddress: true,
 
@@ -144,7 +144,7 @@ echo "<h1>Hello from Pulumi and Terraform modules!</h1>" > /var/www/html/index.h
 
 
 // Output important information
-export const vpcId = myVpc.vpc_id;
+export const vpcId = myVpc.vpcId;
 export const instanceId = webServer.id;
 export const publicIp = webServer.publicIp;
 export const websiteUrl = pulumi.interpolate`http://${webServer.publicIp}`;
@@ -300,11 +300,11 @@ func main() {
 			Cidr: pulumi.String("10.0.0.0/16"),
 
 			Azs:             pulumi.StringArray{pulumi.String("us-west-2a"), pulumi.String("us-west-2b"), pulumi.String("us-west-2c")},
-			Private_subnets: pulumi.StringArray{pulumi.String("10.0.1.0/24"), pulumi.String("10.0.2.0/24"), pulumi.String("10.0.3.0/24")},
-			Public_subnets:  pulumi.StringArray{pulumi.String("10.0.10.0/24"), pulumi.String("10.0.11.0/24"), pulumi.String("10.0.12.0/24")},
+			PrivateSubnets: pulumi.StringArray{pulumi.String("10.0.1.0/24"), pulumi.String("10.0.2.0/24"), pulumi.String("10.0.3.0/24")},
+			PublicSubnets:  pulumi.StringArray{pulumi.String("10.0.10.0/24"), pulumi.String("10.0.11.0/24"), pulumi.String("10.0.12.0/24")},
 
-			Enable_nat_gateway: pulumi.Bool(true),
-			Enable_vpn_gateway: pulumi.Bool(true),
+			EnableNatGateway: pulumi.Bool(true),
+			EnableVpnGateway: pulumi.Bool(true),
 
 			Tags: pulumi.StringMap{
 				"Terraform":   pulumi.String("true"),
@@ -334,7 +334,7 @@ func main() {
 		webSg, err := ec2.NewSecurityGroup(ctx, "web-sg", &ec2.SecurityGroupArgs{
 			Name:        pulumi.String("web-sg"),
 			Description: pulumi.String("Security group for web servers"),
-			VpcId:       myVpc.Vpc_id,
+			VpcId:       myVpc.VpcId,
 			Ingress: ec2.SecurityGroupIngressArray{
 				&ec2.SecurityGroupIngressArgs{
 					Description: pulumi.String("HTTP"),
@@ -368,7 +368,7 @@ func main() {
 		webServer, err := ec2.NewInstance(ctx, "web-server", &ec2.InstanceArgs{
 			Ami:          pulumi.String(amazonLinux.Id),
 			InstanceType: pulumi.String("t3.micro"),
-			SubnetId: myVpc.Public_subnets.ApplyT(func(subnets []string) string {
+			SubnetId: myVpc.PublicSubnets.ApplyT(func(subnets []string) string {
 				return subnets[0]
 			}).(pulumi.StringOutput),
 			VpcSecurityGroupIds:      pulumi.StringArray{webSg.ID()},
@@ -392,7 +392,7 @@ echo "<h1>Hello from Pulumi and Terraform modules!</h1>" > /var/www/html/index.h
 		}
 
 		// Output important information
-		ctx.Export("vpcId", myVpc.Vpc_id)
+		ctx.Export("vpcId", myVpc.VpcId)
 		ctx.Export("instanceId", webServer.ID())
 		ctx.Export("publicIp", webServer.PublicIp)
 		ctx.Export("websiteUrl", pulumi.Sprintf("http://%s", webServer.PublicIp))
@@ -436,12 +436,13 @@ Then use it in your Pulumi program:
 using System.Collections.Generic;
 using Pulumi;
 using Pulumi.Aws.Ec2;
+using Pulumi.Aws.Ec2.Inputs;
 using Pulumi.Vpc;
 
 return await Deployment.RunAsync(() =>
 {
     // Use the Terraform VPC module
-    var myVpc = new Vpc("my-vpc", new VpcArgs
+    var myVpc = new Module("my-vpc", new ModuleArgs
     {
         Name = "my-vpc",
         Cidr = "10.0.0.0/16",
@@ -612,10 +613,10 @@ public class App {
                 .name("my-vpc")
                 .cidr("10.0.0.0/16")
                 .azs("us-west-2a", "us-west-2b", "us-west-2c")
-                .private_subnets("10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24")
-                .public_subnets("10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24")
-                .enable_nat_gateway(true)
-                .enable_vpn_gateway(true)
+                .privateSubnets("10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24")
+                .publicSubnets("10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24")
+                .enableNatGateway(true)
+                .enableVpnGateway(true)
                 .tags(Map.of(
                     "Terraform", "true",
                     "Environment", "dev"
@@ -636,7 +637,7 @@ public class App {
             var webSg = new SecurityGroup("web-sg", SecurityGroupArgs.builder()
                 .name("web-sg")
                 .description("Security group for web servers")
-                .vpcId(myVpc.vpc_id().applyValue(id->id.get()).applyValue(String::valueOf))
+                .vpcId(myVpc.vpcId().applyValue(id->id.get()).applyValue(String::valueOf))
                 .ingress(
                     SecurityGroupIngressArgs.builder()
                         .description("HTTP")
@@ -665,7 +666,7 @@ public class App {
             var webServer = new Instance("web-server", InstanceArgs.builder()
                 .ami(amazonLinux.applyValue(ami -> ami.id()))
                 .instanceType("t3.micro")
-                .subnetId(myVpc.public_subnets().applyValue(subnets -> subnets.get().get(0)))
+                .subnetId(myVpc.publicSubnets().applyValue(subnets -> subnets.get().get(0)))
                 .vpcSecurityGroupIds(webSg.id().applyValue(s -> Collections.singletonList(s)))
                 .associatePublicIpAddress(true)
                 .userData(String.join("\n",
@@ -683,7 +684,7 @@ public class App {
                 .build());
 
             // Output important information
-            ctx.export("vpcId", myVpc.vpc_id());
+            ctx.export("vpcId", myVpc.vpcId());
             ctx.export("instanceId", webServer.id());
             ctx.export("publicIp", webServer.publicIp());
             ctx.export("websiteUrl", webServer.publicIp().applyValue(ip -> String.format("http://%s", ip)));
@@ -736,10 +737,10 @@ resources:
       name: my-vpc
       cidr: 10.0.0.0/16
       azs: ["us-west-2a", "us-west-2b", "us-west-2c"]
-      private_subnets: ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-      public_subnets: ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"]
-      enable_nat_gateway: true
-      enable_vpn_gateway: true
+      privateSubnets: ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+      publicSubnets: ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"]
+      enableNatGateway: true
+      enableVpnGateway: true
       tags:
         Terraform: "true"
         Environment: "dev"
@@ -750,7 +751,7 @@ resources:
     properties:
       name: web-sg
       description: Security group for web servers
-      vpcId: ${my-vpc.vpc_id}
+      vpcId: ${my-vpc.vpcId}
       ingress:
         - description: HTTP
           fromPort: 80
@@ -774,7 +775,7 @@ resources:
     properties:
       ami: ${amazonLinux.id}
       instanceType: t3.micro
-      subnetId: ${my-vpc.public_subnets[0]}
+      subnetId: ${my-vpc.publicSubnets[0]}
       vpcSecurityGroupIds:
         - ${web-sg.id}
       associatePublicIpAddress: true
@@ -790,7 +791,7 @@ resources:
         Environment: dev
 
 outputs:
-  vpcId: ${my-vpc.vpc_id}
+  vpcId: ${my-vpc.vpcId}
   instanceId: ${web-server.id}
   publicIp: ${web-server.publicIp}
   websiteUrl: http://${web-server.publicIp}
@@ -831,7 +832,7 @@ const vpc = new hcl.Module("vpc", {
     },
 });
 
-export const vpcId = vpc.outputs.apply(o => o["vpc_id"]);
+export const vpcId = vpc.outputs.apply(o => o["vpcId"]);
 ```
 
 {{% /choosable %}}
@@ -936,7 +937,7 @@ public class App {
                     "cidr", "10.0.0.0/16"))
                 .build());
 
-            ctx.export("vpcId", vpc.outputs().applyValue(o -> o.get("vpc_id")));
+            ctx.export("vpcId", vpc.outputs().applyValue(o -> o.get("vpcId")));
         });
     }
 }
@@ -959,7 +960,7 @@ resources:
         name: example-vpc
         cidr: 10.0.0.0/16
 outputs:
-  vpcId: ${vpc.outputs["vpc_id"]}
+  vpcId: ${vpc.outputs["vpcId"]}
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/get-started/terraform/terraform-modules.md
+++ b/content/docs/iac/get-started/terraform/terraform-modules.md
@@ -24,15 +24,15 @@ Use the `pulumi package add` command to add Terraform modules to your project:
 
 ```bash
 # Add a module from the Terraform Registry
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
+$ pulumi package add hcl module terraform-aws-modules/s3-bucket/aws 4.1.2
 
 # Add a local module
 $ pulumi package add hcl module ./path/to/module
 ```
 
-## Example: AWS VPC module
+## Example: AWS S3 bucket module
 
-Let's use the popular AWS `vpc` module to create a VPC with subnets, and then deploy an EC2 instance in that VPC:
+Let's use the popular AWS `s3-bucket` module to create an S3 bucket and export its outputs:
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 
@@ -45,109 +45,28 @@ $ mkdir pulumi-terraform-modules-test && cd pulumi-terraform-modules-test
 $ pulumi new aws-typescript --yes
 ```
 
-Next, add the VPC module:
+Next, add the S3 bucket module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
+$ pulumi package add hcl module terraform-aws-modules/s3-bucket/aws 4.1.2
 ```
 
 Then use it in your Pulumi program:
 
 ```typescript
-import * as pulumi from "@pulumi/pulumi";
-import * as aws from "@pulumi/aws";
-import * as vpc from "@pulumi/vpc";
+import * as s3Bucket from "@pulumi/s3-bucket";
 
-// Use the Terraform VPC module
-const myVpc = new vpc.Module("my-vpc", {
-    name: "my-vpc",
-    cidr: "10.0.0.0/16",
-
-    azs: ["us-west-2a", "us-west-2b", "us-west-2c"],
-    publicSubnets: ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"],
-    privateSubnets: ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"],
-
-    enableNatGateway: true,
-    enableVpnGateway: true,
-
+// Create an S3 bucket using the Terraform module
+const bucket = new s3Bucket.Module("my-bucket", {
+    bucketPrefix: "my-example-bucket",
     tags: {
-        Terraform: "true",
         Environment: "dev",
     },
 });
 
-// Create a security group
-
-const webSg = new aws.ec2.SecurityGroup("web-sg", {
-    name: "web-sg",
-    description: "Security group for web servers",
-    vpcId: myVpc.vpcId.apply(id => id!),
-    ingress: [
-        {
-            description: "HTTP",
-            fromPort: 80,
-            toPort: 80,
-            protocol: "tcp",
-            cidrBlocks: ["0.0.0.0/0"],
-        },
-        {
-            description: "SSH",
-            fromPort: 22,
-            toPort: 22,
-            protocol: "tcp",
-            cidrBlocks: ["0.0.0.0/0"],
-        },
-    ],
-    egress: [
-        {
-            fromPort: 0,
-            toPort: 0,
-            protocol: "-1",
-            cidrBlocks: ["0.0.0.0/0"],
-        },
-    ],
-});
-
-// Get the latest Amazon Linux 2 AMI
-const amazonLinux = aws.ec2.getAmiOutput({
-    mostRecent: true,
-    owners: ["amazon"],
-    filters: [
-        {
-            name: "name",
-            values: ["amzn2-ami-hvm-*-x86_64-gp2"],
-        },
-    ],
-});
-
-// Create an EC2 instance in the VPC
-const webServer = new aws.ec2.Instance("web-server", {
-    ami: amazonLinux.id,
-    instanceType: "t3.micro",
-    subnetId: myVpc.publicSubnets.apply(subnets => subnets![0]),
-    vpcSecurityGroupIds: [webSg.id],
-    associatePublicIpAddress: true,
-
-    userData: `#!/bin/bash
-yum update -y
-yum install -y httpd
-systemctl start httpd
-systemctl enable httpd
-echo "<h1>Hello from Pulumi and Terraform modules!</h1>" > /var/www/html/index.html
-`,
-
-    tags: {
-        Name: "web-server",
-        Environment: "dev",
-    },
-});
-
-
-// Output important information
-export const vpcId = myVpc.vpcId;
-export const instanceId = webServer.id;
-export const publicIp = webServer.publicIp;
-export const websiteUrl = pulumi.interpolate`http://${webServer.publicIp}`;
+// The module's outputs are strongly typed
+export const bucketArn = bucket.s3BucketArn;
+export const bucketId = bucket.s3BucketId;
 ```
 
 {{% /choosable %}}
@@ -161,107 +80,28 @@ $ mkdir pulumi-terraform-modules-test && cd pulumi-terraform-modules-test
 $ pulumi new aws-python --yes
 ```
 
-Next, add the VPC module:
+Next, add the S3 bucket module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
+$ pulumi package add hcl module terraform-aws-modules/s3-bucket/aws 4.1.2
 ```
 
 Then use it in your Pulumi program:
 
 ```python
 import pulumi
-import pulumi_aws as aws
-import pulumi_vpc as vpc
+import pulumi_s3_bucket as s3bucket
 
-# Use the Terraform VPC module
-my_vpc = vpc.Module("my-vpc",
-    name="my-vpc",
-    cidr="10.0.0.0/16",
-
-    azs=["us-west-2a", "us-west-2b", "us-west-2c"],
-    public_subnets=["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"],
-    private_subnets=["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"],
-
-    enable_nat_gateway=True,
-    enable_vpn_gateway=True,
-
+# Create an S3 bucket using the Terraform module
+bucket = s3bucket.Module("my-bucket",
+    bucket_prefix="my-example-bucket",
     tags={
-        "Terraform": "true",
         "Environment": "dev",
-    }
-)
+    })
 
-# Create a security group
-web_sg = aws.ec2.SecurityGroup("web-sg",
-    name="web-sg",
-    description="Security group for web servers",
-    vpc_id=my_vpc.vpc_id.apply(lambda id: id),
-    ingress=[
-        {
-            "description": "HTTP",
-            "from_port": 80,
-            "to_port": 80,
-            "protocol": "tcp",
-            "cidr_blocks": ["0.0.0.0/0"],
-        },
-        {
-            "description": "SSH",
-            "from_port": 22,
-            "to_port": 22,
-            "protocol": "tcp",
-            "cidr_blocks": ["0.0.0.0/0"],
-        },
-    ],
-    egress=[
-        {
-            "from_port": 0,
-            "to_port": 0,
-            "protocol": "-1",
-            "cidr_blocks": ["0.0.0.0/0"],
-        }
-    ]
-)
-
-# Get the latest Amazon Linux 2 AMI
-amazon_linux = aws.ec2.get_ami(
-    most_recent=True,
-    owners=["amazon"],
-    filters=[
-        {
-            "name": "name",
-            "values": ["amzn2-ami-hvm-*-x86_64-gp2"],
-        }
-    ]
-)
-
-# Create an EC2 instance in the VPC
-web_server = aws.ec2.Instance("web-server",
-    ami=amazon_linux.id,
-    instance_type="t3.micro",
-    subnet_id=my_vpc.public_subnets.apply(lambda subnets: subnets[0]),
-    vpc_security_group_ids=[web_sg.id],
-    associate_public_ip_address=True,
-
-    user_data="""#!/bin/bash
-yum update -y
-yum install -y httpd
-systemctl start httpd
-systemctl enable httpd
-echo "<h1>Hello from Pulumi and Terraform modules!</h1>" > /var/www/html/index.html
-""",
-
-    tags={
-        "Name": "web-server",
-        "Environment": "dev",
-    }
-)
-
-# Output important information
-pulumi.export("vpcId", my_vpc.vpc_id)
-pulumi.export("instanceId", web_server.id)
-pulumi.export("publicIp", web_server.public_ip)
-pulumi.export("websiteUrl", pulumi.Output.format("http://{0}", web_server.public_ip))
+# The module's outputs are strongly typed
+pulumi.export("bucket_arn", bucket.s3_bucket_arn)
+pulumi.export("bucket_id", bucket.s3_bucket_id)
 ```
 
 {{% /choosable %}}
@@ -275,10 +115,10 @@ $ mkdir pulumi-terraform-modules-test && cd pulumi-terraform-modules-test
 $ pulumi new aws-go --yes
 ```
 
-Next, add the VPC module:
+Next, add the S3 bucket module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
+$ pulumi package add hcl module terraform-aws-modules/s3-bucket/aws 4.1.2
 ```
 
 Then use it in your Pulumi program:
@@ -287,115 +127,25 @@ Then use it in your Pulumi program:
 package main
 
 import (
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
-	vpc "example.com/pulumi-vpc/sdk/go/vpc"
+	"example.com/pulumi-s3-bucket/sdk/go/s3bucket"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		// Use the Terraform VPC module
-		myVpc, err := vpc.NewModule(ctx, "my-vpc", &vpc.ModuleArgs{
-			Name: pulumi.String("my-vpc"),
-			Cidr: pulumi.String("10.0.0.0/16"),
-
-			Azs:             pulumi.StringArray{pulumi.String("us-west-2a"), pulumi.String("us-west-2b"), pulumi.String("us-west-2c")},
-			PrivateSubnets: pulumi.StringArray{pulumi.String("10.0.1.0/24"), pulumi.String("10.0.2.0/24"), pulumi.String("10.0.3.0/24")},
-			PublicSubnets:  pulumi.StringArray{pulumi.String("10.0.10.0/24"), pulumi.String("10.0.11.0/24"), pulumi.String("10.0.12.0/24")},
-
-			EnableNatGateway: pulumi.Bool(true),
-			EnableVpnGateway: pulumi.Bool(true),
-
+		// Create an S3 bucket using the Terraform module
+		bucket, err := s3bucket.NewModule(ctx, "my-bucket", &s3bucket.ModuleArgs{
+			BucketPrefix: pulumi.String("my-example-bucket"),
 			Tags: pulumi.StringMap{
-				"Terraform":   pulumi.String("true"),
 				"Environment": pulumi.String("dev"),
 			},
 		})
 		if err != nil {
 			return err
 		}
-
-		// Get the latest Amazon Linux 2 AMI
-		amazonLinux, err := ec2.LookupAmi(ctx, &ec2.LookupAmiArgs{
-			MostRecent: pulumi.BoolRef(true),
-			Owners:     []string{"amazon"},
-			Filters: []ec2.GetAmiFilter{
-				{
-					Name:   "name",
-					Values: []string{"amzn2-ami-hvm-*-x86_64-gp2"},
-				},
-			},
-		})
-		if err != nil {
-			return err
-		}
-
-		// Create a security group
-		webSg, err := ec2.NewSecurityGroup(ctx, "web-sg", &ec2.SecurityGroupArgs{
-			Name:        pulumi.String("web-sg"),
-			Description: pulumi.String("Security group for web servers"),
-			VpcId:       myVpc.VpcId,
-			Ingress: ec2.SecurityGroupIngressArray{
-				&ec2.SecurityGroupIngressArgs{
-					Description: pulumi.String("HTTP"),
-					FromPort:    pulumi.Int(80),
-					ToPort:      pulumi.Int(80),
-					Protocol:    pulumi.String("tcp"),
-					CidrBlocks:  pulumi.StringArray{pulumi.String("0.0.0.0/0")},
-				},
-				&ec2.SecurityGroupIngressArgs{
-					Description: pulumi.String("SSH"),
-					FromPort:    pulumi.Int(22),
-					ToPort:      pulumi.Int(22),
-					Protocol:    pulumi.String("tcp"),
-					CidrBlocks:  pulumi.StringArray{pulumi.String("0.0.0.0/0")},
-				},
-			},
-			Egress: ec2.SecurityGroupEgressArray{
-				&ec2.SecurityGroupEgressArgs{
-					FromPort:   pulumi.Int(0),
-					ToPort:     pulumi.Int(0),
-					Protocol:   pulumi.String("-1"),
-					CidrBlocks: pulumi.StringArray{pulumi.String("0.0.0.0/0")},
-				},
-			},
-		})
-		if err != nil {
-			return err
-		}
-
-		// Create an EC2 instance in the VPC
-		webServer, err := ec2.NewInstance(ctx, "web-server", &ec2.InstanceArgs{
-			Ami:          pulumi.String(amazonLinux.Id),
-			InstanceType: pulumi.String("t3.micro"),
-			SubnetId: myVpc.PublicSubnets.ApplyT(func(subnets []string) string {
-				return subnets[0]
-			}).(pulumi.StringOutput),
-			VpcSecurityGroupIds:      pulumi.StringArray{webSg.ID()},
-			AssociatePublicIpAddress: pulumi.Bool(true),
-
-			UserData: pulumi.String(`#!/bin/bash
-yum update -y
-yum install -y httpd
-systemctl start httpd
-systemctl enable httpd
-echo "<h1>Hello from Pulumi and Terraform modules!</h1>" > /var/www/html/index.html
-`),
-
-			Tags: pulumi.StringMap{
-				"Name":        pulumi.String("web-server"),
-				"Environment": pulumi.String("dev"),
-			},
-		})
-		if err != nil {
-			return err
-		}
-
-		// Output important information
-		ctx.Export("vpcId", myVpc.VpcId)
-		ctx.Export("instanceId", webServer.ID())
-		ctx.Export("publicIp", webServer.PublicIp)
-		ctx.Export("websiteUrl", pulumi.Sprintf("http://%s", webServer.PublicIp))
+		// The module's outputs are strongly typed
+		ctx.Export("bucketArn", bucket.S3BucketArn)
+		ctx.Export("bucketId", bucket.S3BucketId)
 		return nil
 	})
 }
@@ -412,10 +162,10 @@ $ mkdir pulumi-terraform-modules-test && cd pulumi-terraform-modules-test
 $ pulumi new aws-csharp --yes
 ```
 
-Next, add the VPC module:
+Next, add the S3 bucket module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
+$ pulumi package add hcl module terraform-aws-modules/s3-bucket/aws 4.1.2
 ```
 
 {{% notes type="tip" %}}
@@ -435,116 +185,25 @@ Then use it in your Pulumi program:
 ```csharp
 using System.Collections.Generic;
 using Pulumi;
-using Pulumi.Aws.Ec2;
-using Pulumi.Aws.Ec2.Inputs;
-using Pulumi.Vpc;
+using Pulumi.S3Bucket;
 
 return await Deployment.RunAsync(() =>
 {
-    // Use the Terraform VPC module
-    var myVpc = new Module("my-vpc", new ModuleArgs
+    // Create an S3 bucket using the Terraform module
+    var bucket = new Module("my-bucket", new ModuleArgs
     {
-        Name = "my-vpc",
-        Cidr = "10.0.0.0/16",
-
-        Azs = new[] { "us-west-2a", "us-west-2b", "us-west-2c" },
-        PrivateSubnets = new[] { "10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24" },
-        PublicSubnets = new[] { "10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24" },
-
-        EnableNatGateway = true,
-        EnableVpnGateway = true,
-
-        Tags = new Dictionary<string, string>
+        BucketPrefix = "my-example-bucket",
+        Tags =
         {
-            ["Terraform"] = "true",
-            ["Environment"] = "dev",
+            { "Environment", "dev" },
         },
     });
 
-    // Get the latest Amazon Linux 2 AMI
-    var amazonLinux = GetAmi.Invoke(new GetAmiInvokeArgs
-    {
-        MostRecent = true,
-        Owners = new[] { "amazon" },
-        Filters = new[]
-        {
-            new GetAmiFilterInputArgs
-            {
-                Name = "name",
-                Values = new[] { "amzn2-ami-hvm-*-x86_64-gp2" },
-            },
-        },
-    });
-
-    // Create a security group
-    var webSg = new SecurityGroup("web-sg", new SecurityGroupArgs
-    {
-        Name = "web-sg",
-        Description = "Security group for web servers",
-        VpcId = myVpc.VpcId,
-        Ingress = new[]
-        {
-            new SecurityGroupIngressArgs
-            {
-                Description = "HTTP",
-                FromPort = 80,
-                ToPort = 80,
-                Protocol = "tcp",
-                CidrBlocks = new[] { "0.0.0.0/0" },
-            },
-            new SecurityGroupIngressArgs
-            {
-                Description = "SSH",
-                FromPort = 22,
-                ToPort = 22,
-                Protocol = "tcp",
-                CidrBlocks = new[] { "0.0.0.0/0" },
-            },
-        },
-        Egress = new[]
-        {
-            new SecurityGroupEgressArgs
-            {
-                FromPort = 0,
-                ToPort = 0,
-                Protocol = "-1",
-                CidrBlocks = new[] { "0.0.0.0/0" },
-            },
-        },
-    });
-
-    // Create an EC2 instance in the VPC
-    var webServer = new Instance("web-server", new InstanceArgs
-    {
-        Ami = amazonLinux.Apply(ami => ami.Id),
-        InstanceType = "t3.micro",
-        SubnetId = myVpc.PublicSubnets.Apply(subnets => subnets[0]),
-        VpcSecurityGroupIds = new[] { webSg.Id },
-        AssociatePublicIpAddress = true,
-
-        UserData = @"#!/bin/bash
-yum update -y
-yum install -y httpd
-systemctl start httpd
-systemctl enable httpd
-echo ""<h1>Hello from Pulumi and Terraform modules!</h1>"" > /var/www/html/index.html
-",
-
-        Tags = new Dictionary<string, string>
-        {
-            ["Name"] = "web-server",
-            ["Environment"] = "dev",
-        },
-    });
-
+    // The module's outputs are strongly typed
     return new Dictionary<string, object?>
     {
-        ["vpcId"] = myVpc.VpcId,
-        ["publicSubnets"] = myVpc.PublicSubnets,
-        ["privateSubnets"] = myVpc.PrivateSubnets,
-        ["instanceId"] = webServer.Id,
-        ["publicIp"] = webServer.PublicIp,
-        ["websiteUrl"] = webServer.PublicIp.Apply(ip => $"http://{ip}"),
+        ["bucketArn"] = bucket.S3BucketArn,
+        ["bucketId"] = bucket.S3BucketId,
     };
 });
 ```
@@ -560,10 +219,10 @@ $ mkdir pulumi-terraform-modules-test && cd pulumi-terraform-modules-test
 $ pulumi new aws-java --yes
 ```
 
-Next, add the VPC module:
+Next, add the S3 bucket module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
+$ pulumi package add hcl module terraform-aws-modules/s3-bucket/aws 4.1.2
 ```
 
 {{% notes type="tip" %}}
@@ -587,107 +246,28 @@ The `pulumi package add ...` command will output some important instructions. Th
 
 {{% /notes %}}
 
-Then use it in your Pulumi program, by replacing the contents of `src/main/java/myproject/App.java` with:
+Then use it in your Pulumi program:
 
 ```java
 package myproject;
 
 import com.pulumi.Pulumi;
-import com.pulumi.aws.ec2.Ec2Functions;
-import com.pulumi.aws.ec2.Instance;
-import com.pulumi.aws.ec2.InstanceArgs;
-import com.pulumi.aws.ec2.SecurityGroup;
-import com.pulumi.aws.ec2.SecurityGroupArgs;
-import com.pulumi.aws.ec2.inputs.GetAmiArgs;
-import com.pulumi.aws.ec2.inputs.GetAmiFilterArgs;
-import com.pulumi.aws.ec2.inputs.SecurityGroupEgressArgs;
-import com.pulumi.aws.ec2.inputs.SecurityGroupIngressArgs;
-import java.util.Collections;
+import com.pulumi.s3bucket.Module;
+import com.pulumi.s3bucket.ModuleArgs;
 import java.util.Map;
 
 public class App {
     public static void main(String[] args) {
         Pulumi.run(ctx -> {
-            // Use the Terraform VPC module
-            var myVpc = new com.pulumi.vpc.Module("my-vpc", com.pulumi.vpc.ModuleArgs.builder()
-                .name("my-vpc")
-                .cidr("10.0.0.0/16")
-                .azs("us-west-2a", "us-west-2b", "us-west-2c")
-                .privateSubnets("10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24")
-                .publicSubnets("10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24")
-                .enableNatGateway(true)
-                .enableVpnGateway(true)
-                .tags(Map.of(
-                    "Terraform", "true",
-                    "Environment", "dev"
-                ))
+            // Create an S3 bucket using the Terraform module
+            var bucket = new Module("my-bucket", ModuleArgs.builder()
+                .bucketPrefix("my-example-bucket")
+                .tags(Map.of("Environment", "dev"))
                 .build());
 
-            // Get the latest Amazon Linux 2 AMI
-            var amazonLinux = Ec2Functions.getAmi(GetAmiArgs.builder()
-                .mostRecent(true)
-                .owners("amazon")
-                .filters(GetAmiFilterArgs.builder()
-                    .name("name")
-                    .values("amzn2-ami-hvm-*-x86_64-gp2")
-                    .build())
-                .build());
-
-            // Create a security group
-            var webSg = new SecurityGroup("web-sg", SecurityGroupArgs.builder()
-                .name("web-sg")
-                .description("Security group for web servers")
-                .vpcId(myVpc.vpcId().applyValue(id->id.get()).applyValue(String::valueOf))
-                .ingress(
-                    SecurityGroupIngressArgs.builder()
-                        .description("HTTP")
-                        .fromPort(80)
-                        .toPort(80)
-                        .protocol("tcp")
-                        .cidrBlocks("0.0.0.0/0")
-                        .build(),
-                    SecurityGroupIngressArgs.builder()
-                        .description("SSH")
-                        .fromPort(22)
-                        .toPort(22)
-                        .protocol("tcp")
-                        .cidrBlocks("0.0.0.0/0")
-                        .build()
-                )
-                .egress(SecurityGroupEgressArgs.builder()
-                    .fromPort(0)
-                    .toPort(0)
-                    .protocol("-1")
-                    .cidrBlocks("0.0.0.0/0")
-                    .build())
-                .build());
-
-            // Create an EC2 instance in the VPC
-            var webServer = new Instance("web-server", InstanceArgs.builder()
-                .ami(amazonLinux.applyValue(ami -> ami.id()))
-                .instanceType("t3.micro")
-                .subnetId(myVpc.publicSubnets().applyValue(subnets -> subnets.get().get(0)))
-                .vpcSecurityGroupIds(webSg.id().applyValue(s -> Collections.singletonList(s)))
-                .associatePublicIpAddress(true)
-                .userData(String.join("\n",
-                    "#!/bin/bash",
-                    "yum update -y",
-                    "yum install -y httpd",
-                    "systemctl start httpd",
-                    "systemctl enable httpd",
-                    "echo \"<h1>Hello from Pulumi and Terraform modules!</h1>\" > /var/www/html/index.html"
-                ))
-                .tags(Map.of(
-                    "Name", "web-server",
-                    "Environment", "dev"
-                ))
-                .build());
-
-            // Output important information
-            ctx.export("vpcId", myVpc.vpcId());
-            ctx.export("instanceId", webServer.id());
-            ctx.export("publicIp", webServer.publicIp());
-            ctx.export("websiteUrl", webServer.publicIp().applyValue(ip -> String.format("http://%s", ip)));
+            // The module's outputs are strongly typed
+            ctx.export("bucketArn", bucket.s3BucketArn());
+            ctx.export("bucketId", bucket.s3BucketId());
         });
     }
 }
@@ -704,10 +284,10 @@ $ mkdir pulumi-terraform-modules-test && cd pulumi-terraform-modules-test
 $ pulumi new aws-yaml --yes
 ```
 
-Next, add the VPC module:
+Next, add the S3 bucket module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
+$ pulumi package add hcl module terraform-aws-modules/s3-bucket/aws 4.1.2
 ```
 
 Then use it in your Pulumi program:
@@ -715,96 +295,30 @@ Then use it in your Pulumi program:
 ```yaml
 name: pulumi-terraform-modules-example
 runtime: yaml
-description: Use Terraform modules in Pulumi
-
-variables:
-  # Get the latest Amazon Linux 2 AMI
-  amazonLinux:
-    fn::invoke:
-      function: aws:ec2:getAmi
-      arguments:
-        mostRecent: true
-        owners: ["amazon"]
-        filters:
-          - name: name
-            values: ["amzn2-ami-hvm-*-x86_64-gp2"]
+description: Use a Terraform module in Pulumi
 
 resources:
-  # Use the Terraform VPC module
-  my-vpc:
-    type: vpc:index:Module
+  # Create an S3 bucket using the Terraform module
+  my-bucket:
+    type: s3-bucket:index:Module
     properties:
-      name: my-vpc
-      cidr: 10.0.0.0/16
-      azs: ["us-west-2a", "us-west-2b", "us-west-2c"]
-      privateSubnets: ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-      publicSubnets: ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"]
-      enableNatGateway: true
-      enableVpnGateway: true
+      bucketPrefix: my-example-bucket
       tags:
-        Terraform: "true"
-        Environment: "dev"
-
-  # Create a security group
-  web-sg:
-    type: aws:ec2:SecurityGroup
-    properties:
-      name: web-sg
-      description: Security group for web servers
-      vpcId: ${my-vpc.vpcId}
-      ingress:
-        - description: HTTP
-          fromPort: 80
-          toPort: 80
-          protocol: tcp
-          cidrBlocks: ["0.0.0.0/0"]
-        - description: SSH
-          fromPort: 22
-          toPort: 22
-          protocol: tcp
-          cidrBlocks: ["0.0.0.0/0"]
-      egress:
-        - fromPort: 0
-          toPort: 0
-          protocol: "-1"
-          cidrBlocks: ["0.0.0.0/0"]
-
-  # Create an EC2 instance in the VPC
-  web-server:
-    type: aws:ec2:Instance
-    properties:
-      ami: ${amazonLinux.id}
-      instanceType: t3.micro
-      subnetId: ${my-vpc.publicSubnets[0]}
-      vpcSecurityGroupIds:
-        - ${web-sg.id}
-      associatePublicIpAddress: true
-      userData: |
-        #!/bin/bash
-        yum update -y
-        yum install -y httpd
-        systemctl start httpd
-        systemctl enable httpd
-        echo "<h1>Hello from Pulumi and Terraform modules!</h1>" > /var/www/html/index.html
-      tags:
-        Name: web-server
         Environment: dev
 
+# The module's outputs are strongly typed
 outputs:
-  vpcId: ${my-vpc.vpcId}
-  instanceId: ${web-server.id}
-  publicIp: ${web-server.publicIp}
-  websiteUrl: http://${web-server.publicIp}
+  bucketArn: ${my-bucket.s3BucketArn}
+  bucketId: ${my-bucket.s3BucketId}
 
-# The vpc Terraform module package definition
 packages:
-  vpc:
+  s3-bucket:
     source: hcl
-    version: 0.12.0
+    version: 0.13.0
     parameters:
       - module
-      - terraform-aws-modules/vpc/aws
-      - 6.0.0
+      - terraform-aws-modules/s3-bucket/aws
+      - 4.1.2
 ```
 
 {{% /choosable %}}
@@ -813,7 +327,13 @@ packages:
 
 Generating an SDK gives you strongly typed inputs and outputs, IDE completion, and a package you can pin and share across your team. When you'd rather trade that type safety for flexibility — for example, to load a module whose address isn't known until runtime — you can use the [Any HCL Module](/registry/packages/hcl/) package directly.
 
-Add the Any HCL Module package to your project, then use its `Module` resource to load your desired module. The constructor takes a module `source`, an optional `version`, and a map of `inputs`, and exposes the module's outputs as an untyped map:
+Add the Any HCL Module package to your project:
+
+```bash
+$ pulumi package add hcl
+```
+
+Then use its `Module` resource to load your desired module. The constructor takes a module `source`, an optional `version`, and a map of `inputs`, and exposes the module's outputs as an untyped map:
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 
@@ -823,16 +343,15 @@ Add the Any HCL Module package to your project, then use its `Module` resource t
 import * as pulumi from "@pulumi/pulumi";
 import * as hcl from "@pulumi/hcl";
 
-const vpc = new hcl.Module("vpc", {
-    source: "terraform-aws-modules/vpc/aws",
-    version: "6.0.0",
+const bucket = new hcl.Module("bucket", {
+    source: "terraform-aws-modules/s3-bucket/aws",
+    version: "4.1.2",
     inputs: {
-        name: "example-vpc",
-        cidr: "10.0.0.0/16",
+        bucket_prefix: "my-example-bucket",
     },
 });
 
-export const vpcId = vpc.outputs.apply(o => o["vpcId"]);
+export const bucketArn = bucket.outputs.apply(o => o["s3_bucket_arn"]);
 ```
 
 {{% /choosable %}}
@@ -843,15 +362,14 @@ export const vpcId = vpc.outputs.apply(o => o["vpcId"]);
 import pulumi
 import pulumi_hcl as hcl
 
-vpc = hcl.Module("vpc",
-    source="terraform-aws-modules/vpc/aws",
-    version="6.0.0",
+bucket = hcl.Module("bucket",
+    source="terraform-aws-modules/s3-bucket/aws",
+    version="4.1.2",
     inputs={
-        "name": "example-vpc",
-        "cidr": "10.0.0.0/16",
+        "bucket_prefix": "my-example-bucket",
     })
 
-pulumi.export("vpc_id", vpc.outputs["vpc_id"])
+pulumi.export("bucket_arn", bucket.outputs["s3_bucket_arn"])
 ```
 
 {{% /choosable %}}
@@ -868,18 +386,17 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		vpc, err := hcl.NewModule(ctx, "vpc", &hcl.ModuleArgs{
-			Source:  "terraform-aws-modules/vpc/aws",
-			Version: pulumi.StringRef("6.0.0"),
+		bucket, err := hcl.NewModule(ctx, "bucket", &hcl.ModuleArgs{
+			Source:  "terraform-aws-modules/s3-bucket/aws",
+			Version: pulumi.StringRef("4.1.2"),
 			Inputs: pulumi.Map{
-				"name": pulumi.String("example-vpc"),
-				"cidr": pulumi.String("10.0.0.0/16"),
+				"bucket_prefix": pulumi.String("my-example-bucket"),
 			},
 		})
 		if err != nil {
 			return err
 		}
-		ctx.Export("vpcId", vpc.Outputs.MapIndex(pulumi.String("vpc_id")))
+		ctx.Export("bucketArn", bucket.Outputs.MapIndex(pulumi.String("s3_bucket_arn")))
 		return nil
 	})
 }
@@ -896,20 +413,19 @@ using Pulumi.Hcl;
 
 return await Deployment.RunAsync(() =>
 {
-    var vpc = new Module("vpc", new ModuleArgs
+    var bucket = new Module("bucket", new ModuleArgs
     {
-        Source = "terraform-aws-modules/vpc/aws",
-        Version = "6.0.0",
+        Source = "terraform-aws-modules/s3-bucket/aws",
+        Version = "4.1.2",
         Inputs =
         {
-            { "name", "example-vpc" },
-            { "cidr", "10.0.0.0/16" },
+            { "bucket_prefix", "my-example-bucket" },
         },
     });
 
     return new Dictionary<string, object?>
     {
-        ["vpcId"] = vpc.Outputs.Apply(o => o["vpc_id"]),
+        ["bucketArn"] = bucket.Outputs.Apply(o => o["s3_bucket_arn"]),
     };
 });
 ```
@@ -929,15 +445,14 @@ import java.util.Map;
 public class App {
     public static void main(String[] args) {
         Pulumi.run(ctx -> {
-            var vpc = new Module("vpc", ModuleArgs.builder()
-                .source("terraform-aws-modules/vpc/aws")
-                .version("6.0.0")
+            var bucket = new Module("bucket", ModuleArgs.builder()
+                .source("terraform-aws-modules/s3-bucket/aws")
+                .version("4.1.2")
                 .inputs(Map.of(
-                    "name", "example-vpc",
-                    "cidr", "10.0.0.0/16"))
+                    "bucket_prefix", "my-example-bucket"))
                 .build());
 
-            ctx.export("vpcId", vpc.outputs().applyValue(o -> o.get("vpcId")));
+            ctx.export("bucketArn", bucket.outputs().applyValue(o -> o.get("s3_bucket_arn")));
         });
     }
 }
@@ -951,16 +466,15 @@ public class App {
 name: example
 runtime: yaml
 resources:
-  vpc:
+  bucket:
     type: hcl:index:Module
     properties:
-      source: terraform-aws-modules/vpc/aws
-      version: "6.0.0"
+      source: terraform-aws-modules/s3-bucket/aws
+      version: "4.1.2"
       inputs:
-        name: example-vpc
-        cidr: 10.0.0.0/16
+        bucket_prefix: my-example-bucket
 outputs:
-  vpcId: ${vpc.outputs["vpcId"]}
+  bucketArn: ${bucket.outputs["s3_bucket_arn"]}
 ```
 
 {{% /choosable %}}
@@ -971,100 +485,22 @@ The same functionality in Terraform would look like:
 
 ```hcl
 # Terraform equivalent
-module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
 
-  name = "my-vpc"
-  cidr = "10.0.0.0/16"
-
-  azs             = ["us-west-2a", "us-west-2b", "us-west-2c"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"]
-
-  enable_nat_gateway = true
-  enable_vpn_gateway = true
+  bucket_prefix = "my-example-bucket"
 
   tags = {
-    Terraform = "true"
     Environment = "dev"
   }
 }
 
-data "aws_ami" "amazon_linux" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
-  }
+output "bucket_arn" {
+  value = module.s3_bucket.s3_bucket_arn
 }
 
-resource "aws_security_group" "web_sg" {
-  name        = "web-sg"
-  description = "Security group for web servers"
-  vpc_id      = module.vpc.vpc_id
-
-  ingress {
-    description = "HTTP"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    description = "SSH"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_instance" "web_server" {
-  ami           = data.aws_ami.amazon_linux.id
-  instance_type = "t3.micro"
-  subnet_id     = module.vpc.public_subnets[0]
-  vpc_security_group_ids = [aws_security_group.web_sg.id]
-  associate_public_ip_address = true
-
-  user_data = <<-EOF
-    #!/bin/bash
-    yum update -y
-    yum install -y httpd
-    systemctl start httpd
-    systemctl enable httpd
-    echo "<h1>Hello from Pulumi and Terraform modules!</h1>" > /var/www/html/index.html
-  EOF
-
-  tags = {
-    Name = "web-server"
-    Environment = "dev"
-  }
-}
-
-output "vpc_id" {
-  value = module.vpc.vpc_id
-}
-
-output "instance_id" {
-  value = aws_instance.web_server.id
-}
-
-output "public_ip" {
-  value = aws_instance.web_server.public_ip
-}
-
-output "website_url" {
-  value = "http://${aws_instance.web_server.public_ip}"
+output "bucket_id" {
+  value = module.s3_bucket.s3_bucket_id
 }
 ```
 
@@ -1086,7 +522,6 @@ Test your deployment and clean up resources:
 # Deploy the stack
 $ pulumi up
 
-# Visit the website URL from the output
 # When done, destroy the resources
 $ pulumi destroy
 ```

--- a/content/docs/iac/get-started/terraform/terraform-modules.md
+++ b/content/docs/iac/get-started/terraform/terraform-modules.md
@@ -15,8 +15,8 @@ aliases:
 
 ## Leverage the module ecosystem
 
-Pulumi can directly use existing Terraform modules from the Terraform Registry, private registries, or local sources.
-This allows you to access thousands of existing modules without rewriting them in Pulumi.
+Pulumi can directly use existing Terraform modules from the Terraform Registry, private registries, or local sources. This allows you to access thousands of existing modules without rewriting them in Pulumi.
+It's powered by the [`hcl` provider](/registry/packages/hcl/), which turns any Terraform or OpenTofu module into a Pulumi component, either as a strongly typed SDK or loaded dynamically at runtime.
 
 ## Add Terraform modules
 
@@ -24,10 +24,10 @@ Use the `pulumi package add` command to add Terraform modules to your project:
 
 ```bash
 # Add a module from the Terraform Registry
-$ pulumi package add terraform-module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
 
 # Add a local module
-$ pulumi package add terraform-module ./path/to/module localmod
+$ pulumi package add hcl module ./path/to/module localmod
 ```
 
 ## Example: AWS VPC module
@@ -48,7 +48,7 @@ $ pulumi new aws-typescript --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add terraform-module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
 ```
 
 Then use it in your Pulumi program:
@@ -164,7 +164,7 @@ $ pulumi new aws-python --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add terraform-module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
 ```
 
 Then use it in your Pulumi program:
@@ -278,7 +278,7 @@ $ pulumi new aws-go --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add terraform-module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
 ```
 
 Then use it in your Pulumi program:
@@ -415,7 +415,7 @@ $ pulumi new aws-csharp --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add terraform-module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
 ```
 
 {{% notes type="tip" %}}
@@ -562,7 +562,7 @@ $ pulumi new aws-java --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add terraform-module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
 ```
 
 {{% notes type="tip" %}}
@@ -706,7 +706,7 @@ $ pulumi new aws-yaml --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add terraform-module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
 ```
 
 Then use it in your Pulumi program:
@@ -804,6 +804,162 @@ packages:
       - terraform-aws-modules/vpc/aws
       - 6.0.0
       - vpc
+```
+
+{{% /choosable %}}
+
+## Load a module at runtime
+
+Generating an SDK gives you strongly typed inputs and outputs, IDE completion, and a package you can pin and share across your team. When you'd rather trade that type safety for flexibility — for example, to load a module whose address isn't known until runtime — you can use the [`hcl` provider](/registry/packages/hcl/) instead of generating an SDK.
+
+Add the `hcl` provider to your project, then use the `Module` resource to load your desired module. The constructor takes a module `source`, an optional `version`, and a map of `inputs`, and exposes the module's outputs as an untyped map:
+
+{{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
+
+{{% choosable language "typescript" %}}
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as hcl from "@pulumi/hcl";
+
+const vpc = new hcl.Module("vpc", {
+    source: "terraform-aws-modules/vpc/aws",
+    version: "6.0.0",
+    inputs: {
+        name: "example-vpc",
+        cidr: "10.0.0.0/16",
+    },
+});
+
+export const vpcId = vpc.outputs.apply(o => o["vpc_id"]);
+```
+
+{{% /choosable %}}
+
+{{% choosable language "python" %}}
+
+```python
+import pulumi
+import pulumi_hcl as hcl
+
+vpc = hcl.Module("vpc",
+    source="terraform-aws-modules/vpc/aws",
+    version="6.0.0",
+    inputs={
+        "name": "example-vpc",
+        "cidr": "10.0.0.0/16",
+    })
+
+pulumi.export("vpc_id", vpc.outputs["vpc_id"])
+```
+
+{{% /choosable %}}
+
+{{% choosable language "go" %}}
+
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-hcl/sdk/go/hcl"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		vpc, err := hcl.NewModule(ctx, "vpc", &hcl.ModuleArgs{
+			Source:  "terraform-aws-modules/vpc/aws",
+			Version: pulumi.StringRef("6.0.0"),
+			Inputs: pulumi.Map{
+				"name": pulumi.String("example-vpc"),
+				"cidr": pulumi.String("10.0.0.0/16"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("vpcId", vpc.Outputs.MapIndex(pulumi.String("vpc_id")))
+		return nil
+	})
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language "csharp" %}}
+
+```csharp
+using System.Collections.Generic;
+using Pulumi;
+using Pulumi.Hcl;
+
+return await Deployment.RunAsync(() =>
+{
+    var vpc = new Module("vpc", new ModuleArgs
+    {
+        Source = "terraform-aws-modules/vpc/aws",
+        Version = "6.0.0",
+        Inputs =
+        {
+            { "name", "example-vpc" },
+            { "cidr", "10.0.0.0/16" },
+        },
+    });
+
+    return new Dictionary<string, object?>
+    {
+        ["vpcId"] = vpc.Outputs.Apply(o => o["vpc_id"]),
+    };
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language "java" %}}
+
+```java
+package myapp;
+
+import com.pulumi.Pulumi;
+import com.pulumi.hcl.Module;
+import com.pulumi.hcl.ModuleArgs;
+import java.util.Map;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(ctx -> {
+            var vpc = new Module("vpc", ModuleArgs.builder()
+                .source("terraform-aws-modules/vpc/aws")
+                .version("6.0.0")
+                .inputs(Map.of(
+                    "name", "example-vpc",
+                    "cidr", "10.0.0.0/16"))
+                .build());
+
+            ctx.export("vpcId", vpc.outputs().applyValue(o -> o.get("vpc_id")));
+        });
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language "yaml" %}}
+
+```yaml
+name: example
+runtime: yaml
+resources:
+  vpc:
+    type: hcl:index:Module
+    properties:
+      source: terraform-aws-modules/vpc/aws
+      version: "6.0.0"
+      inputs:
+        name: example-vpc
+        cidr: 10.0.0.0/16
+outputs:
+  vpcId: ${vpc.outputs["vpc_id"]}
 ```
 
 {{% /choosable %}}

--- a/content/docs/iac/get-started/terraform/terraform-modules.md
+++ b/content/docs/iac/get-started/terraform/terraform-modules.md
@@ -16,7 +16,7 @@ aliases:
 ## Leverage the module ecosystem
 
 Pulumi can directly use existing Terraform modules from the Terraform Registry, private registries, or local sources. This allows you to access thousands of existing modules without rewriting them in Pulumi.
-It's powered by the [`hcl` provider](/registry/packages/hcl/), which turns any Terraform or OpenTofu module into a Pulumi component, either as a strongly typed SDK or loaded dynamically at runtime.
+It's powered by the [Any HCL Module](/registry/packages/hcl/) package, which turns any Terraform or OpenTofu module into a Pulumi component, either as a strongly typed SDK or loaded dynamically at runtime.
 
 ## Add Terraform modules
 
@@ -24,10 +24,10 @@ Use the `pulumi package add` command to add Terraform modules to your project:
 
 ```bash
 # Add a module from the Terraform Registry
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
 
 # Add a local module
-$ pulumi package add hcl module ./path/to/module localmod
+$ pulumi package add hcl module ./path/to/module
 ```
 
 ## Example: AWS VPC module
@@ -48,7 +48,7 @@ $ pulumi new aws-typescript --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
 ```
 
 Then use it in your Pulumi program:
@@ -164,7 +164,7 @@ $ pulumi new aws-python --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
 ```
 
 Then use it in your Pulumi program:
@@ -278,7 +278,7 @@ $ pulumi new aws-go --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
 ```
 
 Then use it in your Pulumi program:
@@ -288,7 +288,7 @@ package main
 
 import (
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
-	vpc "github.com/pulumi/pulumi-terraform-module/sdks/go/vpc/v6/vpc"
+	vpc "example.com/pulumi-vpc/sdk/go/vpc"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -415,7 +415,7 @@ $ pulumi new aws-csharp --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
 ```
 
 {{% notes type="tip" %}}
@@ -562,7 +562,7 @@ $ pulumi new aws-java --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
 ```
 
 {{% notes type="tip" %}}
@@ -706,7 +706,7 @@ $ pulumi new aws-yaml --yes
 Next, add the VPC module:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 6.0.0
 ```
 
 Then use it in your Pulumi program:
@@ -798,21 +798,21 @@ outputs:
 # The vpc Terraform module package definition
 packages:
   vpc:
-    source: terraform-module
-    version: 0.1.4
+    source: hcl
+    version: 0.12.0
     parameters:
+      - module
       - terraform-aws-modules/vpc/aws
       - 6.0.0
-      - vpc
 ```
 
 {{% /choosable %}}
 
 ## Load a module at runtime
 
-Generating an SDK gives you strongly typed inputs and outputs, IDE completion, and a package you can pin and share across your team. When you'd rather trade that type safety for flexibility — for example, to load a module whose address isn't known until runtime — you can use the [`hcl` provider](/registry/packages/hcl/) instead of generating an SDK.
+Generating an SDK gives you strongly typed inputs and outputs, IDE completion, and a package you can pin and share across your team. When you'd rather trade that type safety for flexibility — for example, to load a module whose address isn't known until runtime — you can use the [Any HCL Module](/registry/packages/hcl/) package directly.
 
-Add the `hcl` provider to your project, then use the `Module` resource to load your desired module. The constructor takes a module `source`, an optional `version`, and a map of `inputs`, and exposes the module's outputs as an untyped map:
+Add the Any HCL Module package to your project, then use its `Module` resource to load your desired module. The constructor takes a module `source`, an optional `version`, and a map of `inputs`, and exposes the module's outputs as an untyped map:
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 

--- a/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
+++ b/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
@@ -61,8 +61,6 @@ Where:
 - `<module-source>` is either a registry module identifier (e.g. `terraform-aws-modules/rds/aws`) or a local path
 - `<version>` is an optional version constraint (e.g. `3.5.0`)
 
-Pulumi derives the package name from the module source, so there's no name to pass — a module at `terraform-aws-modules/vpc/aws` becomes the `vpc` package.
-
 For example, to add the AWS VPC module from the Terraform Registry:
 
 ```bash
@@ -170,27 +168,27 @@ const vpc = new vpcmod.Module("test-vpc", {
   azs: azs,
   name: `test-vpc-${prefix}`,
   cidr,
-  public_subnets: azs.apply(azs => azs.map((_, i) => {
+  publicSubnets: azs.apply(azs => azs.map((_, i) => {
     return getCidrSubnet(cidr, i+1);
   })),
-  private_subnets: azs.apply(azs => azs.map((_, i) => {
+  privateSubnets: azs.apply(azs => azs.map((_, i) => {
     return getCidrSubnet(cidr, i+1+4);
   })),
-  database_subnets: azs.apply(azs => azs.map((_, i) => {
+  databaseSubnets: azs.apply(azs => azs.map((_, i) => {
     return getCidrSubnet(cidr, i+1 + 8);
   })),
-  create_database_subnet_group: true,
+  createDatabaseSubnetGroup: true,
 });
 
 // Create a security group for the RDS instance
 const rdsSecurityGroup = new aws.ec2.SecurityGroup('test-rds-sg', {
-  vpcId: vpc.vpc_id.apply(id => id!),
+  vpcId: vpc.vpcId.apply(id => id!),
 });
 
 new aws.vpc.SecurityGroupIngressRule('test-rds-sg-ingress', {
   ipProtocol: 'tcp',
   securityGroupId: rdsSecurityGroup.id,
-  cidrIpv4: vpc.vpc_cidr_block.apply(cidr => cidr!),
+  cidrIpv4: vpc.vpcCidrBlock.apply(cidr => cidr!),
   fromPort: 3306,
   toPort: 3306,
 });
@@ -199,23 +197,23 @@ new aws.vpc.SecurityGroupIngressRule('test-rds-sg-ingress', {
 new rdsmod.Module("test-rds", {
   engine: "mysql",
   identifier: `test-rds-${prefix}`,
-  manage_master_user_password: true,
-  publicly_accessible: false,
-  allocated_storage: 20,
-  max_allocated_storage: 100,
-  instance_class: "db.t4g.large",
-  engine_version: "8.0",
+  manageMasterUserPassword: true,
+  publiclyAccessible: false,
+  allocatedStorage: 20,
+  maxAllocatedStorage: 100,
+  instanceClass: "db.t4g.large",
+  engineVersion: "8.0",
   family: "mysql8.0",
-  db_name: "completeMysql",
+  dbName: "completeMysql",
   username: "complete_mysql",
   port: '3306',
-  multi_az: true,
-  db_subnet_group_name: vpc.database_subnet_group_name.apply(name => name!),
-  vpc_security_group_ids: [rdsSecurityGroup.id],
-  skip_final_snapshot: true,
-  deletion_protection: false,
-  create_db_option_group: false,
-  create_db_parameter_group: false,
+  multiAz: true,
+  dbSubnetGroupName: vpc.databaseSubnetGroupName.apply(name => name!),
+  vpcSecurityGroupIds: [rdsSecurityGroup.id],
+  skipFinalSnapshot: true,
+  deletionProtection: false,
+  createDbOptionGroup: false,
+  createDbParameterGroup: false,
 });
 
 // Utility function to calculate subnet CIDRs
@@ -364,10 +362,10 @@ func run(ctx *pulumi.Context) error {
 		Azs:                          azNames,
 		Name:                         pulumi.Sprintf("test-vpc-%s", prefix),
 		Cidr:                         pulumi.String(cidr),
-		Public_subnets:               applyAznamesForSubnet(ctx, azNames, cidr, 1),
-		Private_subnets:              applyAznamesForSubnet(ctx, azNames, cidr, 5),
-		Database_subnets:             applyAznamesForSubnet(ctx, azNames, cidr, 9),
-		Create_database_subnet_group: pulumi.Bool(true),
+		PublicSubnets:               applyAznamesForSubnet(ctx, azNames, cidr, 1),
+		PrivateSubnets:              applyAznamesForSubnet(ctx, azNames, cidr, 5),
+		DatabaseSubnets:             applyAznamesForSubnet(ctx, azNames, cidr, 9),
+		CreateDatabaseSubnetGroup: pulumi.Bool(true),
 	})
 	if err != nil {
 		return err
@@ -375,7 +373,7 @@ func run(ctx *pulumi.Context) error {
 
 	// Create a security group for the RDS instance
 	rdsSecurityGroup, err := ec2.NewSecurityGroup(ctx, "test-rds-sg", &ec2.SecurityGroupArgs{
-		VpcId: vpcInstance.Vpc_id,
+		VpcId: vpcInstance.VpcId,
 	})
 	if err != nil {
 		return err
@@ -383,7 +381,7 @@ func run(ctx *pulumi.Context) error {
 	_, err = vpc.NewSecurityGroupIngressRule(ctx, "test-rds-sg-ingress", &vpc.SecurityGroupIngressRuleArgs{
 		IpProtocol:      pulumi.String("tcp"),
 		SecurityGroupId: rdsSecurityGroup.ID(),
-		CidrIpv4:        vpcInstance.Vpc_cidr_block,
+		CidrIpv4:        vpcInstance.VpcCidrBlock,
 		FromPort:        pulumi.Int(3306),
 		ToPort:          pulumi.Int(3306),
 	})
@@ -395,23 +393,23 @@ func run(ctx *pulumi.Context) error {
 	_, err = rdsmod.NewModule(ctx, "test-rds", &rdsmod.ModuleArgs{
 		Engine:                      pulumi.String("mysql"),
 		Identifier:                  pulumi.Sprintf("test-rds-%s", prefix),
-		Manage_master_user_password: pulumi.Bool(true),
-		Publicly_accessible:         pulumi.Bool(false),
-		Allocated_storage:           pulumi.Float64(20),
-		Max_allocated_storage:       pulumi.Float64(100),
-		Instance_class:              pulumi.String("db.t4g.large"),
-		Engine_version:              pulumi.String("8.0"),
+		ManageMasterUserPassword: pulumi.Bool(true),
+		PubliclyAccessible:         pulumi.Bool(false),
+		AllocatedStorage:           pulumi.Float64(20),
+		MaxAllocatedStorage:       pulumi.Float64(100),
+		InstanceClass:              pulumi.String("db.t4g.large"),
+		EngineVersion:              pulumi.String("8.0"),
 		Family:                      pulumi.String("mysql8.0"),
-		Db_name:                     pulumi.String("completeMysql"),
+		DbName:                     pulumi.String("completeMysql"),
 		Username:                    pulumi.String("complete_mysql"),
 		Port:                        pulumi.String("3306"),
-		Multi_az:                    pulumi.Bool(true),
-		Db_subnet_group_name:        vpcInstance.Database_subnet_group_name,
-		Vpc_security_group_ids:      pulumi.StringArray{rdsSecurityGroup.ID()},
-		Skip_final_snapshot:         pulumi.Bool(true),
-		Deletion_protection:         pulumi.Bool(false),
-		Create_db_option_group:      pulumi.Bool(false),
-		Create_db_parameter_group:   pulumi.Bool(false),
+		MultiAz:                    pulumi.Bool(true),
+		DbSubnetGroupName:        vpcInstance.DatabaseSubnetGroupName,
+		VpcSecurityGroupIds:      pulumi.StringArray{rdsSecurityGroup.ID()},
+		SkipFinalSnapshot:         pulumi.Bool(true),
+		DeletionProtection:         pulumi.Bool(false),
+		CreateDbOptionGroup:      pulumi.Bool(false),
+		CreateDbParameterGroup:   pulumi.Bool(false),
 	})
 	return err
 }
@@ -491,23 +489,23 @@ return await Deployment.RunAsync(() =>
         Azs = azs,
         Name = Output.Format($"test-vpc-{prefix}"),
         Cidr = cidr,
-        Public_subnets = Utils.Subnets(cidr, azs, 1),
-        Private_subnets = Utils.Subnets(cidr, azs, 5),
-        Database_subnets = Utils.Subnets(cidr, azs, 9),
-        Create_database_subnet_group = true,
+        PublicSubnets = Utils.Subnets(cidr, azs, 1),
+        PrivateSubnets = Utils.Subnets(cidr, azs, 5),
+        DatabaseSubnets = Utils.Subnets(cidr, azs, 9),
+        CreateDatabaseSubnetGroup = true,
     });
 
     // Create a security group for the RDS instance
     var rdsSecurityGroup = new Aws.Ec2.SecurityGroup("test-rds-sg", new Aws.Ec2.SecurityGroupArgs
     {
-        VpcId = vpc.Vpc_id.Apply(id => id ?? string.Empty),
+        VpcId = vpc.VpcId.Apply(id => id ?? string.Empty),
     });
 
     _ = new Aws.Vpc.SecurityGroupIngressRule("test-rds-sg-ingress", new Aws.Vpc.SecurityGroupIngressRuleArgs
     {
         IpProtocol = "tcp",
         SecurityGroupId = rdsSecurityGroup.Id,
-        CidrIpv4 = vpc.Vpc_cidr_block.Apply(x => x!),
+        CidrIpv4 = vpc.VpcCidrBlock.Apply(x => x!),
         FromPort = 3306,
         ToPort = 3306,
     });
@@ -517,23 +515,23 @@ return await Deployment.RunAsync(() =>
     {
         Engine = "mysql",
         Identifier = Output.Format($"test-rds-{prefix}"),
-        Manage_master_user_password = true,
-        Publicly_accessible = false,
-        Allocated_storage = 20,
-        Max_allocated_storage = 100,
-        Instance_class = "db.t4g.large",
-        Engine_version = "8.0",
+        ManageMasterUserPassword = true,
+        PubliclyAccessible = false,
+        AllocatedStorage = 20,
+        MaxAllocatedStorage = 100,
+        InstanceClass = "db.t4g.large",
+        EngineVersion = "8.0",
         Family = "mysql8.0",
-        Db_name = "completeMysql",
+        DbName = "completeMysql",
         Username = "complete_mysql",
         Port = "3306",
-        Multi_az = true,
-        Db_subnet_group_name = vpc.Database_subnet_group_name,
-        Vpc_security_group_ids = { rdsSecurityGroup.Id },
-        Skip_final_snapshot = true,
-        Deletion_protection = false,
-        Create_db_option_group = false,
-        Create_db_parameter_group = false,
+        MultiAz = true,
+        DbSubnetGroupName = vpc.DatabaseSubnetGroupName,
+        VpcSecurityGroupIds = { rdsSecurityGroup.Id },
+        SkipFinalSnapshot = true,
+        DeletionProtection = false,
+        CreateDbOptionGroup = false,
+        CreateDbParameterGroup = false,
     });
 });
 
@@ -603,20 +601,20 @@ public class App {
             .azs(azNames)
             .name("test-vpc-" + prefix)
             .cidr(cidr)
-            .public_subnets(subnets(cidr, azNames, 1))
-            .private_subnets(subnets(cidr, azNames, 5))
-            .database_subnets(subnets(cidr, azNames, 9))
-            .create_database_subnet_group(true)
+            .publicSubnets(subnets(cidr, azNames, 1))
+            .privateSubnets(subnets(cidr, azNames, 5))
+            .databaseSubnets(subnets(cidr, azNames, 9))
+            .createDatabaseSubnetGroup(true)
             .build());
 
         final var rdsSecurityGroup = new SecurityGroup("test-rds-sg", SecurityGroupArgs.builder()
-            .vpcId(vpc.vpc_id().applyValue(x -> x.get()))
+            .vpcId(vpc.vpcId().applyValue(x -> x.get()))
             .build());
 
         new SecurityGroupIngressRule("test-rds-sg-ingress", SecurityGroupIngressRuleArgs.builder()
             .ipProtocol("tcp")
             .securityGroupId(rdsSecurityGroup.id())
-            .cidrIpv4(vpc.vpc_cidr_block().applyValue(x -> x.get()))
+            .cidrIpv4(vpc.vpcCidrBlock().applyValue(x -> x.get()))
             .fromPort(3306)
             .toPort(3306)
             .build());
@@ -624,23 +622,23 @@ public class App {
         new com.pulumi.rds.Module("test-rds", com.pulumi.rds.ModuleArgs.builder()
             .engine("mysql")
             .identifier("test-rds-" + prefix)
-            .manage_master_user_password(true)
-            .publicly_accessible(false)
-            .allocated_storage(20.0)
-            .max_allocated_storage(100.0)
-            .instance_class("db.t4g.large")
-            .engine_version("8.0")
+            .manageMasterUserPassword(true)
+            .publiclyAccessible(false)
+            .allocatedStorage(20.0)
+            .maxAllocatedStorage(100.0)
+            .instanceClass("db.t4g.large")
+            .engineVersion("8.0")
             .family("mysql8.0")
-            .db_name("completeMysql")
+            .dbName("completeMysql")
             .username("complete_mysql")
             .port("3306")
-            .multi_az(true)
-            .db_subnet_group_name(vpc.database_subnet_group_name().applyValue(x -> x.get()))
-            .vpc_security_group_ids(rdsSecurityGroup.id().applyValue(x -> Collections.singletonList(x)))
-            .skip_final_snapshot(true)
-            .deletion_protection(false)
-            .create_db_option_group(false)
-            .create_db_parameter_group(false)
+            .multiAz(true)
+            .dbSubnetGroupName(vpc.databaseSubnetGroupName().applyValue(x -> x.get()))
+            .vpcSecurityGroupIds(rdsSecurityGroup.id().applyValue(x -> Collections.singletonList(x)))
+            .skipFinalSnapshot(true)
+            .deletionProtection(false)
+            .createDbOptionGroup(false)
+            .createDbParameterGroup(false)
             .build());
     }
 
@@ -693,29 +691,29 @@ resources:
         - us-west-2b
         - us-west-2c
       cidr: 10.0.0.0/16
-      public_subnets:
+      publicSubnets:
         - 10.0.1.0/24
         - 10.0.2.0/24
         - 10.0.3.0/24
-      private_subnets:
+      privateSubnets:
         - 10.0.5.0/24
         - 10.0.6.0/24
         - 10.0.7.0/24
-      database_subnets:
+      databaseSubnets:
         - 10.0.9.0/24
         - 10.0.10.0/24
         - 10.0.11.0/24
-      create_database_subnet_group: true
+      createDatabaseSubnetGroup: true
   testRdsSg:
     type: aws:ec2:SecurityGroup
     properties:
-      vpcId: ${testVpc.vpc_id}
+      vpcId: ${testVpc.vpcId}
   testRdsSgIngress:
     type: aws:vpc:SecurityGroupIngressRule
     properties:
       ipProtocol: tcp
       securityGroupId: ${testRdsSg.id}
-      cidrIpv4: ${testVpc.vpc_cidr_block}
+      cidrIpv4: ${testVpc.vpcCidrBlock}
       fromPort: 3306
       toPort: 3306
   testRds:
@@ -723,24 +721,24 @@ resources:
     properties:
       engine: mysql
       identifier: test-rds-${pulumi.stack}
-      manage_master_user_password: true
-      publicly_accessible: false
-      allocated_storage: 20
-      max_allocated_storage: 100
-      instance_class: db.t4g.large
-      engine_version: 8
+      manageMasterUserPassword: true
+      publiclyAccessible: false
+      allocatedStorage: 20
+      maxAllocatedStorage: 100
+      instanceClass: db.t4g.large
+      engineVersion: 8
       family: mysql8.0
-      db_name: completeMysql
+      dbName: completeMysql
       username: complete_mysql
       port: '3306'
-      multi_az: true
-      db_subnet_group_name: ${testVpc.database_subnet_group_name}
-      vpc_security_group_ids:
+      multiAz: true
+      dbSubnetGroupName: ${testVpc.databaseSubnetGroupName}
+      vpcSecurityGroupIds:
         - ${testRdsSg.id}
-      skip_final_snapshot: true
-      deletion_protection: false
-      create_db_option_group: false
-      create_db_parameter_group: false
+      skipFinalSnapshot: true
+      deletionProtection: false
+      createDbOptionGroup: false
+      createDbParameterGroup: false
 packages:
   rds:
     source: hcl

--- a/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
+++ b/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
@@ -335,7 +335,7 @@ You can also supply provider settings, including short-lived credentials, throug
 
 ### Fixing Invalid Relative Paths
 
-When a module accepts a file path, pass an absolute path instead of a relative one. For example, the [AWS Lambda module](https://registry.terraform.io/modules/terraform-aws-modules/lambda/aws) accepts a `source_path` that points to the location of function's code:
+When a module accepts a file path, pass an absolute path instead of a relative one. For example, the [AWS Lambda module](https://registry.terraform.io/modules/terraform-aws-modules/lambda/aws) accepts a `source_path` that points to your function's code:
 
 ```typescript
 import * as hcl from "@pulumi/hcl";
@@ -351,4 +351,4 @@ const lambdaModule = new hcl.Module("my-lambda", {
 });
 ```
 
-This is necessary because Terraform modules run from a different working directory than your Pulumi program, so a relative path would resolve incorrectly. The example above uses the Node.js built-in `process.cwd()` to use the full path of the current working directory to resolve the full path to the function code in `src`.
+This is necessary because Terraform modules run from a different working directory than your Pulumi program, so a relative path would resolve incorrectly. The example above uses the Node.js built-in `process.cwd()` to anchor the path to the function code in `src` to your project's working directory.

--- a/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
+++ b/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
@@ -53,7 +53,7 @@ Pulumi's Terraform Module provider allows you to consume Terraform modules as if
 To use a Terraform module in Pulumi, first add it to your project using the `pulumi package add` command:
 
 ```bash
-pulumi package add terraform-module <module-source> [<version>] <pulumi-package-name>
+pulumi package add hcl module <module-source> [<version>] <pulumi-package-name>
 ```
 
 Where:
@@ -65,7 +65,7 @@ Where:
 For example, to add the AWS VPC module from the Terraform Registry:
 
 ```bash
-pulumi package add terraform-module terraform-aws-modules/vpc/aws 5.19.0 vpc
+pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0 vpc
 ```
 
 This will generate a local SDK in your programming language that you can import into your Pulumi program.
@@ -79,7 +79,7 @@ See [Local SDKs](/docs/iac/guides/building-extending/packages/local-sdks/) for d
 You can also use local Terraform modules:
 
 ```bash
-pulumi package add terraform-module ./path/to/module localmod
+pulumi package add hcl module ./path/to/module localmod
 ```
 
 Any directory containing `.tf` files and optionally `variables.tf` and `outputs.tf` is considered a valid module.
@@ -105,8 +105,8 @@ Here's an example of how to use the AWS RDS module to provision a MySQL database
 First, start by installing the Terraform modules:
 
 ```bash
-$ pulumi package add terraform-module terraform-aws-modules/vpc/aws 5.19.0 vpc
-$ pulumi package add terraform-module terraform-aws-modules/rds/aws 6.10.0 rdsmod
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0 vpc
+$ pulumi package add hcl module terraform-aws-modules/rds/aws 6.10.0 rdsmod
 ```
 
 After adding the packages, your `Pulumi.yaml` will be updated, and any necessary dependencies will be added to your project.

--- a/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
+++ b/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
@@ -39,7 +39,7 @@ Also, many Terraform users have created their own custom modules and would like 
 
 ## How It Works
 
-Pulumi's Terraform Module provider allows you to consume Terraform modules as if they were native Pulumi packages. It works by:
+The [Any HCL Module](/registry/packages/hcl/) package allows you to consume Terraform modules as if they were native Pulumi packages. It works by:
 
 1. Automatically installing and managing [OpenTofu](https://opentofu.org/) (an open-source Terraform-compatible implementation) to execute the module.
 2. Translating Pulumi resource declarations to Terraform configurations.
@@ -53,19 +53,20 @@ Pulumi's Terraform Module provider allows you to consume Terraform modules as if
 To use a Terraform module in Pulumi, first add it to your project using the `pulumi package add` command:
 
 ```bash
-pulumi package add hcl module <module-source> [<version>] <pulumi-package-name>
+pulumi package add hcl module <module-source> [<version>]
 ```
 
 Where:
 
 - `<module-source>` is either a registry module identifier (e.g. `terraform-aws-modules/rds/aws`) or a local path
 - `<version>` is an optional version constraint (e.g. `3.5.0`)
-- `<pulumi-package-name>` is the name you want to use for the Pulumi package
+
+Pulumi derives the package name from the module source, so there's no name to pass — a module at `terraform-aws-modules/vpc/aws` becomes the `vpc` package.
 
 For example, to add the AWS VPC module from the Terraform Registry:
 
 ```bash
-pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0 vpc
+pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0
 ```
 
 This will generate a local SDK in your programming language that you can import into your Pulumi program.
@@ -79,7 +80,7 @@ See [Local SDKs](/docs/iac/guides/building-extending/packages/local-sdks/) for d
 You can also use local Terraform modules:
 
 ```bash
-pulumi package add hcl module ./path/to/module localmod
+pulumi package add hcl module ./path/to/module
 ```
 
 Any directory containing `.tf` files and optionally `variables.tf` and `outputs.tf` is considered a valid module.
@@ -89,7 +90,7 @@ Any directory containing `.tf` files and optionally `variables.tf` and `outputs.
 If your organization publishes Terraform modules to the [Pulumi Cloud registry](/docs/idp/concepts/terraform-modules/), every published version is converted into a Pulumi package for you. Install it by package name, which is the module's name and system joined with a hyphen. The system is the last segment of the module's address, naming what the module provisions, such as `aws` or `azurerm`:
 
 ```bash
-pulumi package add <name>-<system> [<version>]
+pulumi package add <name>-<system>[@<version>]
 ```
 
 A module published as `acme-corp/vpc/aws` installs as `vpc-aws`. This is the same as any other Pulumi package: you get a generated SDK in your language, an [API reference](/docs/idp/concepts/private-registry/#api-documentation) on the package's page, and [usage tracking](/docs/idp/concepts/private-registry/#usage-tracking) showing which of your stacks depend on it and which are behind the latest version. Installing a converted package requires Pulumi CLI 3.248.0 or newer; see [Download & Install Pulumi](/docs/install/) to upgrade.
@@ -105,8 +106,8 @@ Here's an example of how to use the AWS RDS module to provision a MySQL database
 First, start by installing the Terraform modules:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0 vpc
-$ pulumi package add hcl module terraform-aws-modules/rds/aws 6.10.0 rdsmod
+$ pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0
+$ pulumi package add hcl module terraform-aws-modules/rds/aws 6.10.0
 ```
 
 After adding the packages, your `Pulumi.yaml` will be updated, and any necessary dependencies will be added to your project.
@@ -121,33 +122,33 @@ runtime:
     packagemanager: npm
 packages:
   vpc:
-    source: terraform-module
-    version: 0.1.4
+    source: hcl
+    version: 0.12.0
     parameters:
+      - module
       - terraform-aws-modules/vpc/aws
       - 5.19.0
-      - vpc
-  rdsmod:
-    source: terraform-module
-    version: 0.1.4
+  rds:
+    source: hcl
+    version: 0.12.0
     parameters:
+      - module
       - terraform-aws-modules/rds/aws
       - 6.10.0
-      - rdsmod
 ```
 
 {{% chooser language "typescript,python,go,csharp,java,yaml" %}}
 
 {{% choosable language typescript %}}
 
-Since this was a TypeScript project, Pulumi generated a TypeScript SDK for the modules, making those available to use as `@pulumi/vpcmod` and `@pulumi/rdsmod` respectively. We can now use the Terraform modules directly in our TypeScript code.
+Since this was a TypeScript project, Pulumi generated a TypeScript SDK for the modules, making those available to use as `@pulumi/vpc` and `@pulumi/rds` respectively. We can now use the Terraform modules directly in our TypeScript code.
 
 **Example:** index.ts - Using the Terraform VPC and RDS module in a Pulumi program*
 
 ```typescript
-import * as vpcmod from '@pulumi/vpcmod';
+import * as vpcmod from '@pulumi/vpc';
 import * as pulumi from '@pulumi/pulumi';
-import * as rdsmod from '@pulumi/rdsmod';
+import * as rdsmod from '@pulumi/rds';
 import * as aws from '@pulumi/aws';
 import * as std from '@pulumi/std';
 
@@ -231,15 +232,15 @@ function getCidrSubnet(cidr: string, netnum: number): pulumi.Output<string> {
 
 {{% choosable language python %}}
 
-Since this was a Python project, Pulumi generated a Python SDK for the modules, making those available to use as `pulumi_vpcmod` and `pulumi_rdsmod` respectively. We can now use the Terraform modules directly in our code:
+Since this was a Python project, Pulumi generated a Python SDK for the modules, making those available to use as `pulumi_vpc` and `pulumi_rds` respectively. We can now use the Terraform modules directly in our code:
 
 **Example:** `__main__.py` - Using the Terraform VPC and RDS module in a Pulumi program
 
 ```python
 import pulumi
 import pulumi_aws as aws
-import pulumi_vpcmod as vpcmod
-import pulumi_rdsmod as rdsmod
+import pulumi_vpc as vpcmod
+import pulumi_rds as rdsmod
 import pulumi_std as std
 
 # Get available availability zones
@@ -317,7 +318,7 @@ rdsmod.Module("test-rds",
 
 **Example:** `main.go` - Using the Terraform VPC and RDS module in a Pulumi program
 
-Since this was a Go project, Pulumi generated a Go SDK for the modules, making those available to use as `github.com/pulumi/pulumi-terraform-module/sdks/go/rdsmod/v6/rdsmod` and `github.com/pulumi/pulumi-terraform-module/sdks/go/vpcmod/v5/vpcmod`. We can now use the Terraform modules directly in our code:
+Since this was a Go project, Pulumi generated a Go SDK for the modules, making those available to use as `example.com/pulumi-rds/sdk/go/rds` and `example.com/pulumi-vpc/sdk/go/vpc`. We can now use the Terraform modules directly in our code:
 
 ```go
 package main
@@ -327,8 +328,8 @@ import (
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/vpc"
 	"github.com/pulumi/pulumi-std/sdk/go/std"
-	rdsmod "github.com/pulumi/pulumi-terraform-module/sdks/go/rdsmod/v6/rdsmod"
-	vpcmod "github.com/pulumi/pulumi-terraform-module/sdks/go/vpcmod/v5/vpcmod"
+	rdsmod "example.com/pulumi-rds/sdk/go/rds"
+	vpcmod "example.com/pulumi-vpc/sdk/go/vpc"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
@@ -448,7 +449,7 @@ func main() {
 
 {{% choosable language csharp %}}
 
-Since this was a C# project, Pulumi generated a C# SDK for the modules, making those available to use as `Pulumi.Rdsmod` and `Pulumi.Vpcmod`. We can now use the Terraform modules directly in our code:
+Since this was a C# project, Pulumi generated a C# SDK for the modules, making those available to use as `Pulumi.Rds` and `Pulumi.Vpc`. We can now use the Terraform modules directly in our code:
 
 **Example:** `Program.cs` - Using the Terraform VPC and RDS module in a Pulumi program
 
@@ -460,9 +461,9 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Pulumi;
 using Aws = Pulumi.Aws;
-using Rdsmod = Pulumi.Rdsmod;
+using Rdsmod = Pulumi.Rds;
 using Std = Pulumi.Std;
-using Vpcmod = Pulumi.Vpcmod;
+using Vpcmod = Pulumi.Vpc;
 
 return await Deployment.RunAsync(() =>
 {
@@ -558,7 +559,7 @@ internal class Utils {
 
 {{% choosable language java %}}
 
-Since this was a Java project, Pulumi generated a Java SDK for the modules, making those available to use as `com.pulumi.rdsmod` and `com.pulumi.vpcmod`. We can now use the Terraform modules directly in our code:
+Since this was a Java project, Pulumi generated a Java SDK for the modules, making those available to use as `com.pulumi.rds` and `com.pulumi.vpc`. We can now use the Terraform modules directly in our code:
 
 **Example:** `App.java` - Using the Terraform VPC and RDS module in a Pulumi program
 
@@ -598,7 +599,7 @@ public class App {
         final var prefix = ctx.config().get("prefix").orElse(ctx.stackName());
 
         // Create a VPC using the terraform-aws-modules/vpc module
-        final var vpc = new com.pulumi.vpcmod.Module("test-vpc", com.pulumi.vpcmod.ModuleArgs.builder()
+        final var vpc = new com.pulumi.vpc.Module("test-vpc", com.pulumi.vpc.ModuleArgs.builder()
             .azs(azNames)
             .name("test-vpc-" + prefix)
             .cidr(cidr)
@@ -620,7 +621,7 @@ public class App {
             .toPort(3306)
             .build());
 
-        new com.pulumi.rdsmod.Module("test-rds", com.pulumi.rdsmod.ModuleArgs.builder()
+        new com.pulumi.rds.Module("test-rds", com.pulumi.rds.ModuleArgs.builder()
             .engine("mysql")
             .identifier("test-rds-" + prefix)
             .manage_master_user_password(true)
@@ -670,8 +671,8 @@ public class App {
 When authoring in YAML, there is no need for Pulumi to generate a SDK. Pulumi generates some metadata instead:
 
 ```bash
-$ ls sdks/vpcmod/
-sdks/vpcmod/vpcmod-5.19.0.yaml
+$ ls sdks/vpc/
+sdks/vpc/vpc-5.19.0.yaml
 ```
 
 In the YAML you can reference the Terraform module by its schema token, which takes the format `<module-name>:index:Module`:
@@ -684,7 +685,7 @@ description: testproj-yaml
 runtime: yaml
 resources:
   testVpc:
-    type: vpcmod:index:Module
+    type: vpc:index:Module
     properties:
       name: test-vpc-${pulumi.stack}
       azs:
@@ -718,7 +719,7 @@ resources:
       fromPort: 3306
       toPort: 3306
   testRds:
-    type: rdsmod:index:Module
+    type: rds:index:Module
     properties:
       engine: mysql
       identifier: test-rds-${pulumi.stack}
@@ -741,20 +742,20 @@ resources:
       create_db_option_group: false
       create_db_parameter_group: false
 packages:
-  rdsmod:
-    source: terraform-module
-    version: 0.1.7
+  rds:
+    source: hcl
+    version: 0.12.0
     parameters:
+      - module
       - terraform-aws-modules/rds/aws
       - 6.10.0
-      - rdsmod
-  vpcmod:
-    source: terraform-module
-    version: 0.1.7
+  vpc:
+    source: hcl
+    version: 0.12.0
     parameters:
+      - module
       - terraform-aws-modules/vpc/aws
       - 5.19.0
-      - vpcmod
 ```
 
 {{% /choosable %}}
@@ -821,7 +822,7 @@ test_bucket = bucket.Module("test-bucket",
 package main
 
 import (
-	bucket "github.com/pulumi/pulumi-terraform-module/sdks/go/bucket/v3/bucket"
+	bucket "example.com/pulumi-bucket/sdk/go/bucket"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
+++ b/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
@@ -42,7 +42,7 @@ Also, many Terraform users have created their own custom modules and would like 
 The [Any HCL Module](/registry/packages/hcl/) package allows you to consume Terraform modules as if they were native Pulumi packages. It works by:
 
 1. Automatically installing and managing [OpenTofu](https://opentofu.org/) (an open-source Terraform-compatible implementation) to execute the module.
-2. Translating Pulumi resource declarations to Terraform configurations.
+2. Passing the inputs you provide to the module as Terraform variables.
 3. Managing state through your standard Pulumi state backend.
 4. Exposing module outputs as native Pulumi outputs.
 
@@ -61,10 +61,10 @@ Where:
 - `<module-source>` is either a registry module identifier (e.g. `terraform-aws-modules/rds/aws`) or a local path
 - `<version>` is an optional version constraint (e.g. `3.5.0`)
 
-For example, to add the AWS VPC module from the Terraform Registry:
+For example, to add the AWS S3 bucket module from the Terraform Registry:
 
 ```bash
-pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0
+pulumi package add hcl module terraform-aws-modules/s3-bucket/aws 4.1.2
 ```
 
 This will generate a local SDK in your programming language that you can import into your Pulumi program.
@@ -97,349 +97,117 @@ The package's page in Pulumi Cloud shows whether a given version has converted.
 
 See [Terraform Modules in the Pulumi Cloud Registry](/docs/idp/concepts/terraform-modules/) for the publishing side and the broader module workflow.
 
-## Example: Using the AWS RDS Module
+## Example: Using the AWS S3 Bucket Module
 
-Here's an example of how to use the AWS RDS module to provision a MySQL database in your Pulumi program.
+Here's an example of how to use the AWS S3 bucket module to create a bucket in your Pulumi program.
 
-First, start by installing the Terraform modules:
+First, add the module to your project:
 
 ```bash
-$ pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0
-$ pulumi package add hcl module terraform-aws-modules/rds/aws 6.10.0
+$ pulumi package add hcl module terraform-aws-modules/s3-bucket/aws 4.1.2
 ```
 
-After adding the packages, your `Pulumi.yaml` will be updated, and any necessary dependencies will be added to your project.
+After adding the package, your `Pulumi.yaml` is updated with the module definition:
 
-**Example:** Pulumi.yaml*
+**Example:** Pulumi.yaml
 
 ```yaml
-name: rds-example
+name: s3-bucket-example
 runtime:
   name: nodejs
   options:
     packagemanager: npm
 packages:
-  vpc:
+  s3-bucket:
     source: hcl
-    version: 0.12.0
+    version: 0.13.0
     parameters:
       - module
-      - terraform-aws-modules/vpc/aws
-      - 5.19.0
-  rds:
-    source: hcl
-    version: 0.12.0
-    parameters:
-      - module
-      - terraform-aws-modules/rds/aws
-      - 6.10.0
+      - terraform-aws-modules/s3-bucket/aws
+      - 4.1.2
 ```
 
 {{% chooser language "typescript,python,go,csharp,java,yaml" %}}
 
 {{% choosable language typescript %}}
 
-Since this was a TypeScript project, Pulumi generated a TypeScript SDK for the modules, making those available to use as `@pulumi/vpc` and `@pulumi/rds` respectively. We can now use the Terraform modules directly in our TypeScript code.
+Since this was a TypeScript project, Pulumi generated a TypeScript SDK for the module, making it available as `@pulumi/s3-bucket`. We can now use the Terraform module directly in our code:
 
-**Example:** index.ts - Using the Terraform VPC and RDS module in a Pulumi program*
+**Example:** index.ts
 
 ```typescript
-import * as vpcmod from '@pulumi/vpc';
-import * as pulumi from '@pulumi/pulumi';
-import * as rdsmod from '@pulumi/rds';
-import * as aws from '@pulumi/aws';
-import * as std from '@pulumi/std';
+import * as s3Bucket from "@pulumi/s3-bucket";
 
-// Get available availability zones
-const azs = aws.getAvailabilityZonesOutput({
-  filters: [{
-        name: "opt-in-status",
-        values: ["opt-in-not-required"],
-    }]
-}).names.apply(names => names.slice(0, 3));
-
-const cidr = "10.0.0.0/16";
-
-const cfg = new pulumi.Config();
-const prefix = cfg.get("prefix") ?? pulumi.getStack();
-
-// Create a VPC using the terraform-aws-modules/vpc module
-const vpc = new vpcmod.Module("test-vpc", {
-  azs: azs,
-  name: `test-vpc-${prefix}`,
-  cidr,
-  publicSubnets: azs.apply(azs => azs.map((_, i) => {
-    return getCidrSubnet(cidr, i+1);
-  })),
-  privateSubnets: azs.apply(azs => azs.map((_, i) => {
-    return getCidrSubnet(cidr, i+1+4);
-  })),
-  databaseSubnets: azs.apply(azs => azs.map((_, i) => {
-    return getCidrSubnet(cidr, i+1 + 8);
-  })),
-  createDatabaseSubnetGroup: true,
+// Create an S3 bucket using the Terraform module
+const bucket = new s3Bucket.Module("my-bucket", {
+    bucketPrefix: "my-example-bucket",
+    tags: {
+        Environment: "dev",
+    },
 });
 
-// Create a security group for the RDS instance
-const rdsSecurityGroup = new aws.ec2.SecurityGroup('test-rds-sg', {
-  vpcId: vpc.vpcId.apply(id => id!),
-});
-
-new aws.vpc.SecurityGroupIngressRule('test-rds-sg-ingress', {
-  ipProtocol: 'tcp',
-  securityGroupId: rdsSecurityGroup.id,
-  cidrIpv4: vpc.vpcCidrBlock.apply(cidr => cidr!),
-  fromPort: 3306,
-  toPort: 3306,
-});
-
-// Create an RDS instance using the terraform-aws-modules/rds module
-new rdsmod.Module("test-rds", {
-  engine: "mysql",
-  identifier: `test-rds-${prefix}`,
-  manageMasterUserPassword: true,
-  publiclyAccessible: false,
-  allocatedStorage: 20,
-  maxAllocatedStorage: 100,
-  instanceClass: "db.t4g.large",
-  engineVersion: "8.0",
-  family: "mysql8.0",
-  dbName: "completeMysql",
-  username: "complete_mysql",
-  port: '3306',
-  multiAz: true,
-  dbSubnetGroupName: vpc.databaseSubnetGroupName.apply(name => name!),
-  vpcSecurityGroupIds: [rdsSecurityGroup.id],
-  skipFinalSnapshot: true,
-  deletionProtection: false,
-  createDbOptionGroup: false,
-  createDbParameterGroup: false,
-});
-
-// Utility function to calculate subnet CIDRs
-function getCidrSubnet(cidr: string, netnum: number): pulumi.Output<string> {
-    return std.cidrsubnetOutput({
-    input: cidr,
-    newbits: 8,
-    netnum,
-  }).result;
-}
+// The module's outputs are strongly typed
+export const bucketArn = bucket.s3BucketArn;
+export const bucketId = bucket.s3BucketId;
 ```
 
 {{% /choosable %}}
 
 {{% choosable language python %}}
 
-Since this was a Python project, Pulumi generated a Python SDK for the modules, making those available to use as `pulumi_vpc` and `pulumi_rds` respectively. We can now use the Terraform modules directly in our code:
+Since this was a Python project, Pulumi generated a Python SDK for the module, making it available as `pulumi_s3_bucket`. We can now use the Terraform module directly in our code:
 
-**Example:** `__main__.py` - Using the Terraform VPC and RDS module in a Pulumi program
+**Example:** `__main__.py`
 
 ```python
 import pulumi
-import pulumi_aws as aws
-import pulumi_vpc as vpcmod
-import pulumi_rds as rdsmod
-import pulumi_std as std
+import pulumi_s3_bucket as s3bucket
 
-# Get available availability zones
-azs = aws.get_availability_zones_output(
-    filters=[{
-        "name": "opt-in-status",
-        "values": ["opt-in-not-required"],
-    }]
-).names.apply(lambda names: names[:3])
+# Create an S3 bucket using the Terraform module
+bucket = s3bucket.Module("my-bucket",
+    bucket_prefix="my-example-bucket",
+    tags={
+        "Environment": "dev",
+    })
 
-cidr = "10.0.0.0/16"
-
-cfg = pulumi.Config()
-prefix = cfg.get("prefix") or pulumi.get_stack()
-
-# Utility function to calculate subnet CIDRs
-def get_cidr_subnet(cidr, netnum):
-    return std.cidrsubnet_output(
-        input=cidr,
-        newbits=8,
-        netnum=netnum
-    ).result
-
-# Create a VPC using the terraform-aws-modules/vpc module
-vpc = vpcmod.Module("test-vpc",
-    azs=azs,
-    name=f"test-vpc-{prefix}",
-    cidr=cidr,
-    public_subnets=azs.apply(lambda azs: [get_cidr_subnet(cidr, i+1) for i in range(len(azs))]),
-    private_subnets=azs.apply(lambda azs: [get_cidr_subnet(cidr, i+1+4) for i in range(len(azs))]),
-    database_subnets=azs.apply(lambda azs: [get_cidr_subnet(cidr, i+1+8) for i in range(len(azs))]),
-    create_database_subnet_group=True
-)
-
-# Create a security group for the RDS instance
-rds_security_group = aws.ec2.SecurityGroup('test-rds-sg',
-    vpc_id=vpc.vpc_id
-)
-
-aws.vpc.SecurityGroupIngressRule('test-rds-sg-ingress',
-    ip_protocol='tcp',
-    security_group_id=rds_security_group.id,
-    cidr_ipv4=vpc.vpc_cidr_block,
-    from_port=3306,
-    to_port=3306
-)
-
-# Create an RDS instance using the terraform-aws-modules/rds module
-rdsmod.Module("test-rds",
-    engine="mysql",
-    identifier=f"test-rds-{prefix}",
-    manage_master_user_password=True,
-    publicly_accessible=False,
-    allocated_storage=20,
-    max_allocated_storage=100,
-    instance_class="db.t4g.large",
-    engine_version="8.0",
-    family="mysql8.0",
-    db_name="completeMysql",
-    username="complete_mysql",
-    port='3306',
-    multi_az=True,
-    db_subnet_group_name=vpc.database_subnet_group_name,
-    vpc_security_group_ids=[rds_security_group.id],
-    skip_final_snapshot=True,
-    deletion_protection=False,
-    create_db_option_group=False,
-    create_db_parameter_group=False
-)
+# The module's outputs are strongly typed
+pulumi.export("bucket_arn", bucket.s3_bucket_arn)
+pulumi.export("bucket_id", bucket.s3_bucket_id)
 ```
 
 {{% /choosable %}}
 
 {{% choosable language go %}}
 
-**Example:** `main.go` - Using the Terraform VPC and RDS module in a Pulumi program
+Since this was a Go project, Pulumi generated a Go SDK for the module. We can now use the Terraform module directly in our code:
 
-Since this was a Go project, Pulumi generated a Go SDK for the modules, making those available to use as `example.com/pulumi-rds/sdk/go/rds` and `example.com/pulumi-vpc/sdk/go/vpc`. We can now use the Terraform modules directly in our code:
+**Example:** `main.go`
 
 ```go
 package main
 
 import (
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws"
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/vpc"
-	"github.com/pulumi/pulumi-std/sdk/go/std"
-	rdsmod "example.com/pulumi-rds/sdk/go/rds"
-	vpcmod "example.com/pulumi-vpc/sdk/go/vpc"
+	"example.com/pulumi-s3-bucket/sdk/go/s3bucket"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
-func run(ctx *pulumi.Context) error {
-	// Get available availability zones
-	azs := aws.GetAvailabilityZonesOutput(ctx, aws.GetAvailabilityZonesOutputArgs{
-		Filters: aws.GetAvailabilityZonesFilterArray{
-			aws.GetAvailabilityZonesFilterArgs{
-				Name:   pulumi.String("opt-in-status"),
-				Values: pulumi.StringArray{pulumi.String("opt-in-not-required")},
-			},
-		},
-	})
-
-	azNames := azs.Names().ApplyT(func(names []string) []string {
-		if len(names) > 3 {
-			return names[:3]
-		}
-		return names
-	}).(pulumi.StringArrayOutput)
-
-	cidr := "10.0.0.0/16"
-	cfg := config.New(ctx, "")
-	prefix := cfg.Get("prefix")
-	if prefix == "" {
-		prefix = ctx.Stack()
-	}
-
-	// Create a VPC using the terraform-aws-modules/vpc module
-	vpcInstance, err := vpcmod.NewModule(ctx, "test-vpc", &vpcmod.ModuleArgs{
-		Azs:                          azNames,
-		Name:                         pulumi.Sprintf("test-vpc-%s", prefix),
-		Cidr:                         pulumi.String(cidr),
-		PublicSubnets:               applyAznamesForSubnet(ctx, azNames, cidr, 1),
-		PrivateSubnets:              applyAznamesForSubnet(ctx, azNames, cidr, 5),
-		DatabaseSubnets:             applyAznamesForSubnet(ctx, azNames, cidr, 9),
-		CreateDatabaseSubnetGroup: pulumi.Bool(true),
-	})
-	if err != nil {
-		return err
-	}
-
-	// Create a security group for the RDS instance
-	rdsSecurityGroup, err := ec2.NewSecurityGroup(ctx, "test-rds-sg", &ec2.SecurityGroupArgs{
-		VpcId: vpcInstance.VpcId,
-	})
-	if err != nil {
-		return err
-	}
-	_, err = vpc.NewSecurityGroupIngressRule(ctx, "test-rds-sg-ingress", &vpc.SecurityGroupIngressRuleArgs{
-		IpProtocol:      pulumi.String("tcp"),
-		SecurityGroupId: rdsSecurityGroup.ID(),
-		CidrIpv4:        vpcInstance.VpcCidrBlock,
-		FromPort:        pulumi.Int(3306),
-		ToPort:          pulumi.Int(3306),
-	})
-	if err != nil {
-		return err
-	}
-
-	// Create an RDS instance using the terraform-aws-modules/rds module
-	_, err = rdsmod.NewModule(ctx, "test-rds", &rdsmod.ModuleArgs{
-		Engine:                      pulumi.String("mysql"),
-		Identifier:                  pulumi.Sprintf("test-rds-%s", prefix),
-		ManageMasterUserPassword: pulumi.Bool(true),
-		PubliclyAccessible:         pulumi.Bool(false),
-		AllocatedStorage:           pulumi.Float64(20),
-		MaxAllocatedStorage:       pulumi.Float64(100),
-		InstanceClass:              pulumi.String("db.t4g.large"),
-		EngineVersion:              pulumi.String("8.0"),
-		Family:                      pulumi.String("mysql8.0"),
-		DbName:                     pulumi.String("completeMysql"),
-		Username:                    pulumi.String("complete_mysql"),
-		Port:                        pulumi.String("3306"),
-		MultiAz:                    pulumi.Bool(true),
-		DbSubnetGroupName:        vpcInstance.DatabaseSubnetGroupName,
-		VpcSecurityGroupIds:      pulumi.StringArray{rdsSecurityGroup.ID()},
-		SkipFinalSnapshot:         pulumi.Bool(true),
-		DeletionProtection:         pulumi.Bool(false),
-		CreateDbOptionGroup:      pulumi.Bool(false),
-		CreateDbParameterGroup:   pulumi.Bool(false),
-	})
-	return err
-}
-
-func applyAznamesForSubnet(
-	ctx *pulumi.Context,
-	azNames pulumi.StringArrayOutput,
-	cidr string,
-	offset int,
-) pulumi.StringArrayOutput {
-	return azNames.ApplyT(func(azs []string) ([]string, error) {
-		subnets := make([]string, len(azs))
-		for i := range azs {
-			netnum := offset + i
-			r, err := std.Cidrsubnet(ctx, &std.CidrsubnetArgs{
-				Input:   cidr,
-				Newbits: 8,
-				Netnum:  netnum,
-			})
-			if err != nil {
-				return nil, err
-			}
-			subnets[i] = r.Result
-		}
-		return subnets, nil
-	}).(pulumi.StringArrayOutput)
-}
-
 func main() {
-	pulumi.Run(run)
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Create an S3 bucket using the Terraform module
+		bucket, err := s3bucket.NewModule(ctx, "my-bucket", &s3bucket.ModuleArgs{
+			BucketPrefix: pulumi.String("my-example-bucket"),
+			Tags: pulumi.StringMap{
+				"Environment": pulumi.String("dev"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		// The module's outputs are strongly typed
+		ctx.Export("bucketArn", bucket.S3BucketArn)
+		ctx.Export("bucketId", bucket.S3BucketId)
+		return nil
+	})
 }
 ```
 
@@ -447,217 +215,65 @@ func main() {
 
 {{% choosable language csharp %}}
 
-Since this was a C# project, Pulumi generated a C# SDK for the modules, making those available to use as `Pulumi.Rds` and `Pulumi.Vpc`. We can now use the Terraform modules directly in our code:
+Since this was a C# project, Pulumi generated a C# SDK for the module, making it available as `Pulumi.S3Bucket`. We can now use the Terraform module directly in our code:
 
-**Example:** `Program.cs` - Using the Terraform VPC and RDS module in a Pulumi program
+**Example:** `Program.cs`
 
 ```csharp
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Pulumi;
-using Aws = Pulumi.Aws;
-using Rdsmod = Pulumi.Rds;
-using Std = Pulumi.Std;
-using Vpcmod = Pulumi.Vpc;
+using Pulumi.S3Bucket;
 
 return await Deployment.RunAsync(() =>
 {
-    // Get available availability zones
-    var azs = Aws.GetAvailabilityZones.Invoke(new Aws.GetAvailabilityZonesInvokeArgs
+    // Create an S3 bucket using the Terraform module
+    var bucket = new Module("my-bucket", new ModuleArgs
     {
-        Filters =
-            {
-                new Aws.Inputs.GetAvailabilityZonesFilterInputArgs
-                {
-                    Name = "opt-in-status",
-                    Values = { "opt-in-not-required" }
-                }
-            }
-    }).Apply(result => result.Names.Take(3).ToArray());
-
-    var cidr = "10.0.0.0/16";
-
-    var config = new Pulumi.Config();
-    var prefix = config.Get("prefix") ?? Deployment.Instance.StackName;
-
-    // Create a VPC using the terraform-aws-modules/vpc module
-    var vpc = new Vpcmod.Module("test-vpc", new Vpcmod.ModuleArgs
-    {
-        Azs = azs,
-        Name = Output.Format($"test-vpc-{prefix}"),
-        Cidr = cidr,
-        PublicSubnets = Utils.Subnets(cidr, azs, 1),
-        PrivateSubnets = Utils.Subnets(cidr, azs, 5),
-        DatabaseSubnets = Utils.Subnets(cidr, azs, 9),
-        CreateDatabaseSubnetGroup = true,
-    });
-
-    // Create a security group for the RDS instance
-    var rdsSecurityGroup = new Aws.Ec2.SecurityGroup("test-rds-sg", new Aws.Ec2.SecurityGroupArgs
-    {
-        VpcId = vpc.VpcId.Apply(id => id ?? string.Empty),
-    });
-
-    _ = new Aws.Vpc.SecurityGroupIngressRule("test-rds-sg-ingress", new Aws.Vpc.SecurityGroupIngressRuleArgs
-    {
-        IpProtocol = "tcp",
-        SecurityGroupId = rdsSecurityGroup.Id,
-        CidrIpv4 = vpc.VpcCidrBlock.Apply(x => x!),
-        FromPort = 3306,
-        ToPort = 3306,
-    });
-
-    // Create an RDS instance using the terraform-aws-modules/rds module
-    _ = new Rdsmod.Module("test-rds", new Rdsmod.ModuleArgs
-    {
-        Engine = "mysql",
-        Identifier = Output.Format($"test-rds-{prefix}"),
-        ManageMasterUserPassword = true,
-        PubliclyAccessible = false,
-        AllocatedStorage = 20,
-        MaxAllocatedStorage = 100,
-        InstanceClass = "db.t4g.large",
-        EngineVersion = "8.0",
-        Family = "mysql8.0",
-        DbName = "completeMysql",
-        Username = "complete_mysql",
-        Port = "3306",
-        MultiAz = true,
-        DbSubnetGroupName = vpc.DatabaseSubnetGroupName,
-        VpcSecurityGroupIds = { rdsSecurityGroup.Id },
-        SkipFinalSnapshot = true,
-        DeletionProtection = false,
-        CreateDbOptionGroup = false,
-        CreateDbParameterGroup = false,
-    });
-});
-
-// Utilities to calculate subnet CIDRs
-internal class Utils {
-    public static Output<ImmutableArray<string>> Subnets(string cidr, Output<string[]> azs, int offset) {
-        return azs.Apply(names => Pulumi.Output.All(names.Select((_, i) => Utils.GetCidrSubnet(cidr, i + 1))));
-    }
-
-    public static Output<string> GetCidrSubnet(string cidr, int netnum)
-    {
-        return Std.Cidrsubnet.Invoke(new Std.CidrsubnetInvokeArgs
+        BucketPrefix = "my-example-bucket",
+        Tags =
         {
-            Input = cidr,
-            Newbits = 8,
-            Netnum = netnum
-        }).Apply(result => result.Result);
-    }
-}
+            { "Environment", "dev" },
+        },
+    });
+
+    // The module's outputs are strongly typed
+    return new Dictionary<string, object?>
+    {
+        ["bucketArn"] = bucket.S3BucketArn,
+        ["bucketId"] = bucket.S3BucketId,
+    };
+});
 ```
 
 {{% /choosable %}}
 
 {{% choosable language java %}}
 
-Since this was a Java project, Pulumi generated a Java SDK for the modules, making those available to use as `com.pulumi.rds` and `com.pulumi.vpc`. We can now use the Terraform modules directly in our code:
+Since this was a Java project, Pulumi generated a Java SDK for the module, making it available as `com.pulumi.s3bucket`. We can now use the Terraform module directly in our code:
 
-**Example:** `App.java` - Using the Terraform VPC and RDS module in a Pulumi program
+**Example:** `App.java`
 
 ```java
 package myproject;
 
-import com.pulumi.Context;
 import com.pulumi.Pulumi;
-import com.pulumi.core.Output;
-import com.pulumi.aws.AwsFunctions;
-import com.pulumi.aws.inputs.GetAvailabilityZonesArgs;
-import com.pulumi.aws.inputs.GetAvailabilityZonesFilterArgs;
-import com.pulumi.std.StdFunctions;
-import com.pulumi.aws.ec2.SecurityGroup;
-import com.pulumi.aws.ec2.SecurityGroupArgs;
-import com.pulumi.aws.vpc.SecurityGroupIngressRule;
-import com.pulumi.aws.vpc.SecurityGroupIngressRuleArgs;
-import com.pulumi.Config;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.List;
-import java.util.Collections;
+import com.pulumi.s3bucket.Module;
+import com.pulumi.s3bucket.ModuleArgs;
+import java.util.Map;
 
 public class App {
-    public static void stack(Context ctx) {
-
-        // Get available availability zones
-        final var azNames = AwsFunctions.getAvailabilityZones(GetAvailabilityZonesArgs.builder()
-            .filters(GetAvailabilityZonesFilterArgs.builder()
-                     .name("opt-in-status")
-                     .values("opt-in-not-required")
-                     .build())
-            .build())
-            .applyValue(result -> result.names().subList(0, 3));
-
-        final var cidr = "10.0.0.0/16";
-        final var prefix = ctx.config().get("prefix").orElse(ctx.stackName());
-
-        // Create a VPC using the terraform-aws-modules/vpc module
-        final var vpc = new com.pulumi.vpc.Module("test-vpc", com.pulumi.vpc.ModuleArgs.builder()
-            .azs(azNames)
-            .name("test-vpc-" + prefix)
-            .cidr(cidr)
-            .publicSubnets(subnets(cidr, azNames, 1))
-            .privateSubnets(subnets(cidr, azNames, 5))
-            .databaseSubnets(subnets(cidr, azNames, 9))
-            .createDatabaseSubnetGroup(true)
-            .build());
-
-        final var rdsSecurityGroup = new SecurityGroup("test-rds-sg", SecurityGroupArgs.builder()
-            .vpcId(vpc.vpcId().applyValue(x -> x.get()))
-            .build());
-
-        new SecurityGroupIngressRule("test-rds-sg-ingress", SecurityGroupIngressRuleArgs.builder()
-            .ipProtocol("tcp")
-            .securityGroupId(rdsSecurityGroup.id())
-            .cidrIpv4(vpc.vpcCidrBlock().applyValue(x -> x.get()))
-            .fromPort(3306)
-            .toPort(3306)
-            .build());
-
-        new com.pulumi.rds.Module("test-rds", com.pulumi.rds.ModuleArgs.builder()
-            .engine("mysql")
-            .identifier("test-rds-" + prefix)
-            .manageMasterUserPassword(true)
-            .publiclyAccessible(false)
-            .allocatedStorage(20.0)
-            .maxAllocatedStorage(100.0)
-            .instanceClass("db.t4g.large")
-            .engineVersion("8.0")
-            .family("mysql8.0")
-            .dbName("completeMysql")
-            .username("complete_mysql")
-            .port("3306")
-            .multiAz(true)
-            .dbSubnetGroupName(vpc.databaseSubnetGroupName().applyValue(x -> x.get()))
-            .vpcSecurityGroupIds(rdsSecurityGroup.id().applyValue(x -> Collections.singletonList(x)))
-            .skipFinalSnapshot(true)
-            .deletionProtection(false)
-            .createDbOptionGroup(false)
-            .createDbParameterGroup(false)
-            .build());
-    }
-
-    private static Output<List<String>> subnets(String cidr, Output<List<String>> azNames, int offset) {
-        return azNames.apply(names -> Output.all(IntStream.range(0, names.size())
-                                                 .mapToObj(i -> getCidrSubnet(cidr, i+offset))
-                                                 .collect(Collectors.toList())));
-    }
-
-    private static Output<String> getCidrSubnet(String cidr, int netnum) {
-        return StdFunctions.cidrsubnet(com.pulumi.std.inputs.CidrsubnetArgs.builder()
-            .input(cidr)
-            .newbits(8)
-            .netnum(netnum)
-            .build()).applyValue(x -> x.result());
-    }
-
     public static void main(String[] args) {
-        Pulumi.run(App::stack);
+        Pulumi.run(ctx -> {
+            // Create an S3 bucket using the Terraform module
+            var bucket = new Module("my-bucket", ModuleArgs.builder()
+                .bucketPrefix("my-example-bucket")
+                .tags(Map.of("Environment", "dev"))
+                .build());
+
+            // The module's outputs are strongly typed
+            ctx.export("bucketArn", bucket.s3BucketArn());
+            ctx.export("bucketId", bucket.s3BucketId());
+        });
     }
 }
 ```
@@ -666,94 +282,37 @@ public class App {
 
 {{% choosable language yaml %}}
 
-When authoring in YAML, there is no need for Pulumi to generate a SDK. Pulumi generates some metadata instead:
+When authoring in YAML, there's no SDK to generate — you reference the module by its schema token, which takes the format `<package-name>:index:Module`:
 
-```bash
-$ ls sdks/vpc/
-sdks/vpc/vpc-5.19.0.yaml
-```
-
-In the YAML you can reference the Terraform module by its schema token, which takes the format `<module-name>:index:Module`:
-
-**Example:** `Pulumi.yaml` - Using the Terraform VPC and RDS module in a Pulumi program
+**Example:** `Pulumi.yaml`
 
 ```yaml
-name: testproj-yaml
-description: testproj-yaml
+name: s3-bucket-example
 runtime: yaml
+description: Use a Terraform module in Pulumi
+
 resources:
-  testVpc:
-    type: vpc:index:Module
+  # Create an S3 bucket using the Terraform module
+  my-bucket:
+    type: s3-bucket:index:Module
     properties:
-      name: test-vpc-${pulumi.stack}
-      azs:
-        - us-west-2a
-        - us-west-2b
-        - us-west-2c
-      cidr: 10.0.0.0/16
-      publicSubnets:
-        - 10.0.1.0/24
-        - 10.0.2.0/24
-        - 10.0.3.0/24
-      privateSubnets:
-        - 10.0.5.0/24
-        - 10.0.6.0/24
-        - 10.0.7.0/24
-      databaseSubnets:
-        - 10.0.9.0/24
-        - 10.0.10.0/24
-        - 10.0.11.0/24
-      createDatabaseSubnetGroup: true
-  testRdsSg:
-    type: aws:ec2:SecurityGroup
-    properties:
-      vpcId: ${testVpc.vpcId}
-  testRdsSgIngress:
-    type: aws:vpc:SecurityGroupIngressRule
-    properties:
-      ipProtocol: tcp
-      securityGroupId: ${testRdsSg.id}
-      cidrIpv4: ${testVpc.vpcCidrBlock}
-      fromPort: 3306
-      toPort: 3306
-  testRds:
-    type: rds:index:Module
-    properties:
-      engine: mysql
-      identifier: test-rds-${pulumi.stack}
-      manageMasterUserPassword: true
-      publiclyAccessible: false
-      allocatedStorage: 20
-      maxAllocatedStorage: 100
-      instanceClass: db.t4g.large
-      engineVersion: 8
-      family: mysql8.0
-      dbName: completeMysql
-      username: complete_mysql
-      port: '3306'
-      multiAz: true
-      dbSubnetGroupName: ${testVpc.databaseSubnetGroupName}
-      vpcSecurityGroupIds:
-        - ${testRdsSg.id}
-      skipFinalSnapshot: true
-      deletionProtection: false
-      createDbOptionGroup: false
-      createDbParameterGroup: false
+      bucketPrefix: my-example-bucket
+      tags:
+        Environment: dev
+
+# The module's outputs are strongly typed
+outputs:
+  bucketArn: ${my-bucket.s3BucketArn}
+  bucketId: ${my-bucket.s3BucketId}
+
 packages:
-  rds:
+  s3-bucket:
     source: hcl
-    version: 0.12.0
+    version: 0.13.0
     parameters:
       - module
-      - terraform-aws-modules/rds/aws
-      - 6.10.0
-  vpc:
-    source: hcl
-    version: 0.12.0
-    parameters:
-      - module
-      - terraform-aws-modules/vpc/aws
-      - 5.19.0
+      - terraform-aws-modules/s3-bucket/aws
+      - 4.1.2
 ```
 
 {{% /choosable %}}
@@ -764,193 +323,32 @@ In the above code, the imported Terraform module works the same as any other Pul
 
 ## Configuring Terraform Providers
 
-Some modules require Terraform providers to be configured with specific settings. You can configure these providers from within Pulumi:
+A Terraform module runs against your project's default provider configuration — the same configuration your Pulumi-native resources use — so it inherits whatever region, account, or credentials you've already set. To target a specific region, for example, set it the way you would for any Pulumi provider:
 
-{{% chooser language "typescript,python,go,csharp,java" %}}
-
-{{% choosable language typescript %}}
-
-**Example:** `index.ts` - Configuring the imported Terraform bucket module
-
-```typescript
-import * as bucket from "@pulumi/bucket";
-
-// Configure the AWS provider for the module
-const provider = new bucket.Provider("test-provider", {
-    aws: {
-        "region": "us-west-2"
-    }
-});
-
-// Use the provider with the module
-const testBucket = new bucket.Module("test-bucket", {
-    bucket: `${prefix}-test-bucket`
-}, { provider: provider });
+```bash
+$ pulumi config set aws:region us-west-2
 ```
 
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-**Example:** `__main__.py` - Configuring the imported Terraform bucket module
-
-```python
-import pulumi
-import pulumi_bucket as bucket
-
-# Configure the AWS provider for the module
-provider = bucket.Provider("bucket-provider", aws={
-    "region": "us-west-2"
-})
-
-# Use the provider with the module
-test_bucket = bucket.Module("test-bucket",
-    bucket=f"${prefix}-test-bucket"
-    opts=pulumi.ResourceOptions(provider=provider)
-)
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-**Example:** `main.go` - Configuring the imported Terraform bucket module
-
-```go
-package main
-
-import (
-	bucket "example.com/pulumi-bucket/sdk/go/bucket"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-)
-
-
-func run(ctx *pulumi.Context) error {
-	// Configure the AWS provider for the module
-	prov, err := bucket.NewProvider(ctx, "provider", &bucket.ProviderArgs{
-		Aws: pulumi.ToMap(map[string]any{
-			"region": "us-west-2",
-		}),
-	})
-	if err != nil {
-		return err
-	}
-
-	// Use the provider with the module
-	bucketInstance, err := bucket.NewModule(ctx, "test-bucket", &bucket.ModuleArgs{
-		Bucket: pulumi.Sprintf("test-vpc-%s", prefix),
-	}, pulumi.Provider(prov))
-	if err != nil {
-		return err
-	}
-}
-
-func main() {
-	pulumi.Run(run)
-}
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-**Example:** `Program.cs` - Configuring the imported Terraform bucket module
-
-```csharp
-using Pulumi;
-using Bucket = Pulumi.Bucket;
-
-return await Deployment.RunAsync(() =>
-{
-    // Configure the AWS provider for the module
-    var provider = new Bucket.Provider("test-provider", new Bucket.ProviderArgs
-    {
-        Aws = {{"region", "us-west-2"}}
-    });
-
-    // Use the provider with the module
-    var bucket = new Bucket.Module("test-bucket", new Bucket.Args
-    {
-        Bucket = $"{prefix}-test-bucket"
-    }, new CustomResourceOptions
-    {
-        Provider = provider
-    });
-```
-
-{{% /choosable %}}
-
-{{% choosable language java %}}
-
-**Example:** `App.java` - Configuring the imported Terraform bucket module
-
-```java
-import com.pulumi.Context;
-import com.pulumi.Pulumi;
-import com.pulumi.resources.CustomResourceOptions;
-
-public class App {
-    public static void stack(Context ctx) {
-
-        // Configure the AWS provider for the module
-        final var provider = new com.pulumi.bucket.Provider("test-provider",
-            com.pulumi.bucket.ProviderArgs.builder()
-            .aws(Collections.singletonMap("region", "us-west-2"))
-            .build());
-
-        // Use the provider with the module
-        final var bucket = new com.pulumi.bucket.Module("test-bucket",
-            com.pulumi.bucket.ModuleArgs.builder()
-                .bucket(prefix+"-test-bucket")
-                .build(),
-            CustomResourceOptions.builder().provider(provider).build());
-    }
-
-    public static void main(String[] args) {
-        Pulumi.run(App::stack);
-    }
-}
-```
-
-{{% /choosable %}}
-
-{{% /chooser %}}
-
-Provider configuration is module-specific, so refer to the module's documentation for available configuration options.
+You can also supply provider settings, including short-lived credentials, through a [Pulumi ESC environment](/docs/esc/). See [Providers](/docs/iac/concepts/providers/) for the full range of configuration options.
 
 ## Troubleshooting
 
 ### Fixing Invalid Relative Paths
 
-When using modules that accept file paths, use absolute paths instead of relative paths.
-
-**Example:** index.ts - Using absolute paths to reference external files*
+When a module accepts a file path, pass an absolute path instead of a relative one. For example, the [AWS Lambda module](https://registry.terraform.io/modules/terraform-aws-modules/lambda/aws) accepts a `source_path` that points to the location of function's code:
 
 ```typescript
-import * as path from "path";
-import * as process from "process";
+import * as hcl from "@pulumi/hcl";
 
-const pwd = process.cwd();
-
-const lambdaModule = new lambda.Module("my-lambda", {
-    source_path: `${pwd}/src/app.ts`,
+const lambdaModule = new hcl.Module("my-lambda", {
+    source: "terraform-aws-modules/lambda/aws",
+    inputs: {
+        function_name: "my-function",
+        handler: "index.handler",
+        runtime: "nodejs20.x",
+        source_path: `${process.cwd()}/src`,
+    },
 });
 ```
 
-This is important because the Terraform modules have a different working directory, to allow for relative import of other modules, which means during execution the working directory will be different. Using `process.cwd()` here captures the Pulumi working directory, which we then use to build an absolute path to the external file.
-
-### Fixing Incorrect Output Types
-
-If Pulumi infers an incorrect type for a module output, you can override it as documented in the [Config Reference](https://github.com/pulumi/pulumi-terraform-module/blob/main/docs/config-reference.md).
-
-## Limitations
-
-Current limitations include:
-
-- Using the `transforms` resource option
-- Targeted updates via `pulumi up --target ...`
-- Protecting individual resources deployed by the module
-
-## Conclusion
-
-Using Terraform modules directly in Pulumi allows you to leverage the vast ecosystem of Terraform modules and your existing investments into custom modules, while maintaining all the benefits of Pulumi's rich programming model. This approach enables the two products to coexist, allowing teams to continue to collaborate while using the best tools for their specific needs, and enables a gradual migration path from Terraform to Pulumi.
+This is necessary because Terraform modules run from a different working directory than your Pulumi program, so a relative path would resolve incorrectly. The example above uses the Node.js built-in `process.cwd()` to use the full path of the current working directory to resolve the full path to the function code in `src`.

--- a/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
+++ b/content/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module.md
@@ -9,7 +9,7 @@ menu:
         parent: iac-guides-using-existing-tools
         weight: 50
 aliases:
-- /docs/iac/using-pulumi/extending-pulumi/use-terraform-module/
+- /docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/
 - /docs/iac/extending-pulumi/use-terraform-module/
 - /docs/iac/build-with-pulumi/use-terraform-module/
 ---

--- a/content/docs/iac/guides/migration/migrating-to-pulumi/from-terraform.md
+++ b/content/docs/iac/guides/migration/migrating-to-pulumi/from-terraform.md
@@ -303,13 +303,13 @@ Pulumi allows you to use existing Terraform modules directly in your Pulumi prog
 To use a Terraform module in Pulumi, you can add it to your project using the `pulumi package add` command:
 
 ```bash
-pulumi package add hcl module <module-source> [<version>] <pulumi-package-name>
+pulumi package add hcl module <module-source> [<version>]
 ```
 
 For example, to add the AWS VPC module from the Terraform Registry:
 
 ```bash
-pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0 vpc
+pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0
 ```
 
 This will generate a local SDK in your programming language that you can import into your Pulumi program. You can then use this module like any other Pulumi package:
@@ -439,7 +439,7 @@ class MyStack : Stack
 This feature also works seamlessly with local Terraform modules:
 
 ```bash
-pulumi package add hcl module ./path/to/module mylocalmod
+pulumi package add hcl module ./path/to/module
 ```
 
 For more information about using Terraform modules directly in Pulumi, see the [Use a Terraform Module in Pulumi](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) guide.

--- a/content/docs/iac/guides/migration/migrating-to-pulumi/from-terraform.md
+++ b/content/docs/iac/guides/migration/migrating-to-pulumi/from-terraform.md
@@ -303,13 +303,13 @@ Pulumi allows you to use existing Terraform modules directly in your Pulumi prog
 To use a Terraform module in Pulumi, you can add it to your project using the `pulumi package add` command:
 
 ```bash
-pulumi package add terraform-module <module-source> [<version>] <pulumi-package-name>
+pulumi package add hcl module <module-source> [<version>] <pulumi-package-name>
 ```
 
 For example, to add the AWS VPC module from the Terraform Registry:
 
 ```bash
-pulumi package add terraform-module terraform-aws-modules/vpc/aws 5.19.0 vpc
+pulumi package add hcl module terraform-aws-modules/vpc/aws 5.19.0 vpc
 ```
 
 This will generate a local SDK in your programming language that you can import into your Pulumi program. You can then use this module like any other Pulumi package:
@@ -439,7 +439,7 @@ class MyStack : Stack
 This feature also works seamlessly with local Terraform modules:
 
 ```bash
-pulumi package add terraform-module ./path/to/module mylocalmod
+pulumi package add hcl module ./path/to/module mylocalmod
 ```
 
 For more information about using Terraform modules directly in Pulumi, see the [Use a Terraform Module in Pulumi](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) guide.

--- a/content/docs/iac/languages-sdks/hcl/hcl-component-reference.md
+++ b/content/docs/iac/languages-sdks/hcl/hcl-component-reference.md
@@ -115,7 +115,7 @@ For a module on the local filesystem, pass its directory:
 pulumi package add ../randommodule
 ```
 
-For a remote module — a Git repository or a Terraform registry module — parameterize the `hcl` provider with the module source and an optional version:
+For a remote module — a Git repository or a Terraform registry module — parameterize the [Any HCL Module](/registry/packages/hcl/) package with the module source and an optional version:
 
 ```bash
 pulumi package add hcl module terraform-aws-modules/vpc/aws 5.0.0

--- a/content/docs/idp/concepts/terraform-modules.md
+++ b/content/docs/idp/concepts/terraform-modules.md
@@ -90,14 +90,14 @@ Publishing a module version also converts it into a Pulumi package, with no extr
 
 Conversion runs per version, so a module can have some versions with packages and some without. The package's page in Pulumi Cloud shows which versions have converted and gives you the command to install one.
 
-Under the hood, the conversion job derives the package schema by reading the module through Pulumi's [`hcl`](https://github.com/pulumi/pulumi-hcl) parameterized provider (`pulumi package get-schema hcl module <address>`) and publishes that schema as a package version. SDKs and API documentation come from the schema, the same as for any other package.
+Under the hood, the conversion job derives the package schema by reading the module through the [Any HCL Module](/registry/packages/hcl/) parameterized provider (`pulumi package get-schema hcl module <address>`) and publishes that schema as a package version. SDKs and API documentation come from the schema, the same as for any other package.
 
 ## Consume from a Pulumi program
 
 Once a version has converted, install it by package name:
 
 ```bash
-pulumi package add <name>-<system> [<version>]
+pulumi package add <name>-<system>[@<version>]
 ```
 
 The module is a [multi-language component](https://github.com/pulumi/pulumi-hcl/blob/master/docs/mlc.md): its `variable` blocks become typed inputs, its `output` blocks become typed outputs, and Pulumi generates an SDK in the language your project uses. The version you pass is persisted in `Pulumi.yaml`, so `pulumi install` regenerates the same pinned version.

--- a/content/what-is/what-is-a-terraform-module.md
+++ b/content/what-is/what-is-a-terraform-module.md
@@ -207,7 +207,7 @@ export class S3Bucket extends pulumi.ComponentResource {
 
 Because a component is ordinary code, you get the reuse tools of the host language for free: loops, conditionals, functions, unit tests with your normal test framework, and package managers (npm, PyPI, NuGet, Maven) for distribution. A component packaged as a [Pulumi package](/docs/iac/concepts/packages/) can be published with a Pulumi plugin so that Pulumi generates SDKs for it in every supported language, letting a component authored in one language be consumed from another.
 
-Pulumi also interoperates with the Terraform ecosystem rather than replacing it. You can [consume an existing Terraform module directly from a Pulumi program](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/), which lets teams reuse modules they've already written while adopting Pulumi. For a side-by-side of the two tools' models and terminology, see the [Pulumi and Terraform comparison](/docs/iac/comparisons/terraform/).
+Pulumi also interoperates with the Terraform ecosystem rather than replacing it. The [Any HCL Module](/registry/packages/hcl/) package turns any Terraform or OpenTofu module into a Pulumi component, so you can [consume an existing module directly from a Pulumi program](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) in any supported language and reuse modules you've already written. For a side-by-side of the two tools' models and terminology, see the [Pulumi and Terraform comparison](/docs/iac/comparisons/terraform/).
 
 | Aspect | Terraform module | Pulumi component |
 |---|---|---|
@@ -244,7 +244,7 @@ The root module is the directory where you run Terraform commands; Terraform alw
 
 ### Where can Terraform modules be stored?
 
-The `source` argument supports several locations: a local path in the same repository, the public Terraform Registry, a Git repository (including private ones over SSH), and generic or cloud object-storage sources such as HTTP URLs, Amazon S3, or Google Cloud Storage. Registry and Git sources also support version pinning.
+The `source` argument supports several locations: a local path in the same repository, the public Terraform Registry, a Git repository (including private ones over SSH), and generic or cloud object-storage sources such as HTTP URLs, Amazon S3, or Google Cloud Storage. Registry and Git sources also support version pinning. Private registries are another option: [Pulumi Cloud's registry](/docs/idp/concepts/terraform-modules/), for example, hosts Terraform modules over the same protocol HCP Terraform uses, so `.tf` files reference them with an ordinary `tf.pulumi.com/<namespace>/<name>/<system>` source address.
 
 ### What is the difference between a Terraform module and a Pulumi component?
 
@@ -252,7 +252,7 @@ Both encapsulate a group of resources behind inputs and outputs. A Terraform mod
 
 ### Can you use Terraform modules with Pulumi?
 
-Yes. Pulumi can consume an existing Terraform module directly from a Pulumi program, so teams can reuse modules they've already written while adopting Pulumi's programming model. See the guide on [using a Terraform module in Pulumi](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/).
+Yes. `pulumi package add hcl module <source> [<version>]` turns any Terraform or OpenTofu module into a Pulumi component with a generated, strongly typed SDK, so teams can reuse modules they've already written while adopting Pulumi's programming model. Organizations that publish their modules to [Pulumi Cloud's registry](/docs/idp/concepts/terraform-modules/) get that conversion automatically for every version they publish. See the guide on [using a Terraform module in Pulumi](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/).
 
 ## Learn more
 


### PR DESCRIPTION
Stacked on #20709 — review that one first; the diff here is against its branch.

#20709 renames `pulumi package add terraform-module` to `pulumi package add hcl module` across the six pages that carried the old syntax. This PR picks up the Terraform-facing pages it doesn't touch, which still describe an incomplete picture of what shipped in the [August 2026 release](/releases/terraform-state-backend-modules-hcl/).

- **`get-started/terraform/convert-hcl.md`** presented converting and the HCL runtime as the only two options. It now names three alternatives to converting: run `.tf` files natively, consume a module as a package via [Any HCL Module](/registry/packages/hcl/), or publish to the Pulumi Cloud registry and get conversion for free.
- **`get-started/terraform/_index.md`** listed five of the section's eight topics, omitting the HCL runtime and the Pulumi Cloud state backend / remote execution pages that live in the same section.
- **`what-is/what-is-a-terraform-module.md`** described module reuse without naming the mechanism or mentioning that Pulumi Cloud's registry is a place Terraform modules can live.
- **`comparisons/cdktf.md`** had four links to the pre-move `/docs/iac/using-pulumi/extending-pulumi/use-terraform-module/` path.

Plan names ("Enterprise or Business Critical") and the `tf.pulumi.com/<namespace>/<name>/<system>` source form are taken from `content/docs/idp/concepts/terraform-modules.md`; the `pulumi package add hcl module` syntax from #20709.

## Test plan

1. Automated checks
   - `node scripts/lint/lint-markdown.js`: 1845 files parsed, 0 errors
2. Manual checks
   - Grepped the repo (excluding `content/blog/`) for remaining `package add terraform-module`, `source: terraform-module`, and `pulumi-terraform-module` references: none outside example directory names