### PR TITLE
Stop the homepage promoting an event that has already happened

### DIFF
--- a/layouts/partials/events/list-section.html
+++ b/layouts/partials/events/list-section.html
@@ -11,9 +11,10 @@
 
 {{ $allEvents := (where $.Site.Pages "Type" "events") }}
 
-{{/* Upcoming events come from the shared helper so this list and any other
-     consumer (e.g. the homepage section) agree on what "upcoming" means. */}}
-{{ $upcomingEvents := partialCached "events/upcoming.html" . "upcoming" }}
+{{/* Shared with the homepage section so both agree on how "upcoming" is decided.
+     A cutoff 24 hours back keeps an event listed until a day after it starts,
+     so a session running right now doesn't disappear mid-event. */}}
+{{ $upcomingEvents := partialCached "events/upcoming.html" (now.Add (duration "hour" -24)) "upcoming-list" }}
 {{ $upcomingPages := slice }}
 {{ range $upcomingEvents }}{{ $upcomingPages = $upcomingPages | append .data }}{{ end }}
 

--- a/layouts/partials/events/upcoming.html
+++ b/layouts/partials/events/upcoming.html
@@ -2,22 +2,34 @@
     Upcoming events — the single source of truth for "which events are still
     ahead of us", shared by the events list page and the homepage section.
 
-    An event counts as upcoming until 24 hours after its start time, so a session
-    that ran earlier today doesn't vanish from the list mid-event.
+    Context: the cutoff time. An event is upcoming while its start time is after
+    that instant. Callers pass a cutoff because "upcoming" means two things here:
+
+      - The events list passes `now` minus 24 hours, so a session running right
+        now doesn't vanish from the list mid-event.
+
+      - The homepage passes `now` plus 24 hours, so the one event it promotes is
+        still in the future at every moment the page is served — published HTML
+        outlives the `now` it was built with, and weekend gaps between builds
+        have measured 15+ hours. A cutoff of `now` would leave an evening event
+        on the page into the next morning, a day after it happened.
+
+        Lead time rather than "end of the build day" because Hugo's `now` is the
+        runner's clock and the runner is UTC, so end-of-day lands at 5pm Pacific
+        and lets US evening events through — the exact case this guards against.
 
     Returns: a slice of dicts, oldest-first (i.e. the next event is index 0):
       date  the event's sortable_date
       data  the event page
 
-    Global (depends only on site content), so callers should use partialCached
-    with a constant key.
+    Depends only on site content and the cutoff, so callers should use
+    partialCached with a constant key per cutoff.
 */ -}}
-{{- $nowUnix := now.UnixMilli -}}
+{{- $cutoffUnix := .UnixMilli -}}
 {{- $upcoming := slice -}}
 {{- range where site.Pages "Type" "events" -}}
     {{- if eq .Params.unlisted false -}}
-        {{- $endUnix := add (.Params.sortable_date | time.AsTime).UnixMilli (duration "hour" 24).Milliseconds -}}
-        {{- if lt $nowUnix $endUnix -}}
+        {{- if gt (.Params.sortable_date | time.AsTime).UnixMilli $cutoffUnix -}}
             {{- $upcoming = $upcoming | append (dict "date" .Params.sortable_date "data" .) -}}
         {{- end -}}
     {{- end -}}

--- a/layouts/partials/template-partials/template-latest-posts.html
+++ b/layouts/partials/template-partials/template-latest-posts.html
@@ -26,7 +26,8 @@
       { text: "Read the blog", link: "/blog/" }. The row mixes two content types,
       so this takes a list rather than the single cta_text/cta_link other sections use.
     - count: Total number of tiles in the row. Default 3.
-    - show_event: Optional true to give the last slot to the next upcoming event.
+    - show_event: Optional true to give the last slot to the next upcoming event
+      that's more than a day out — see the cutoff below.
     - anchor: Optional anchor for section id
 */}}
 
@@ -42,7 +43,10 @@
 
 {{ $nextEvent := "" }}
 {{ if $showEvent }}
-    {{ with first 1 (partialCached "events/upcoming.html" $ctx "upcoming") }}
+    {{/* A day of lead time so the tile can't go stale-dated while this page sits
+         published between builds (see events/upcoming.html); the practical
+         effect is that an event drops off the homepage the day before it runs. */}}
+    {{ with first 1 (partialCached "events/upcoming.html" (now.Add (duration "hour" 24)) "upcoming-homepage") }}
         {{ $nextEvent = index . 0 }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
### Proposed changes

The homepage was showing "Camp AI: Agents at Work" (Aug 6) on Aug 7, because `events/upcoming.html` counted an event as upcoming until 24 hours *after* its start time — a rule inherited from the events list page (#20506) and extracted verbatim into the shared partial in #20665. The partial now takes a cutoff instead of hardcoding that rule: the events list passes `now - 24h` so its behavior is unchanged, and the homepage passes `now + 24h` so the one event it promotes is still in the future at every moment the page is served. The forward cutoff is what the guarantee needs — published HTML outlives the `now` it was built with, and while master gets ~18 builds a day midweek, weekends run on `build-and-deploy.yml`'s crons alone where the 20:23 → 11:17 UTC gap has measured 15+ hours, so a cutoff of `now` would leave an evening event on the page into the next morning. It's a fixed lead time rather than an end-of-day boundary because Hugo's `now` is the runner's clock and the runner is UTC, so "end of day" would land at 5pm Pacific and let US evening events through — the exact case this guards against. The visible tradeoff is that an event now drops off the homepage the day before it runs rather than the day of; `/events/` still lists same-day and in-progress sessions.

Verified with a full `hugo` build: the homepage slot renders "Getting Started with DevOps AI Skills" (Aug 12) with Camp AI absent from the page, and `/events/` still lists Camp AI.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A