### PR TITLE
Show what a Credit buys on the Team and Enterprise pricing cards

### DIFF
--- a/data/pulumi_pricing.yaml
+++ b/data/pulumi_pricing.yaml
@@ -131,14 +131,14 @@ editions:
       # Not every meter belongs: esc-api-call-price is free to 10K and priced per
       # 10K rather than per unit, so it stays in the table below.
       note_tooltip:
-        intro: "Additional usage, in Credits (1 Credit = $1):"
+        intro: "Additional usage, in Credits (1 Credit = $1)"
         rates:
-          - label: 1 IaC resource / month
-            value: "0.1825"
-          - label: 1 secret / month
-            value: "0.50"
-          - label: 1 Insights resource / month
-            value: "0.0185"
+          - label: 1 IaC resource
+            value: "0.1825/month"
+          - label: 1 managed secret
+            value: "0.50/month"
+          - label: 1 Insights resource
+            value: "0.0185/month"
           - label: 1 workflow minute
             value: "0.01"
           - label: 1M Neo tokens
@@ -168,14 +168,14 @@ editions:
       unit: "**Includes 400 Credits**"
       note: Up to 2,000 resources, additional usage billed on demand
       note_tooltip:
-        intro: "Additional usage, in Credits (1 Credit = $1):"
+        intro: "Additional usage, in Credits (1 Credit = $1)"
         rates:
-          - label: 1 IaC resource / month
-            value: from 0.365
-          - label: 1 secret / month
-            value: "0.75"
-          - label: 1 Insights resource / month
-            value: from 0.0365
+          - label: 1 IaC resource
+            value: from 0.365/month
+          - label: 1 managed secret
+            value: "0.75/month"
+          - label: 1 Insights resource
+            value: from 0.0365/month
           - label: 1 workflow minute
             value: "0.01"
           - label: 1M Neo tokens

--- a/data/pulumi_pricing.yaml
+++ b/data/pulumi_pricing.yaml
@@ -125,20 +125,24 @@ editions:
       note: Up to 500 resources, additional usage billed on demand
       # What a Credit buys, per meter, for the (i) tooltip on the note above. A
       # Credit is $1, so these are also the dollar rates — they mirror the
-      # on-demand rows below (iac-on-demand-price, esc-on-demand-price, neo,
-      # workflow-minutes-price) for this edition's column. Change a rate there
-      # and change it here.
+      # on-demand rows below (iac-on-demand-price, esc-on-demand-price,
+      # insights-on-demand-price, workflow-minutes-price, neo) for this
+      # edition's column, in that order. Change a rate there and change it here.
+      # Not every meter belongs: esc-api-call-price is free to 10K and priced per
+      # 10K rather than per unit, so it stays in the table below.
       note_tooltip:
         intro: "Additional usage, in Credits (1 Credit = $1):"
         rates:
-          - label: 1 resource / month
+          - label: 1 IaC resource / month
             value: "0.1825"
           - label: 1 secret / month
             value: "0.50"
-          - label: 1M Neo tokens
-            value: "3"
+          - label: 1 Insights resource / month
+            value: "0.0185"
           - label: 1 workflow minute
             value: "0.01"
+          - label: 1M Neo tokens
+            value: "3"
       cta:
         label: Start a free trial
         href: https://app.pulumi.com/signup?create-organization=1
@@ -166,14 +170,16 @@ editions:
       note_tooltip:
         intro: "Additional usage, in Credits (1 Credit = $1):"
         rates:
-          - label: 1 resource / month
+          - label: 1 IaC resource / month
             value: from 0.365
           - label: 1 secret / month
             value: "0.75"
-          - label: 1M Neo tokens
-            value: "3"
+          - label: 1 Insights resource / month
+            value: from 0.0365
           - label: 1 workflow minute
             value: "0.01"
+          - label: 1M Neo tokens
+            value: "3"
       cta:
         label: Start a free trial
         href: https://app.pulumi.com/signup?create-organization=1

--- a/data/pulumi_pricing.yaml
+++ b/data/pulumi_pricing.yaml
@@ -123,6 +123,22 @@ editions:
       price_label: /month base
       unit: "**Includes 40 Credits**"
       note: Up to 500 resources, additional usage billed on demand
+      # What a Credit buys, per meter, for the (i) tooltip on the note above. A
+      # Credit is $1, so these are also the dollar rates — they mirror the
+      # on-demand rows below (iac-on-demand-price, esc-on-demand-price, neo,
+      # workflow-minutes-price) for this edition's column. Change a rate there
+      # and change it here.
+      note_tooltip:
+        intro: "Additional usage, in Credits (1 Credit = $1):"
+        rates:
+          - label: 1 resource / month
+            value: "0.1825"
+          - label: 1 secret / month
+            value: "0.50"
+          - label: 1M Neo tokens
+            value: "3"
+          - label: 1 workflow minute
+            value: "0.01"
       cta:
         label: Start a free trial
         href: https://app.pulumi.com/signup?create-organization=1
@@ -147,6 +163,17 @@ editions:
       price_label: /month base
       unit: "**Includes 400 Credits**"
       note: Up to 2,000 resources, additional usage billed on demand
+      note_tooltip:
+        intro: "Additional usage, in Credits (1 Credit = $1):"
+        rates:
+          - label: 1 resource / month
+            value: from 0.365
+          - label: 1 secret / month
+            value: "0.75"
+          - label: 1M Neo tokens
+            value: "3"
+          - label: 1 workflow minute
+            value: "0.01"
       cta:
         label: Start a free trial
         href: https://app.pulumi.com/signup?create-organization=1

--- a/layouts/page/pricing.html
+++ b/layouts/page/pricing.html
@@ -45,7 +45,10 @@
         {{ $borderClass := "" }}
         {{ if $card.badge }}{{ $borderClass = "rounded-lg border-0 ring ring-[1.5px] relative z-10 ring-offset-4 ring-violet-accent" }}{{ end }}
         <div>
-            <div class=" p-8 flex flex-col gap-6 bg-white h-full overflow-hidden rounded-lg {{ $borderClass }}">
+            {{/* No overflow-hidden: the note's rate tooltip is absolutely
+                 positioned and wider than the card's content column, so
+                 clipping the card would cut the bubble in half. */}}
+            <div class=" p-8 flex flex-col gap-6 bg-white h-full rounded-lg {{ $borderClass }}">
                 <div>
                     <div class="flex items-center gap-3">
                         <h2 class="text-2xl font-semibold tracking-tight m-0">{{ $edition.name }}</h2>
@@ -66,11 +69,7 @@
                     <p class="text-3xl font-semibold tracking-tight m-0">{{ $card.price }}</p>
                     {{ end }}
                     <div class="mt-4 md:min-h-[4rem] text-sm">
-                        {{ with $card.unit }}
-                        <p class="m-0">{{ . | markdownify }}</p>
-                        {{ end }} {{ with $card.note }}
-                        <p class="text-gray-700 m-0">{{ . | markdownify }}</p>
-                        {{ end }}
+                        {{ partial "pricing/card-usage.html" $card }}
                     </div>
                 </div>
 

--- a/layouts/partials/pricing/card-usage.html
+++ b/layouts/partials/pricing/card-usage.html
@@ -1,0 +1,44 @@
+{{- /*
+  The usage block under a pricing card's price: the included-Credits line and the
+  "additional usage billed on demand" note. When the edition declares
+  `note_tooltip` rates, the whole block becomes the hover target for a tooltip
+  saying what that edition's extra usage actually costs, per meter — readers
+  can't get from a resource count to a dollar figure from the cards alone
+  (pulumi/docs#20696), and a Credit is $1, so these rates are the dollar rates.
+
+  Takes the card's `unit`, `note`, and `note_tooltip` from data/pulumi_pricing.yaml:
+
+      {{ partial "pricing/card-usage.html" $card }}
+
+    tooltip.intro   one line of orientation above the list
+    tooltip.rates   [{label, value}] — value is a bare number; the intro carries
+                    the unit
+
+  size="lg" widens and left-aligns the bubble (theme/src/scss/_tooltip.scss); the
+  default 12rem centered bubble wraps a two-column list into an unreadable stack.
+*/ -}}
+{{- $tooltip := .note_tooltip -}}
+{{- if $tooltip -}}
+<pulumi-tooltip size="lg" class="block">
+{{- end }}
+    <span class="block">
+        {{ with .unit }}<span class="block mb-1.5">{{ . | markdownify }}</span>{{ end }}
+        {{ with .note }}<span class="block text-gray-700 leading-normal">{{ . | markdownify }}{{ with $tooltip }}{{ partial "icon.html" (dict "name" "info" "class" "size-4 ml-0.5 -mt-0.5 inline text-gray-600") }}{{ end }}</span>{{ end }}
+    </span>
+{{- with $tooltip }}
+    {{- /* Everything sits inside one block wrapper: _tooltip.scss sets
+           `display: unset` on the [slot="content"] element itself, which leaves
+           it inline, and rows laid out directly under an inline box misbehave. */ -}}
+    <span slot="content">
+        <span class="block">
+            {{ with .intro }}<span class="block pb-1.5 mb-1.5 border-b border-white/20">{{ . }}</span>{{ end }}
+            {{ range .rates }}
+            <span class="flex items-baseline justify-between gap-3">
+                <span>{{ .label }}</span>
+                <span class="font-semibold whitespace-nowrap">{{ .value }}</span>
+            </span>
+            {{ end }}
+        </span>
+    </span>
+</pulumi-tooltip>
+{{- end }}

--- a/layouts/partials/pricing/card-usage.html
+++ b/layouts/partials/pricing/card-usage.html
@@ -23,7 +23,7 @@
 {{- end }}
     <span class="block">
         {{ with .unit }}<span class="block mb-1.5">{{ . | markdownify }}</span>{{ end }}
-        {{ with .note }}<span class="block text-gray-700 leading-normal">{{ . | markdownify }}{{ with $tooltip }}{{ partial "icon.html" (dict "name" "info" "class" "size-4 ml-0.5 -mt-0.5 inline text-gray-600") }}{{ end }}</span>{{ end }}
+        {{ with .note }}<span class="block text-gray-700 leading-normal">{{ . | markdownify }}{{ with $tooltip }}{{ partial "icon.html" (dict "name" "info" "class" "size-4 ml-0.5 -mt-0.5 inline text-gray-700") }}{{ end }}</span>{{ end }}
     </span>
 {{- with $tooltip }}
     {{- /* Everything sits inside one block wrapper: _tooltip.scss sets

--- a/theme/src/scss/_tooltip.scss
+++ b/theme/src/scss/_tooltip.scss
@@ -61,6 +61,15 @@ pulumi-tooltip {
         }
     }
 
+    // Wide placement (opt in with size="lg"): a roomier, left-aligned bubble for
+    // multi-line content — e.g. the label/value rate lists on the /pricing/ cards,
+    // which the default 12rem centered bubble wraps into an unreadable stack.
+    &[size="lg"] {
+        .tooltip-content {
+            @apply w-72 text-left leading-relaxed;
+        }
+    }
+
     // To prevent a flash of unstyled/understyled slotted content, we hide that content until
     // it's rendered as a child of the tooltip component.
     [slot="content"] {


### PR DESCRIPTION
### Proposed changes

The plan cards name a Credit balance without saying what a Credit is or what it buys, so a reader can't get from "I have N resources" to a dollar figure. Hovering the "Includes N Credits" block on the Team and Enterprise cards now opens a tooltip stating that a Credit is \$1 and listing that edition's per-meter rates. The rates are authored per edition in `data/pulumi_pricing.yaml` under `card.note_tooltip`, mirroring the on-demand rows in the comparison table further down the same file; a new `layouts/partials/pricing/card-usage.html` renders the usage block and wraps it in the tooltip only when an edition declares rates; and a `size="lg"` tooltip variant widens and left-aligns the bubble so the label/value rows don't wrap.

**What the tooltip says.** Team:

```
Additional usage, in Credits (1 Credit = $1)

1 IaC resource              0.1825/month
1 managed secret              0.50/month
1 Insights resource         0.0185/month
1 workflow minute                   0.01
1M Neo tokens                          3
```

Enterprise:

```
Additional usage, in Credits (1 Credit = $1)

1 IaC resource           from 0.365/month
1 managed secret              0.75/month
1 Insights resource     from 0.0365/month
1 workflow minute                   0.01
1M Neo tokens                          3
```

ESC API calls are deliberately left out: free to 10K, priced per 10K rather than per unit, and too small to move an estimate. This is a partial fix — it covers "surface the per-resource rate in the cards" and "say what a Credit is," but not the on-demand-table link, the FAQ worked example, or the calculator.

### Related issues (optional)

Part of #20696