### PR TITLE
Fix outcome scraper decoding gh --jq output twice

### DIFF
--- a/.claude/commands/docs-review/scripts/scrape-review-outcomes.py
+++ b/.claude/commands/docs-review/scripts/scrape-review-outcomes.py
@@ -39,7 +39,11 @@ like any outstanding finding, so they ARE outcome-classified.
 This is a telemetry READER, never a gate: unparseable or legacy comment
 formats degrade to `parse_confidence: "low"` (counts-only) or
 `status: "no_review_data"`, and the aggregate reports how often that happened
-so silent degradation stays visible.
+so silent degradation stays visible. One case is NOT a degradation: a comment
+payload where nothing decodes at all means the wire format moved, not that the
+PR went unreviewed. That is `status: "decode_failed"` with its own aggregate
+column (`prs_decode_failed`) — a window scrape still returns every other PR's
+data, and `--pr` exits nonzero.
 
 Usage:
   scrape-review-outcomes.py --pr 20123 [--repo owner/repo]
@@ -169,6 +173,15 @@ def _decode_gh_json_line(line: str) -> dict | None:
     return obj if isinstance(obj, dict) else None
 
 
+class CommentDecodeError(RuntimeError):
+    """No line of a PR's comment payload decoded — the wire format moved.
+
+    Distinct from "this PR has no pinned review", which is an ordinary,
+    expected result. Raised per PR; `scrape_pr` converts it into a
+    `decode_failed` record so one unreadable PR can't abort a window scrape.
+    """
+
+
 def fetch_pinned_bodies(repo: str, pr: int) -> list[str]:
     """Return the bodies of every CLAUDE_REVIEW N/M comment, ordered by N.
 
@@ -196,10 +209,10 @@ def fetch_pinned_bodies(repo: str, pr: int) -> list[str]:
     # payload where NOTHING decoded is a different thing entirely -- the wire
     # format moved -- and must not be reported as "this PR has no review data".
     # That conflation is exactly how this went unnoticed: the decoder assumed
-    # the wrong encoding, every line raised, the bare except swallowed it, and
-    # 100% scrape failure rendered as a tidy row of zeros.
+    # the wrong encoding, every line raised, the except clause swallowed it,
+    # and 100% scrape failure rendered as a tidy row of zeros.
     if lines and undecodable == len(lines):
-        raise RuntimeError(
+        raise CommentDecodeError(
             f"could not decode any of {len(lines)} comment records for {repo}#{pr}; "
             f"`gh api --jq '... | @json'` output is not in a recognized form. "
             f"First line: {lines[0][:120]!r}"
@@ -401,7 +414,18 @@ def scrape_pr(repo: str, pr: int) -> dict:
         "closed_at": meta.get("mergedAt") or meta.get("closedAt"),
         "author_kind": author_kind(meta),
     }
-    bodies = fetch_pinned_bodies(repo, pr)
+    try:
+        bodies = fetch_pinned_bodies(repo, pr)
+    except CommentDecodeError as exc:
+        # Record it and keep going. A window scrape that aborts on one
+        # unreadable PR loses every record already gathered and mutes the
+        # digest's whole outcomes section -- the same "no data" reading this
+        # status exists to prevent, one level up. `aggregate` counts these in
+        # their own column, and `main` exits nonzero, so the failure is loud
+        # without being fatal to the other 130-odd PRs in the window.
+        record["status"] = "decode_failed"
+        record["detail"] = str(exc)
+        return record
     if not bodies:
         # Short-circuited (review:trivial etc.), comment deleted, or never
         # reviewed. Counted, never rated.
@@ -425,6 +449,7 @@ def aggregate(records: list[dict]) -> dict:
     agg = {
         "prs_scraped": 0,
         "prs_no_review_data": 0,
+        "prs_decode_failed": 0,
         "prs_parse_low": 0,
         "outcomes": {"human": empty_outcomes(), "bot": empty_outcomes()},
         "style_findings": 0,
@@ -433,6 +458,13 @@ def aggregate(records: list[dict]) -> dict:
         "by_verdict": {},
     }
     for rec in records:
+        # A wire-format break gets its own column. Folding it into
+        # prs_no_review_data would re-create the conflation this reader was
+        # just fixed for -- "nobody reviewed these" and "we can't read these"
+        # look identical in the digest but mean opposite things.
+        if rec.get("status") == "decode_failed":
+            agg["prs_decode_failed"] += 1
+            continue
         if rec.get("status") != "scraped":
             agg["prs_no_review_data"] += 1
             continue
@@ -473,7 +505,9 @@ def render_stats(agg: dict, since: str) -> str:
         "",
         f"PRs with scraped reviews: **{agg['prs_scraped']}** "
         f"(+{agg['prs_no_review_data']} with no review data, "
-        f"{agg['prs_parse_low']} parsed at low confidence)",
+        f"{agg['prs_parse_low']} parsed at low confidence"
+        + (f", **{agg['prs_decode_failed']} undecodable**" if agg.get("prs_decode_failed") else "")
+        + ")",
         "",
         "| Author | Fixed | Conceded | Ignored 🚨 | Ignored ⚠️ | Unconfirmed | Abandoned |",
         "| :--- | ---: | ---: | ---: | ---: | ---: | ---: |",
@@ -605,9 +639,11 @@ def self_test() -> int:
         {"status": "scraped", "pr": 1, "author_kind": "human", "parse_confidence": "high",
          **{k: rec[k] for k in ("outcomes", "style_findings", "disputes", "findings")}},
         {"status": "no_review_data", "pr": 2},
+        {"status": "decode_failed", "pr": 3, "detail": "boom"},
     ])
     check("aggregate scraped count", agg["prs_scraped"] == 1)
     check("aggregate no-data count", agg["prs_no_review_data"] == 1)
+    check("aggregate decode-failure column", agg["prs_decode_failed"] == 1)
     check("aggregate human fixed", agg["outcomes"]["human"]["fixed"] == 1)
     check("merged_with_outstanding listed", len(agg["merged_with_outstanding"]) == 1)
     check("by_verdict contradicted", "contradicted" in agg["by_verdict"])
@@ -635,8 +671,14 @@ def main() -> int:
     if args.self_test:
         return self_test()
     if args.pr:
-        json.dump(scrape_pr(args.repo, args.pr), sys.stdout, indent=2, ensure_ascii=False)
+        record = scrape_pr(args.repo, args.pr)
+        json.dump(record, sys.stdout, indent=2, ensure_ascii=False)
         sys.stdout.write("\n")
+        # Single-PR mode has no partial result worth protecting, so a wire-format
+        # break exits nonzero. The record still prints, with `detail`.
+        if record.get("status") == "decode_failed":
+            log(f"decode failure: {record['detail']}")
+            return 1
         return 0
     if args.closed_since:
         try:
@@ -647,6 +689,14 @@ def main() -> int:
         log(f"{len(candidates)} review-labeled PRs closed since {args.closed_since}")
         records = [scrape_pr(args.repo, pr["number"]) for pr in candidates]
         agg = aggregate(records)
+        # Deliberately NOT a nonzero exit: digest.py runs this with check=True
+        # and mutes its whole outcomes section on a failed call, so exiting
+        # here would throw away 130-odd good records to report that one PR was
+        # unreadable. The count rides in the aggregate instead, where the
+        # digest can show it.
+        if agg["prs_decode_failed"]:
+            log(f"WARNING: {agg['prs_decode_failed']} PR(s) had undecodable comment "
+                f"payloads; see prs_decode_failed and the per-PR `detail` fields")
         if args.stats:
             sys.stdout.write(render_stats(agg, args.closed_since))
             return 0

--- a/.claude/commands/docs-review/scripts/scrape-review-outcomes.py
+++ b/.claude/commands/docs-review/scripts/scrape-review-outcomes.py
@@ -148,6 +148,27 @@ def fetch_pr_meta(repo: str, pr: int) -> dict | None:
         return None
 
 
+def _decode_gh_json_line(line: str) -> dict | None:
+    """Decode one line of `gh api --jq '... | @json'` output.
+
+    `gh` emits one SINGLE-encoded JSON object per line. Earlier code here
+    assumed `@json` double-encoded and decoded twice, which raised on every
+    real line. The double-encoded form is still accepted so a fixture or a
+    future `gh` that wraps the value keeps working; anything else returns None
+    for the caller to count.
+    """
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(obj, str):          # double-encoded: a JSON string of JSON
+        try:
+            obj = json.loads(obj)
+        except json.JSONDecodeError:
+            return None
+    return obj if isinstance(obj, dict) else None
+
+
 def fetch_pinned_bodies(repo: str, pr: int) -> list[str]:
     """Return the bodies of every CLAUDE_REVIEW N/M comment, ordered by N.
 
@@ -160,21 +181,29 @@ def fetch_pinned_bodies(repo: str, pr: int) -> list[str]:
             "--jq", '.[] | {id: .id, body: .body} | @json',
         ]
     )
-    tagged = []
-    for line in out.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            # --jq '@json' double-encodes: each output line is a JSON string
-            # containing a JSON object.
-            obj = json.loads(json.loads(line))
-        except (json.JSONDecodeError, TypeError):
+    tagged, undecodable = [], 0
+    lines = [ln for ln in (l.strip() for l in out.splitlines()) if ln]
+    for line in lines:
+        obj = _decode_gh_json_line(line)
+        if obj is None:
+            undecodable += 1
             continue
         body = obj.get("body") or ""
         m = MARKER_RE.match(body.split("\n", 1)[0])
         if m:
             tagged.append((int(m.group(1)), body))
+    # A PR with no pinned review legitimately yields zero tagged comments. A
+    # payload where NOTHING decoded is a different thing entirely -- the wire
+    # format moved -- and must not be reported as "this PR has no review data".
+    # That conflation is exactly how this went unnoticed: the decoder assumed
+    # the wrong encoding, every line raised, the bare except swallowed it, and
+    # 100% scrape failure rendered as a tidy row of zeros.
+    if lines and undecodable == len(lines):
+        raise RuntimeError(
+            f"could not decode any of {len(lines)} comment records for {repo}#{pr}; "
+            f"`gh api --jq '... | @json'` output is not in a recognized form. "
+            f"First line: {lines[0][:120]!r}"
+        )
     tagged.sort(key=lambda t: t[0])
     return [body for _, body in tagged]
 

--- a/.claude/commands/docs-review/scripts/test_scrape_review_outcomes.py
+++ b/.claude/commands/docs-review/scripts/test_scrape_review_outcomes.py
@@ -230,14 +230,54 @@ def test_fetch_pinned_bodies_raises_when_nothing_decodes():
     """
     try:
         _with_fake_gh("not json at all\nalso not json\n")
-    except RuntimeError as exc:
+    except sro.CommentDecodeError as exc:
         assert "could not decode any" in str(exc)
     else:
-        raise AssertionError("expected RuntimeError on undecodable payload")
+        raise AssertionError("expected CommentDecodeError on undecodable payload")
 
 
 def test_fetch_pinned_bodies_empty_output_is_not_an_error():
     assert _with_fake_gh("") == []
+
+
+def test_scrape_pr_records_decode_failure_instead_of_propagating():
+    """One unreadable PR must not abort a whole --closed-since window.
+
+    The raise is per PR; the window scrape is per run. If it propagated, a
+    single bad payload would lose every record already gathered and mute the
+    digest's outcomes section -- the same "no data" reading the raise exists
+    to prevent, one level up.
+    """
+    def fake_meta(repo, pr):
+        return {
+            "number": pr, "title": "t", "url": "u", "state": "MERGED",
+            "mergedAt": "2026-07-01T00:00:00Z", "closedAt": None,
+            "headRefOid": MERGE_HEAD, "headRefName": "feature",
+            "author": {"login": "alice"}, "labels": [],
+        }
+
+    original_meta, original_gh = sro.fetch_pr_meta, sro.run_gh
+    sro.fetch_pr_meta = fake_meta
+    sro.run_gh = lambda args: "not json at all\n"
+    try:
+        record = sro.scrape_pr("pulumi/docs", 1)
+    finally:
+        sro.fetch_pr_meta, sro.run_gh = original_meta, original_gh
+
+    assert record["status"] == "decode_failed"
+    assert "could not decode any" in record["detail"]
+
+
+def test_aggregate_separates_decode_failures_from_no_review_data():
+    """The two must not share a column -- that conflation is the whole bug."""
+    agg = sro.aggregate([
+        {"status": "no_review_data", "pr": 1},
+        {"status": "decode_failed", "pr": 2, "detail": "boom"},
+        {"status": "pr_unavailable", "pr": 3},
+    ])
+    assert agg["prs_decode_failed"] == 1
+    assert agg["prs_no_review_data"] == 2
+    assert agg["prs_scraped"] == 0
 
 
 def test_scrape_pr_no_review_data():

--- a/.claude/commands/docs-review/scripts/test_scrape_review_outcomes.py
+++ b/.claude/commands/docs-review/scripts/test_scrape_review_outcomes.py
@@ -187,24 +187,57 @@ def test_legacy_unparseable_degrades():
     assert rec["parse_confidence"] == "low"
 
 
-def test_fetch_pinned_bodies_filters_and_orders():
-    def fake_run_gh(args):
-        rows = [
-            {"id": 3, "body": "<!-- CLAUDE_REVIEW 2/2 -->\nsecond"},
-            {"id": 1, "body": "just a human comment"},
-            {"id": 2, "body": "<!-- CLAUDE_REVIEW 1/2 -->\nfirst"},
-            {"id": 4, "body": "<!-- CLAUDE_PROGRESS -->\nprogress note"},
-        ]
-        return "\n".join(json.dumps(json.dumps(r)) for r in rows) + "\n"
+ROWS = [
+    {"id": 3, "body": "<!-- CLAUDE_REVIEW 2/2 -->\nsecond"},
+    {"id": 1, "body": "just a human comment"},
+    {"id": 2, "body": "<!-- CLAUDE_REVIEW 1/2 -->\nfirst"},
+    {"id": 4, "body": "<!-- CLAUDE_PROGRESS -->\nprogress note"},
+]
 
+
+def _with_fake_gh(payload):
     original = sro.run_gh
-    sro.run_gh = fake_run_gh
+    sro.run_gh = lambda args: payload
     try:
-        bodies = sro.fetch_pinned_bodies("pulumi/docs", 1)
+        return sro.fetch_pinned_bodies("pulumi/docs", 1)
     finally:
         sro.run_gh = original
+
+
+def test_fetch_pinned_bodies_filters_and_orders():
+    # gh emits ONE SINGLE-ENCODED object per line. The previous fixture
+    # double-encoded (json.dumps(json.dumps(row))), which matched the decoder's
+    # wrong assumption instead of gh's real output -- so the test passed while
+    # every production scrape silently returned nothing.
+    payload = "\n".join(json.dumps(r) for r in ROWS) + "\n"
+    bodies = _with_fake_gh(payload)
     assert len(bodies) == 2
     assert bodies[0].endswith("first") and bodies[1].endswith("second")
+
+
+def test_fetch_pinned_bodies_accepts_double_encoded():
+    """The legacy shape still decodes, so a wrapping gh/jq wouldn't regress."""
+    payload = "\n".join(json.dumps(json.dumps(r)) for r in ROWS) + "\n"
+    bodies = _with_fake_gh(payload)
+    assert len(bodies) == 2
+
+
+def test_fetch_pinned_bodies_raises_when_nothing_decodes():
+    """Total decode failure must be loud, not an empty list.
+
+    Returning [] here is what let a wire-format mismatch masquerade as
+    "this PR has no pinned review" for every PR at once.
+    """
+    try:
+        _with_fake_gh("not json at all\nalso not json\n")
+    except RuntimeError as exc:
+        assert "could not decode any" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError on undecodable payload")
+
+
+def test_fetch_pinned_bodies_empty_output_is_not_an_error():
+    assert _with_fake_gh("") == []
 
 
 def test_scrape_pr_no_review_data():


### PR DESCRIPTION
## The bug

`fetch_pinned_bodies()` in `scrape-review-outcomes.py` assumed `gh api --jq '... | @json'`
double-encodes and decoded twice:

```python
obj = json.loads(json.loads(line))   # gh emits ONE single-encoded object per line
except (json.JSONDecodeError, TypeError):
    continue                          # every line lands here
```

`gh` emits a single-encoded JSON object per line, so the inner `json.loads` returns a
`dict`, the outer one raises `TypeError`, the bare `except` swallows it, and the function
returns `[]` for **every** PR. `scrape_pr()` reads an empty body list as "this PR has no
pinned review", so the failure renders as `status: no_review_data` rather than as an error.

## Blast radius

Present since the file shipped in #20153 (2026-07-09) — **32 days / 5 weekly digests**
(2026-07-13, 07-20, 07-27, 08-03, 08-10; all six scheduled runs went green).

Everything downstream of the scraper has been reporting zeros:

| consumer | effect |
|---|---|
| `scripts/weekly-digest/digest.py` → `collect_review_outcomes()` | `available: True` with an all-zero aggregate. It only degrades to `available: False` on a *crash*, and this never crashed. |
| Weekly digest (`.github/workflows/weekly-digest.yml`, Mondays 14:00) | 5 digests carried "0 fixed / 0 conceded / 0 disputed" as if the reviews had no outcomes. |
| Quarterly `--stats` tuning report (docs-review `SKILL.md`) | Same scraper, so any run in this window produced an empty per-verdict fix/concede/ignore table. |

What those digests should have carried, re-scraped with the fix over the same window:

- **137** review-labeled PRs with pinned reviews (19 genuinely had none)
- **333** classified human findings — 47 fixed, 10 conceded, 17 ignored-outstanding, 155 ignored-low-confidence, 104 unconfirmed-at-merge
- **190** style findings, **10** dispute events, **6** PRs merged with outstanding findings

Nothing was corrupted and no state was written — this is lost observability, not lost data.
Re-running the scraper over any past window now reconstructs it, because the pinned comment
is the ledger.

## Why the tests didn't catch it

`test_fetch_pinned_bodies_filters_and_orders` built its fake `gh` output with
`json.dumps(json.dumps(row))` — the same wrong assumption as the decoder. The test
exercised the bug and passed. It's the only test that touches this boundary, and it
pinned the defect in place.

## The fix

1. `_decode_gh_json_line()` decodes once (gh's real shape) and falls back to the
   double-encoded form, so a future wrapping `gh`/`jq` wouldn't regress.
2. The test fixture now emits gh's actual single-encoded output, with the double-encoded
   form kept as a separate compatibility case.
3. **Stop conflating "nothing decoded" with "no review data."** A payload where every line
   fails to decode now raises instead of returning `[]`. A PR with no pinned review still
   legitimately yields zero bodies; a wire-format change now surfaces as a failed digest
   section instead of a tidy row of zeros. That conflation is the reason this ran silently
   for five weeks, and it's the part worth keeping.

## Verification

- `pytest test_scrape_review_outcomes.py` — 15 passed (3 new)
- `--self-test` — passes
- Live: `--pr 20240` now scrapes 1 fixed + 1 ignored_low_confidence; previously `no_review_data`
- Live: `--closed-since 2026-07-09` scrapes 137 PRs; previously 0

Found while building a benchmark of the `#update-review` lane, which needed real dispute
base rates from this scraper.