### PR TITLE
Add a note to the TF state ESC provider page about using pulumi-stacks provder if using Pulumi Cloud as TF backend.

### DIFF
--- a/content/docs/esc/providers/iac/terraform-state.md
+++ b/content/docs/esc/providers/iac/terraform-state.md
@@ -17,6 +17,10 @@ aliases:
   - /docs/esc/concepts/providers/secrets/terraform-state/
 ---
 
+{{% notes type="info" %}}
+If using Pulumi Cloud as your state backend for Terraform, use the [`pulumi-stacks`](/docs/esc/providers/iac/pulumi-stacks/) provider instead.
+{{% /notes %}}
+
 The `terraform-state` provider enables you to read outputs from Terraform state files stored in S3 or Terraform Cloud. By importing those outputs into your environment, you can seamlessly consume Terraform-managed infrastructure as inputs to your Pulumi programs — referencing values such as VPC IDs, subnet IDs, and cluster endpoints directly, without copying them by hand or rewriting your Terraform in Pulumi. This bridges the two tools, so you can adopt Pulumi incrementally alongside an existing Terraform footprint.
 
 Imported outputs are available under the `outputs` key (for example, `${terraform.outputs.vpc_id}`) and can be mapped to either of the following:


### PR DESCRIPTION
This pull request adds an informational note to the Terraform State provider documentation to clarify usage when Pulumi Cloud is used as the state backend. This helps users select the correct provider for their use case.

- **Documentation improvement:**
  * Added an info note to `terraform-state.md` advising users to use the `pulumi-stacks` provider when Pulumi Cloud is the state backend for Terraform.
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Tip: open this PR as a **draft** while you iterate. Automated review
    fires when you mark it ready for review — drafting first keeps the
    review fresh and avoids comment noise. While iterating, you can also
    run /docs-review locally to catch findings before they cost review
    budget.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Unreleased product version (optional)

<!--If this change only applies to an unreleased version of a product, note the version here and add a docs/unreleased PR label.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
