### PR TITLE
Open post-body images and videos in a lightbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,12 @@ To promote an event or another post from inside a post, embed its card with `{{<
 
 Card layouts live in `layouts/partials/blog/card/` — `medium` (grid tile), `contained` (`medium` boxed in a `.card`), `wide` (text left, square image right; the homepage feed's card view **and** in-body embeds), `small`, `featured`, `series`, `list-row`. Reuse one; don't clone its markup into a new partial. `wide` renders only its wrapper's contents and takes the wrapper's classes as a param, because the homepage row starts `hidden` (the view toggle flips it to flex) while an embed is a boxed `.card`.
 
+### Images and videos in a post body
+
+Post-body images and `{{< video >}}` clips open in a lightbox when — and only when — enlarging them would show the reader more. `theme/src/ts/blog-lightbox.ts` measures each one in `.blog-post-content` against the viewport (intrinsic size vs. rendered size vs. the size the overlay could draw it at) and wraps the ones that qualify in a trigger button; the overlay shell is `layouts/partials/blog/lightbox.html`, rendered by `layouts/blog/single.html`. Nothing about this is author-driven: **do not add a wrapping link, a `figure`, or a per-image opt-in** to make something clickable, and don't hand-roll a second modal. The escape hatch runs the other way — `data-no-lightbox` on the element or any ancestor keeps it plain. A post-body video that already has `controls` is skipped entirely: a wrapping button would swallow clicks meant for the control bar, and those controls already offer fullscreen. (The overlay's own copy of a video always has controls, and is exempt from click-to-close for the same reason.)
+
+The thresholds live at the top of the TypeScript file with the reasoning for each; tune them there rather than special-casing a post. Two of them, `OVERLAY_MARGIN_X`/`OVERLAY_MARGIN_Y`, mirror the overlay's padding and its caption budget — **if you change the spacing in `lightbox.html`, change them to match**, or the script will promise an enlargement the overlay can't deliver.
+
 ### Dates: `updated` vs `lastmod`
 
 When you revise an existing blog post, use **`updated: YYYY-MM-DD`** — not `lastmod`. This is the established convention (the vast majority of revised posts use it) and the one wired to the UI: `layouts/blog/single.html` renders `.Params.updated` as the visible "Updated \<date\>" line beside the publish date. Leave the original `date` unchanged; set `updated` to the revision date. It's the same field documented in `BLOGGING.md`.

--- a/BLOGGING.md
+++ b/BLOGGING.md
@@ -225,6 +225,10 @@ To add images to the body of your post, first place them within the folder conta
 ![The humble platypus](platypus.png)
 ```
 
+Readers can click an image to see it full size in an overlay, but only where that actually helps: an image gets the treatment when the overlay could draw it meaningfully bigger than the post does, so screenshots and other detail-heavy images become clickable while icons, badges, and images already shown at their full size stay plain. That's decided in the browser from the image's own dimensions — there's nothing to add to your Markdown. If you have an image that qualifies but shouldn't be clickable, add `data-no-lightbox` to it (or to a wrapping element) in raw HTML.
+
+The same applies to videos added with the [`video` shortcode](#video) below, which is worth knowing when you record one: a clip shot at 1080p is being squeezed into the ~768px content column, and readers can open it at full size, so record at a comfortably higher resolution than the column rather than at the column's width. The enlarged copy always gets playback controls, even though the clip in the post body has none, so readers can pause and scrub there. Clips you give `controls="true"` are left out of this altogether — their controls already include a fullscreen button.
+
 #### Social ("Meta") and Feature Images
 
 > [!IMPORTANT]

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -102,4 +102,9 @@
     </div>
 
     {{ partial "blog/related-posts.html" . }}
+
+    {{- /* Overlay shell for the post-body media lightbox; blog-lightbox.ts
+        decides at runtime which images and videos (if any) open into it. Only
+        posts carrying one or the other need it. */ -}}
+    {{ if or (strings.Contains .Content "<img") (strings.Contains .Content "<video") }}{{ partial "blog/lightbox.html" . }}{{ end }}
 {{ end }}

--- a/layouts/partials/blog/lightbox.html
+++ b/layouts/partials/blog/lightbox.html
@@ -1,5 +1,5 @@
 {{/*
-    Blog image lightbox
+    Blog media lightbox
 
     Hidden overlay shell for a blog post. theme/src/ts/blog-lightbox.ts decides
     which images and videos in the post body are worth enlarging (see that file
@@ -19,7 +19,7 @@
     closed. Layout classes belong on the <figure> inside.
 */}}
 
-<dialog data-lightbox aria-label="Expanded image"
+<dialog data-lightbox aria-label="Expanded view"
         class="fixed inset-0 m-0 h-full max-h-none w-full max-w-none border-0 bg-transparent p-4 backdrop:bg-service-black/90 md:p-8">
     <button type="button" data-lightbox-close aria-label="Close"
             class="absolute right-2 top-2 z-10 inline-flex size-10 items-center justify-center rounded-full border-0 bg-transparent text-white transition-colors hover:bg-white/15 md:right-4 md:top-4">

--- a/layouts/partials/blog/lightbox.html
+++ b/layouts/partials/blog/lightbox.html
@@ -1,0 +1,61 @@
+{{/*
+    Blog image lightbox
+
+    Hidden overlay shell for a blog post. theme/src/ts/blog-lightbox.ts decides
+    which images and videos in the post body are worth enlarging (see that file
+    for the rules), wraps each one in a [data-lightbox-trigger] button, and
+    shows it here at up to its intrinsic size. The close button, Escape, and a
+    click anywhere in the overlay but the video itself all close it. No
+    parameters.
+
+    A native <dialog> rather than a hand-rolled overlay like the changelog modal
+    (partials/releases/changelog-modal.html): showModal() gives the top layer,
+    the focus trap, the inert background, Escape, and focus restoration for
+    free, and unlike that modal this one holds no prose, so it doesn't need to
+    stay inside <main> for content styles to reach it.
+
+    Do NOT put a display utility (flex/grid/block) on the <dialog> itself — it
+    would defeat the UA's `display: none` and leave the overlay on screen while
+    closed. Layout classes belong on the <figure> inside.
+*/}}
+
+<dialog data-lightbox aria-label="Expanded image"
+        class="fixed inset-0 m-0 h-full max-h-none w-full max-w-none border-0 bg-transparent p-4 backdrop:bg-service-black/90 md:p-8">
+    <button type="button" data-lightbox-close aria-label="Close"
+            class="absolute right-2 top-2 z-10 inline-flex size-10 items-center justify-center rounded-full border-0 bg-transparent text-white transition-colors hover:bg-white/15 md:right-4 md:top-4">
+        {{ partial "icon.html" (dict "name" "x" "class" "size-6") }}
+    </button>
+
+    {{- /* Media and caption are centred as one group, caption directly beneath.
+        The 6rem the media gives up is the caption's: three clamped lines plus
+        the gap, with room to spare, so the media never has to flex-shrink (which
+        would squash it — a shrunk flex item keeps its own width). Width and
+        height are capped and the intrinsic ratio does the rest, so it scales
+        down to fit and is never upscaled. Only one of the two media elements is
+        shown at a time; the script hides the other.
+
+        blog-lightbox.ts subtracts the same budget when it decides whether the
+        overlay is bigger than the post — keep OVERLAY_MARGIN_Y in step with the
+        6rem here plus this element's padding. */ -}}
+    <figure class="m-0 flex h-full w-full flex-col items-center justify-center gap-3">
+        <img data-lightbox-image alt="" class="max-h-[calc(100%-6rem)] max-w-full rounded-lg shadow-2xl" />
+        {{- /* Controls here but not inline: a post-body clip is an autoplaying
+            loop with nothing to operate, while at full size it's worth being
+            able to pause, scrub, or go fullscreen. blog-lightbox.ts exempts
+            this element from the click-to-close handler so that operating them
+            doesn't also dismiss the overlay. */ -}}
+        <video data-lightbox-video controls playsinline
+               class="hidden max-h-[calc(100%-6rem)] max-w-full rounded-lg shadow-2xl"></video>
+        <figcaption data-lightbox-caption aria-hidden="true"
+                    class="body-sm line-clamp-3 max-w-3xl shrink-0 text-center text-gray-300 empty:hidden"></figcaption>
+    </figure>
+
+    {{- /* Cloned into each trigger button as the hover/focus affordance. Lives
+        here rather than in the TypeScript so the icon comes from the sprite. */ -}}
+    <template data-lightbox-badge>
+        <span aria-hidden="true"
+              class="pointer-events-none absolute right-3 top-3 inline-flex size-9 items-center justify-center rounded-md bg-service-black/60 text-white opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+            {{ partial "icon.html" (dict "name" "magnifying-glass-plus" "class" "size-5") }}
+        </span>
+    </template>
+</dialog>

--- a/theme/src/ts/blog-lightbox.ts
+++ b/theme/src/ts/blog-lightbox.ts
@@ -44,11 +44,15 @@ const OVERLAY_MARGIN_X = 64;
 const OVERLAY_MARGIN_Y = 160;
 
 // The injected wrapper must not change the media's box: no padding, no border,
-// and shrink-to-fit like the image it wraps. `group` drives the badge's
-// hover/focus reveal (see the template in the partial).
+// and shrink-to-fit like the image it wraps.
 const TRIGGER_CLASS =
-    "group relative block cursor-zoom-in appearance-none border-0 bg-transparent p-0 " +
+    "relative block appearance-none border-0 bg-transparent p-0 " +
     "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-primary";
+
+// Carried only while the wrapper is live, so that an inert one (see disable())
+// neither advertises a click nor reveals the badge: `group` is what drives the
+// badge's hover/focus reveal (see the template in the partial).
+const ACTIVE_CLASSES = ["group", "cursor-zoom-in"];
 
 // Videos need the wrapper to span the column instead: the shortcode renders
 // them `w-full`, and a percentage width resolved against a shrink-to-fit button
@@ -119,13 +123,19 @@ document.addEventListener("DOMContentLoaded", () => {
     let pausedSource: HTMLVideoElement | null = null;
 
     function enable(el: Media): void {
-        if (el.parentElement?.hasAttribute("data-lightbox-trigger")) {
+        const existing = el.parentElement;
+        if (existing?.hasAttribute("data-lightbox-trigger")) {
+            // An inert wrapper left behind by disable(), now eligible again.
+            existing.removeAttribute("data-lightbox-inert");
+            (existing as HTMLButtonElement).disabled = false;
+            existing.classList.add(...ACTIVE_CLASSES);
             return;
         }
         const button = document.createElement("button");
         button.type = "button";
         button.setAttribute("data-lightbox-trigger", "");
         button.className = isVideo(el) ? VIDEO_TRIGGER_CLASS : TRIGGER_CLASS;
+        button.classList.add(...ACTIVE_CLASSES);
         // The alt text or title still names the media; the suffix says what the
         // button does with it.
         const description = describe(el);
@@ -135,9 +145,22 @@ document.addEventListener("DOMContentLoaded", () => {
         button.appendChild(badge.content.cloneNode(true));
     }
 
+    // An image is simply unwrapped. A video isn't: moving a media element in
+    // the DOM re-runs resource selection in some engines, and a post-body clip
+    // is an autoplaying loop, so unwrapping one mid-resize can restart it from
+    // frame 0. Its wrapper stays where it is and goes inert instead — disabled
+    // (out of the tab order, and no longer announced as a control) and stripped
+    // of the classes that make it look clickable.
     function disable(el: Media): void {
         const button = el.parentElement;
-        if (button?.hasAttribute("data-lightbox-trigger")) {
+        if (!button?.hasAttribute("data-lightbox-trigger")) {
+            return;
+        }
+        if (isVideo(el)) {
+            button.setAttribute("data-lightbox-inert", "");
+            (button as HTMLButtonElement).disabled = true;
+            button.classList.remove(...ACTIVE_CLASSES);
+        } else {
             button.replaceWith(el);
         }
     }
@@ -199,8 +222,11 @@ document.addEventListener("DOMContentLoaded", () => {
         dialog.showModal();
     }
 
+    // The :not() covers the inert wrappers disable() leaves around videos,
+    // rather than trusting engines to agree on whether a click inside a
+    // disabled button is dispatched at all.
     postBody.addEventListener("click", (e: MouseEvent) => {
-        const button = (e.target as HTMLElement).closest("[data-lightbox-trigger]");
+        const button = (e.target as HTMLElement).closest("[data-lightbox-trigger]:not([data-lightbox-inert])");
         const el = button?.querySelector<Media>("img, video");
         if (el) {
             open(el);

--- a/theme/src/ts/blog-lightbox.ts
+++ b/theme/src/ts/blog-lightbox.ts
@@ -16,11 +16,13 @@
 //
 // Authors can opt an element (or a block of them) out explicitly by putting
 // data-no-lightbox on it or any ancestor. Anything inside a link is always
-// skipped — it already does something when clicked — which also covers the card
-// embeds ({{< blog/card >}}) that render inside a post body. A video with
-// controls is skipped too: a wrapping button would swallow clicks meant for the
-// control bar, and those controls already carry a fullscreen button, which is
-// the same offer the lightbox makes.
+// skipped — it already does something when clicked. That doesn't reach the card
+// embeds ({{< blog/card >}}) that render inside a post body, whose link is
+// stretched over the card from the title rather than wrapped around its
+// thumbnail; it's the display-width floor below that keeps those out. A video
+// with controls is skipped too: a wrapping button would swallow clicks meant for
+// the control bar, and those controls already carry a fullscreen button, which
+// is the same offer the lightbox makes.
 
 // Narrower than this on screen and it's a badge or an icon, not a figure.
 const MIN_DISPLAY_WIDTH = 240;
@@ -156,6 +158,9 @@ document.addEventListener("DOMContentLoaded", () => {
         overlayVideo.src = video.currentSrc;
         overlayVideo.muted = video.muted;
         overlayVideo.loop = video.loop;
+        // The name the caption shows is aria-hidden, so the title is what names
+        // the player for assistive tech.
+        overlayVideo.title = video.title;
         // Pick up where the inline clip was rather than restarting it, and hold
         // the inline copy still while its bigger twin plays. currentTime is only
         // settable once the new source has metadata.

--- a/theme/src/ts/blog-lightbox.ts
+++ b/theme/src/ts/blog-lightbox.ts
@@ -1,0 +1,248 @@
+// Blog media lightbox: click an image or video in a post body to see it larger,
+// in the overlay rendered by layouts/partials/blog/lightbox.html.
+//
+// Only media that actually gains something from the treatment gets it. An
+// inline icon, a badge, a logo, or a screenshot already shown at its full size
+// gains nothing from a modal that redraws it at the same size — and making it
+// clickable is noise, not a feature. So eligibility is measured, not marked up:
+// an element becomes clickable only when the overlay could draw it meaningfully
+// bigger than the post draws it. That check has to run in the browser, because
+// it needs the intrinsic pixel size and the current viewport; post images are
+// plain markdown references, many of them pointing at another post's bundle or
+// at /static, so there's no dependable build-time size to test against. Videos
+// are the same measurement against videoWidth/videoHeight — the {{< video >}}
+// shortcode renders them `w-full`, so a screen recording shot at 1080p is
+// always being squeezed into the ~768px column.
+//
+// Authors can opt an element (or a block of them) out explicitly by putting
+// data-no-lightbox on it or any ancestor. Anything inside a link is always
+// skipped — it already does something when clicked — which also covers the card
+// embeds ({{< blog/card >}}) that render inside a post body. A video with
+// controls is skipped too: a wrapping button would swallow clicks meant for the
+// control bar, and those controls already carry a fullscreen button, which is
+// the same offer the lightbox makes.
+
+// Narrower than this on screen and it's a badge or an icon, not a figure.
+const MIN_DISPLAY_WIDTH = 240;
+
+// The source needs real detail to reveal: below the ~768px content column
+// there's nothing behind the constraint worth opening. SVGs are measured the
+// same way — the overlay draws everything at its intrinsic size at most, so a
+// vector authored small has no more to show than a raster of the same size.
+const MIN_INTRINSIC_WIDTH = 600;
+
+// The overlay has to be at least this much wider than the inline image to be
+// worth a click.
+const MIN_ENLARGEMENT = 1.2;
+
+// Room the overlay's own chrome takes off the viewport, mirroring
+// partials/blog/lightbox.html: its md:p-8 side padding, and vertically that
+// padding plus the 6rem the media yields to the caption.
+const OVERLAY_MARGIN_X = 64;
+const OVERLAY_MARGIN_Y = 160;
+
+// The injected wrapper must not change the media's box: no padding, no border,
+// and shrink-to-fit like the image it wraps. `group` drives the badge's
+// hover/focus reveal (see the template in the partial).
+const TRIGGER_CLASS =
+    "group relative block cursor-zoom-in appearance-none border-0 bg-transparent p-0 " +
+    "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-primary";
+
+// Videos need the wrapper to span the column instead: the shortcode renders
+// them `w-full`, and a percentage width resolved against a shrink-to-fit button
+// would collapse the video to nothing.
+const VIDEO_TRIGGER_CLASS = `${TRIGGER_CLASS} w-full`;
+
+type Media = HTMLImageElement | HTMLVideoElement;
+
+function isVideo(el: Media): el is HTMLVideoElement {
+    return el.tagName === "VIDEO";
+}
+
+// Zero on either axis means hidden, still loading, or broken.
+function intrinsicSize(el: Media): [number, number] {
+    return isVideo(el) ? [el.videoWidth, el.videoHeight] : [el.naturalWidth, el.naturalHeight];
+}
+
+function worthEnlarging(el: Media): boolean {
+    const displayWidth = el.clientWidth;
+    const [intrinsicWidth, intrinsicHeight] = intrinsicSize(el);
+    if (!displayWidth || !intrinsicWidth || !intrinsicHeight) {
+        return false;
+    }
+    if (displayWidth < MIN_DISPLAY_WIDTH || intrinsicWidth < MIN_INTRINSIC_WIDTH) {
+        return false;
+    }
+
+    // How wide the overlay would draw it: scaled down to fit the viewport box,
+    // never up past its intrinsic size, since upscaling only adds blur.
+    // Comparing that against the inline width is also what keeps a tall image
+    // out — fitting one to the viewport height leaves it no wider than the
+    // content column already made it.
+    const fit = Math.min((window.innerWidth - OVERLAY_MARGIN_X) / intrinsicWidth, (window.innerHeight - OVERLAY_MARGIN_Y) / intrinsicHeight, 1);
+    return intrinsicWidth * fit >= displayWidth * MIN_ENLARGEMENT;
+}
+
+// The alt text on an image, the title on a {{< video >}} clip.
+function describe(el: Media): string {
+    return isVideo(el) ? el.title : el.alt;
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    const dialog = document.querySelector<HTMLDialogElement>("[data-lightbox]");
+    const postBody = document.querySelector<HTMLElement>(".blog-post-content");
+    if (!dialog || !postBody) {
+        return;
+    }
+
+    const overlayImage = dialog.querySelector<HTMLImageElement>("[data-lightbox-image]");
+    const overlayVideo = dialog.querySelector<HTMLVideoElement>("[data-lightbox-video]");
+    const caption = dialog.querySelector<HTMLElement>("[data-lightbox-caption]");
+    const badge = dialog.querySelector<HTMLTemplateElement>("[data-lightbox-badge]");
+    if (!overlayImage || !overlayVideo || !caption || !badge) {
+        return;
+    }
+
+    // closest() matches the element itself, so this covers both an opted-out
+    // element and an opted-out (or linked) container around one.
+    const media = Array.from(postBody.querySelectorAll<Media>("img, video")).filter(
+        el => !el.closest("a, [data-no-lightbox]") && !(isVideo(el) && el.controls),
+    );
+    if (media.length === 0) {
+        return;
+    }
+
+    // The inline clip a video overlay was opened from, if opening it paused
+    // one; it gets resumed on close.
+    let pausedSource: HTMLVideoElement | null = null;
+
+    function enable(el: Media): void {
+        if (el.parentElement?.hasAttribute("data-lightbox-trigger")) {
+            return;
+        }
+        const button = document.createElement("button");
+        button.type = "button";
+        button.setAttribute("data-lightbox-trigger", "");
+        button.className = isVideo(el) ? VIDEO_TRIGGER_CLASS : TRIGGER_CLASS;
+        // The alt text or title still names the media; the suffix says what the
+        // button does with it.
+        const description = describe(el);
+        button.setAttribute("aria-label", description ? `${description} (view larger)` : "View larger");
+        el.replaceWith(button);
+        button.appendChild(el);
+        button.appendChild(badge.content.cloneNode(true));
+    }
+
+    function disable(el: Media): void {
+        const button = el.parentElement;
+        if (button?.hasAttribute("data-lightbox-trigger")) {
+            button.replaceWith(el);
+        }
+    }
+
+    // Eligibility depends on the viewport, so it isn't decided once: an image
+    // that gains nothing on a wide screen can gain plenty on a narrow one.
+    function refresh(): void {
+        for (const el of media) {
+            if (worthEnlarging(el)) {
+                enable(el);
+            } else {
+                disable(el);
+            }
+        }
+    }
+
+    function openVideo(video: HTMLVideoElement): void {
+        overlayVideo.src = video.currentSrc;
+        overlayVideo.muted = video.muted;
+        overlayVideo.loop = video.loop;
+        // Pick up where the inline clip was rather than restarting it, and hold
+        // the inline copy still while its bigger twin plays. currentTime is only
+        // settable once the new source has metadata.
+        const resumeAt = video.currentTime;
+        overlayVideo.addEventListener(
+            "loadedmetadata",
+            () => {
+                overlayVideo.currentTime = resumeAt;
+                void overlayVideo.play().catch(() => {
+                    /* autoplay may be blocked; the first frame still shows */
+                });
+            },
+            { once: true },
+        );
+        if (!video.paused) {
+            video.pause();
+            pausedSource = video;
+        }
+    }
+
+    function open(el: Media): void {
+        const video = isVideo(el);
+        overlayImage.classList.toggle("hidden", video);
+        overlayVideo.classList.toggle("hidden", !video);
+        if (isVideo(el)) {
+            openVideo(el);
+        } else {
+            overlayImage.src = el.currentSrc || el.src;
+            overlayImage.alt = el.alt;
+        }
+        // Visible caption only — the overlay image's alt (and the video's own
+        // title) already carry this text for assistive tech, hence aria-hidden
+        // on the figcaption.
+        caption.textContent = describe(el);
+        document.body.style.overflow = "hidden";
+        dialog.showModal();
+    }
+
+    postBody.addEventListener("click", (e: MouseEvent) => {
+        const button = (e.target as HTMLElement).closest("[data-lightbox-trigger]");
+        const el = button?.querySelector<Media>("img, video");
+        if (el) {
+            open(el);
+        }
+    });
+
+    // Anywhere in the overlay, including the image itself: there's nothing to
+    // interact with in there, so every click is a dismissal. That's also why
+    // the close button needs no handler of its own — its click lands here.
+    // The video is the exception: it carries controls at this size, and they
+    // sit in a UA shadow root, so a click on play or the scrubber arrives here
+    // retargeted to the <video> itself and must not also close the overlay.
+    dialog.addEventListener("click", (e: MouseEvent) => {
+        if (e.target !== overlayVideo) {
+            dialog.close();
+        }
+    });
+
+    // Fires for the close button, Escape, and the backdrop click alike. The UA
+    // restores focus to the trigger on its own.
+    dialog.addEventListener("close", () => {
+        document.body.style.overflow = "";
+        overlayImage.removeAttribute("src");
+        // load() after dropping the source stops the download the paused
+        // element would otherwise keep buffering.
+        overlayVideo.pause();
+        overlayVideo.removeAttribute("src");
+        overlayVideo.load();
+        pausedSource?.play().catch(() => {
+            /* the inline clip was playing a moment ago; if it won't resume, leave it */
+        });
+        pausedSource = null;
+        caption.textContent = "";
+    });
+
+    // Nothing that hasn't decoded yet has a size to measure. Both events fire
+    // once per element, and anything already loaded is caught by the initial
+    // refresh() below.
+    for (const el of media) {
+        el.addEventListener(isVideo(el) ? "loadedmetadata" : "load", refresh, { once: true });
+    }
+
+    let resizeTimer: number | undefined;
+    window.addEventListener("resize", () => {
+        window.clearTimeout(resizeTimer);
+        resizeTimer = window.setTimeout(refresh, 200);
+    });
+
+    refresh();
+});

--- a/theme/src/ts/main.ts
+++ b/theme/src/ts/main.ts
@@ -12,6 +12,7 @@ import "./tracking";
 import "./docs-feedback";
 import "./blog-list";
 import "./blog-post";
+import "./blog-lightbox";
 import "./what-is-list";
 import "./case-studies-list";
 import "./details-dropdown";


### PR DESCRIPTION
### Proposed changes

Images and `{{< video >}}` clips in a post body now open at full size in an overlay.

* Nothing to do on the authoring side - `theme/src/ts/blog-lightbox.ts` measures each one against the viewport and only makes it clickable when the overlay could draw it at least 20% wider than the post does, so icons, badges and anything already at full size stay plain. Thresholds and the reasoning for each are at the top of that file.
* `data-no-lightbox` on the element or any ancestor opts out, and anything inside a link is skipped, which is what keeps the `{{< blog/card >}}` embeds out of it.
* Post-body videos that already have `controls` are skipped entirely, since a wrapping button would eat clicks meant for the control bar and those controls already have a fullscreen button (only 2 of the 65 videos in the blog have them).
* The overlay's copy of a video does get controls, as the inline ones are autoplaying loops with nothing to operate - that's also why it's exempt from the click-anywhere-to-close.
* `OVERLAY_MARGIN_X`/`OVERLAY_MARGIN_Y` mirror the padding and caption budget in `lightbox.html`, so those need to move together or the script will offer a bigger view than the overlay can give.

**Known gaps**

* Does nothing on phones, since the overlay ends up no wider than the column already is. Making it useful there would mean pinch/pan, which this doesn't attempt.
* Tall screenshots never qualify - fitting one to the viewport height leaves it narrower than the column. Correct for how the overlay works now, but those are often the ones you'd most want bigger, so letting the overlay scroll instead of fitting is an option.
* Closing a video doesn't sync the scrub position back to the inline clip, though it does carry it forward when you open one. Couple of lines if we want it.

### Related issues (optional)

Relates to pulumi/marketing#1823
