### PR TITLE
Hold an evidence-spine floor on review refreshes, and move the lane to opus-5 medium

### DIFF
--- a/.claude/commands/docs-review/scripts/pinned-comment.sh
+++ b/.claude/commands/docs-review/scripts/pinned-comment.sh
@@ -367,7 +367,18 @@ cmd_upsert() {
     # Never fatal: splice-spine.py exits 0 on any internal failure and leaves
     # the body as rendered. A repair pass must not be the reason a review fails
     # to publish. Operates on a COPY so a caller's file is never mutated.
-    if [[ "${SPLICE_SPINE:-1}" != "0" ]]; then
+    # Scoped by CAPABILITY, not by lane name. The floor is only sound where the
+    # caller could not have re-derived the trail: claude-update.yml does a fresh
+    # shallow checkout and runs only Vale, so a shrunken trail there is always a
+    # loss. The composer lane (claude-code-review.yml, which reaches this
+    # function through cmd_upsert_validated) recomposes from
+    # `.verified-claims.json` against the CURRENT diff — if the author force-
+    # pushed a smaller change and re-requested review, a shorter trail is
+    # CORRECT there, and restoring the old one would inject records for lines
+    # that no longer exist. So: claims artifacts present => the caller owns the
+    # trail, stand down. Absent => the prior comment is the only copy, hold.
+    if [[ "${SPLICE_SPINE:-1}" != "0" ]] \
+       && [[ ! -f .verified-claims.json && ! -f .candidate-claims.json ]]; then
         local script_dir splicer
         script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
         splicer="$script_dir/splice-spine.py"

--- a/.claude/commands/docs-review/scripts/pinned-comment.sh
+++ b/.claude/commands/docs-review/scripts/pinned-comment.sh
@@ -350,6 +350,43 @@ cmd_upsert() {
         fi
     fi
 
+    # Evidence-spine floor. This is the only point in the system that holds the
+    # old body and the new one at the same moment: everything above fetches
+    # comment IDs, not bodies, so nothing else can notice that a re-render
+    # dropped the 🔍 Verification trail. Measured on 2026-08-10, the update
+    # lane dropped it in 1 of 6 chained refreshes and published green.
+    #
+    # UNCONDITIONAL, deliberately. The model composes its own `pinned-comment.sh
+    # upsert` command and the Bash allow-list is a prefix match, so a
+    # `--spine-floor` flag could simply be omitted — the same reason the ✏️
+    # marks are workflow-written rather than model-written. The escape hatch is
+    # the env var, which does NOT match the allow-list pattern (that requires
+    # the command to begin `bash .claude/…`), so it is reachable by a human or
+    # a workflow step and not by the model.
+    #
+    # Never fatal: splice-spine.py exits 0 on any internal failure and leaves
+    # the body as rendered. A repair pass must not be the reason a review fails
+    # to publish. Operates on a COPY so a caller's file is never mutated.
+    if [[ "${SPLICE_SPINE:-1}" != "0" ]]; then
+        local script_dir splicer
+        script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+        splicer="$script_dir/splice-spine.py"
+        if [[ -f "$splicer" ]]; then
+            local prior_file spliced_file
+            prior_file=$(mktemp)
+            spliced_file=$(mktemp)
+            fetch_pinned_bodies "$repo" "$pr" >"$prior_file" 2>/dev/null || true
+            cp "$body_file" "$spliced_file"
+            python3 "$splicer" \
+                --prior "$prior_file" \
+                --body "$spliced_file" \
+                --in-place \
+                --report "${SPLICE_SPINE_REPORT:-/tmp/splice-spine.json}" || true
+            body_file="$spliced_file"
+            rm -f "$prior_file"
+        fi
+    fi
+
     # Reserve the footer's bytes out of the per-page budget up front: it is
     # appended to every page after the split, and a page sized to exactly
     # MAX_BYTES plus a footer would sail past GitHub's 65536 hard cap.

--- a/.claude/commands/docs-review/scripts/splice-spine.py
+++ b/.claude/commands/docs-review/scripts/splice-spine.py
@@ -321,9 +321,18 @@ def main() -> int:
             # First review on this PR, or the pinned comment was deleted. Both
             # are ordinary; there is simply no floor to hold.
             report["status"] = "no-prior"
+            log("no prior pinned review; no floor to hold")
         else:
             drops = assess(prior, new)
             report["considered"] = drops
+            # Always say what happened, including the quiet case. A check that
+            # is silent when it passes cannot be distinguished in a CI log from
+            # a check that never ran -- and the whole point of this one is that
+            # nothing else notices the failure it guards against.
+            if not drops:
+                log(f"spine floor held ({len(_vp.extract_trail_records(prior))} trail records, "
+                    f"balance={'yes' if _section_with_heading(prior, BALANCE_HEADING) else 'n/a'}, "
+                    f"log bullets={_log_bullet_count(_investigation_log(prior))})")
             if drops:
                 new, applied = restore(prior, new, drops)
                 report["restored"] = applied

--- a/.claude/commands/docs-review/scripts/splice-spine.py
+++ b/.claude/commands/docs-review/scripts/splice-spine.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Restore invariant "evidence spine" sections a re-render dropped.
+
+WHY THIS EXISTS
+---------------
+`pinned-comment.sh upsert` is a transport: it splits the body it is handed,
+stamps markers, and PATCHes the existing comments in place. It never reads the
+OLD comments' content -- it fetches their ids, not their bodies -- so a refresh
+that re-renders the review without its 🔍 Verification trail publishes cleanly
+and the job goes green. On `claude-update.yml` that loss is permanent: the lane
+does a fresh shallow checkout and runs only Vale, so it has no
+`.candidate-claims.json` / `.verified-claims.json` to rebuild from, and the
+pinned comment it just overwrote was the only copy. Later refreshes then merge
+from the damaged body, so the loss compounds.
+
+Measured on 2026-08-10 (`2026-08-10-update-lane-model-config` in
+pulumi/docs-review-benchmarks): the shipping configuration dropped the spine in
+1 of 6 chained refreshes, and `--effort low` in 3 of 6 -- one of those collapsing
+a 40-line trail to 11 lines and then holding exactly 11 through the next
+refresh, because the "floor" it was checked against had moved down with it.
+
+WHAT IS INVARIANT, AND WHY VERBATIM RESTORE IS CORRECT
+------------------------------------------------------
+Three sections describe the review's own INVESTIGATION, not the findings' state:
+
+  * 🔍 Verification trail   -- which claims were extracted and how they verified
+  * 📊 Editorial balance    -- the balance pass's own tally (content/blog only)
+  * Investigation log       -- which passes ran, as a <details> block
+
+Moving a finding to ✅ Resolved does not retire its trail record, so a refresh
+has no legitimate reason to shrink any of them. The update lane cannot extract
+new claims at all (no claims artifacts in its workspace), so on that lane they
+cannot legitimately GROW either -- but growth is allowed here anyway, because
+the composer lane can and does add trail lines. The rule is the one already in
+the render contract: **may add, never drop.**
+
+SAFETY POSTURE
+--------------
+This runs immediately before publication, on a body nobody has seen yet, so a
+wrong repair would corrupt a good review. Every ambiguous case therefore
+no-ops rather than guessing:
+
+  * prior body absent, empty, or unparseable      -> no-op
+  * section missing from prior                    -> no-op (nothing to restore)
+  * section in the new body is same size or larger-> no-op
+  * section missing from the new body entirely    -> restore only if the H3
+                                                     order in MANDATORY_H3_SECTIONS
+                                                     fixes where it goes
+  * anything raises                               -> no-op, exit 0, warn
+
+Exit status is ALWAYS 0 unless the arguments themselves are unusable. This is a
+repair pass, not a gate: it must never be the reason a review fails to publish.
+
+Usage:
+  splice-spine.py --prior <file> --body <file> [--in-place] [--report <json>]
+      --prior   the published pinned body, as `pinned-comment.sh fetch` emits it
+                (parts joined by the delimiter, each with marker and footer)
+      --body    the newly rendered body about to be published
+      --in-place  rewrite --body with restored sections (default: print to stdout)
+      --report  write a JSON summary of what was restored
+
+Parsing reuses validate-pinned.py's helpers (find_section, section_text,
+extract_trail_records, INVESTIGATION_LOG_BULLETS) by the same import-by-path
+pattern scrape-review-outcomes.py uses, so the comment-format contract keeps
+exactly one parser.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+_spec = importlib.util.spec_from_file_location("validate_pinned", HERE / "validate-pinned.py")
+_vp = importlib.util.module_from_spec(_spec)
+# Register before exec: validate-pinned.py defines dataclasses, and the
+# dataclass machinery resolves the defining module through sys.modules.
+sys.modules["validate_pinned"] = _vp
+_spec.loader.exec_module(_vp)
+
+# Mirrors pinned-comment.sh: FOOTER_SENTINEL (:41), the fetch delimiter (:161),
+# and the continuation block split_body re-opens across a page boundary (:212).
+FOOTER_SENTINEL = "<!-- CLAUDE_REVIEW_FOOTER -->"
+PART_DELIMITER = "----- PINNED-COMMENT-DELIMITER -----"
+MARKER_RE = re.compile(r"^<!-- CLAUDE_REVIEW \d+/\d+ -->\s*$")
+CONTINUATION_SUMMARY = "<summary><em>continued from previous comment</em></summary>"
+
+TRAIL_HEADING = "🔍 Verification trail"
+BALANCE_HEADING = "📊 Editorial balance"
+INVESTIGATION_SUMMARY = "<summary>Investigation log</summary>"
+
+
+def log(msg: str) -> None:
+    print(f"splice-spine: {msg}", file=sys.stderr)
+
+
+def extract_trail_records_of(body: str) -> list[dict]:
+    """Re-export, so callers and tests never reach past this module's parser."""
+    return _vp.extract_trail_records(body)
+
+
+# ---- reassembling the published body -----------------------------------------
+
+
+def _strip_part(part: str) -> list[str]:
+    """One published comment -> its logical lines (marker, footer, artifacts gone)."""
+    lines = []
+    for line in part.splitlines():
+        if MARKER_RE.match(line):
+            continue
+        if line.startswith(FOOTER_SENTINEL):
+            break  # footer is by contract the last block of every part
+        lines.append(line)
+    return lines
+
+
+def reassemble(published: str) -> str:
+    """Undo `pinned-comment.sh` publication: parts -> the single logical body.
+
+    Removes per-part markers and footers, then the synthetic <details> wrapper
+    split_body inserts when a block spills across a page boundary: a bare
+    `</details>` closing the earlier page and a three-line continuation block
+    opening the next. Leaving those in is the "re-run the splitter over its own
+    continuation artifacts" failure the update lane's comment warns about
+    (claude-update.yml:506) -- and here it would also make a section look like
+    it changed when it did not.
+    """
+    parts = [_strip_part(p) for p in published.split(PART_DELIMITER)]
+    parts = [p for p in parts if any(ln.strip() for ln in p)]
+    if not parts:
+        return ""
+
+    merged = list(parts[0])
+    for nxt in parts[1:]:
+        nxt = list(nxt)
+        # Drop the continuation opener: <details> / <summary><em>continued…</em></summary> / blank
+        while nxt and not nxt[0].strip():
+            nxt.pop(0)
+        if len(nxt) >= 2 and nxt[0].strip() == "<details>" and CONTINUATION_SUMMARY in nxt[1]:
+            nxt = nxt[2:]
+            while nxt and not nxt[0].strip():
+                nxt.pop(0)
+            # ...and the synthetic close that pairs with it on the previous page.
+            while merged and not merged[-1].strip():
+                merged.pop()
+            if merged and merged[-1].strip() == "</details>":
+                merged.pop()
+        merged.extend(nxt)
+    return "\n".join(merged)
+
+
+# ---- the three invariants ------------------------------------------------------
+
+
+def _details_span(body: str, summary: str) -> tuple[int, int] | None:
+    """(start, end) line span of a <details> block, inclusive of both tags."""
+    lines = body.splitlines()
+    for i, line in enumerate(lines):
+        if summary in line:
+            start = i - 1 if i > 0 and lines[i - 1].strip() == "<details>" else i
+            for j in range(i + 1, len(lines)):
+                if lines[j].strip() == "</details>":
+                    return (start, j + 1)
+            return None
+    return None
+
+
+def _investigation_log(body: str) -> str | None:
+    span = _details_span(body, INVESTIGATION_SUMMARY)
+    if span is None:
+        return None
+    return "\n".join(body.splitlines()[span[0]:span[1]])
+
+
+def _log_bullet_count(block: str | None) -> int:
+    if not block:
+        return 0
+    return sum(1 for name in _vp.INVESTIGATION_LOG_BULLETS if f"**{name}" in block)
+
+
+def _section_with_heading(body: str, heading: str) -> str | None:
+    span = _vp.find_section(body, heading)
+    if span is None:
+        return None
+    return "\n".join(body.splitlines()[span[0]:span[1]]).rstrip()
+
+
+def assess(prior: str, new: str) -> list[dict]:
+    """What shrank. One entry per section that must be restored."""
+    drops = []
+
+    p_trail, n_trail = len(_vp.extract_trail_records(prior)), len(_vp.extract_trail_records(new))
+    if p_trail > n_trail and _section_with_heading(prior, TRAIL_HEADING):
+        drops.append({"section": TRAIL_HEADING, "kind": "h3",
+                      "prior": p_trail, "new": n_trail, "unit": "trail records"})
+
+    p_log, n_log = _investigation_log(prior), _investigation_log(new)
+    p_bul, n_bul = _log_bullet_count(p_log), _log_bullet_count(n_log)
+    if p_log and p_bul > n_bul:
+        drops.append({"section": "Investigation log", "kind": "details",
+                      "prior": p_bul, "new": n_bul, "unit": "mandatory bullets"})
+
+    p_bal, n_bal = _section_with_heading(prior, BALANCE_HEADING), _section_with_heading(new, BALANCE_HEADING)
+    if p_bal:
+        # Byte length, not a parse: the balance block's shape varies by pass and
+        # there is no record-level parser for it. Half is a deliberately coarse
+        # threshold -- reflowed prose must not trip it, a gutted section must.
+        p_len, n_len = len(p_bal), len(n_bal or "")
+        if n_len < p_len // 2:
+            drops.append({"section": BALANCE_HEADING, "kind": "h3",
+                          "prior": p_len, "new": n_len, "unit": "bytes"})
+
+    return drops
+
+
+# ---- repair --------------------------------------------------------------------
+
+
+def _insert_index_for_h3(body: str, heading: str) -> int | None:
+    """Where a missing mandatory H3 belongs, from MANDATORY_H3_SECTIONS order.
+
+    Returns a line index, or None when the order does not determine it -- in
+    which case the caller must leave the body alone rather than guess.
+    """
+    order = list(_vp.MANDATORY_H3_SECTIONS)
+    # 📊 Editorial balance is conditional and absent from the mandatory list; it
+    # renders directly after the trail, so anchor it there.
+    if heading == BALANCE_HEADING:
+        span = _vp.find_section(body, TRAIL_HEADING)
+        return span[1] if span else None
+    if heading not in order:
+        return None
+    for later in order[order.index(heading) + 1:]:
+        span = _vp.find_section(body, later)
+        if span:
+            return span[0]
+    for earlier in reversed(order[:order.index(heading)]):
+        span = _vp.find_section(body, earlier)
+        if span:
+            return span[1]
+    return None
+
+
+def restore(prior: str, new: str, drops: list[dict]) -> tuple[str, list[dict]]:
+    applied = []
+    for drop in drops:
+        heading = drop["section"]
+        if drop["kind"] == "details":
+            block = _investigation_log(prior)
+            span = _details_span(new, INVESTIGATION_SUMMARY)
+            if block is None:
+                continue
+            lines = new.splitlines()
+            if span is not None:
+                lines[span[0]:span[1]] = block.splitlines()
+            else:
+                # No log at all in the new body. It renders under the Review
+                # confidence table, above the count table -- anchor on the first
+                # mandatory H3 and sit just above it.
+                anchor = None
+                for h in _vp.MANDATORY_H3_SECTIONS:
+                    s = _vp.find_section(new, h)
+                    if s:
+                        anchor = s[0]
+                        break
+                if anchor is None:
+                    continue
+                lines[anchor:anchor] = block.splitlines() + [""]
+            new = "\n".join(lines)
+        else:
+            block = _section_with_heading(prior, heading)
+            if block is None:
+                continue
+            span = _vp.find_section(new, heading)
+            lines = new.splitlines()
+            if span is not None:
+                lines[span[0]:span[1]] = block.splitlines() + [""]
+            else:
+                idx = _insert_index_for_h3(new, heading)
+                if idx is None:
+                    continue
+                lines[idx:idx] = block.splitlines() + [""]
+            new = "\n".join(lines)
+        applied.append(drop)
+    return new, applied
+
+
+# ---- main ----------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--prior", required=True, help="published pinned body (may be missing/empty)")
+    ap.add_argument("--body", required=True, help="newly rendered body")
+    ap.add_argument("--in-place", action="store_true")
+    ap.add_argument("--report", help="write a JSON summary here")
+    args = ap.parse_args()
+
+    body_path = Path(args.body)
+    if not body_path.is_file():
+        log(f"body file not readable: {args.body}")
+        return 2
+    new = body_path.read_text()
+
+    report = {"restored": [], "considered": [], "status": "noop"}
+    try:
+        prior_path = Path(args.prior)
+        published = prior_path.read_text() if prior_path.is_file() else ""
+        prior = reassemble(published) if published.strip() else ""
+        if not prior:
+            # First review on this PR, or the pinned comment was deleted. Both
+            # are ordinary; there is simply no floor to hold.
+            report["status"] = "no-prior"
+        else:
+            drops = assess(prior, new)
+            report["considered"] = drops
+            if drops:
+                new, applied = restore(prior, new, drops)
+                report["restored"] = applied
+                report["status"] = "restored" if applied else "noop"
+                for d in applied:
+                    log(f"restored {d['section']}: {d['new']} -> {d['prior']} {d['unit']}")
+                for d in drops:
+                    if d not in applied:
+                        log(f"WARNING: {d['section']} shrank ({d['new']} < {d['prior']} "
+                            f"{d['unit']}) but could not be restored safely; left as rendered")
+    except Exception as exc:  # noqa: BLE001 -- a repair pass must never block a publish
+        log(f"WARNING: floor check failed ({type(exc).__name__}: {exc}); publishing as rendered")
+        report["status"] = "error"
+        report["error"] = f"{type(exc).__name__}: {exc}"
+
+    if args.report:
+        Path(args.report).write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n")
+    if args.in_place:
+        if report["restored"]:
+            body_path.write_text(new if new.endswith("\n") else new + "\n")
+    else:
+        sys.stdout.write(new if new.endswith("\n") else new + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/commands/docs-review/scripts/test_splice_spine.py
+++ b/.claude/commands/docs-review/scripts/test_splice_spine.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Unit tests for splice-spine.py.
+
+Self-contained — run with `python3 test_splice_spine.py` or under pytest.
+
+The cases that matter most are the NEGATIVE ones. This code runs immediately
+before publication on a body nobody has seen, so a spurious restore corrupts a
+good review; "leaves a healthy body byte-identical" is the property under test
+as much as "puts a dropped trail back".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import traceback
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+_spec = importlib.util.spec_from_file_location("splice_spine", HERE / "splice-spine.py")
+ss = importlib.util.module_from_spec(_spec)
+sys.modules["splice_spine"] = ss
+_spec.loader.exec_module(ss)  # type: ignore[union-attr]
+
+TRAIL = ss.TRAIL_HEADING
+BALANCE = ss.BALANCE_HEADING
+
+LOG_BLOCK = """<details>
+<summary>Investigation log</summary>
+
+- **Cross-sibling reads:** not run (not in a templated section)
+- **External claim verification:** 4 of 4 claims verified
+- **Cited-claim spot-checks:** not run (no cited claims)
+- **Frontmatter sweep:** not run (no frontmatter in diff)
+- **Temporal-trigger sweep:** not run (no trigger words)
+- **Code execution:** not run (no `static/programs/` change)
+- **Code-examples checks:** not run (no fenced code blocks)
+- **Editorial-balance pass:** ran
+
+</details>"""
+
+
+def body(trail_lines: int = 3, log: bool = True, balance: bool = True,
+         resolved: str = "_None._") -> str:
+    trail = "\n".join(
+        f'- L{10 + i} in `content/a.md` "claim {i}" → ✅ verified (evidence: e{i}; source: s{i})'
+        for i in range(trail_lines)
+    )
+    parts = ["<!-- CLAUDE_REVIEW 1/1 -->", "## Pre-merge Review — Last updated 2026-08-10T00:00:00Z", ""]
+    if log:
+        parts += [LOG_BLOCK, ""]
+    parts += [
+        "| 🚨 Outstanding | ⚠️ Low-confidence | 💡 Pre-existing | ✅ Resolved |",
+        "| :---: | :---: | :---: | :---: |",
+        "| **1** | **0** | **0** | **0** |",
+        "",
+        f"### {TRAIL}",
+        "",
+        "<details>",
+        "<summary><strong>3 claims extracted</strong></summary>",
+        "",
+        trail,
+        "",
+        "</details>",
+        "",
+    ]
+    if balance:
+        parts += [f"### {BALANCE}", "",
+                  "Vendor mentions: 4 Pulumi / 2 Terraform. Tone: balanced.",
+                  "No unsourced superlatives found in the diff.", ""]
+    parts += [
+        "### 🚨 Outstanding in this PR", "", "- **[L10]** `content/a.md` — Something is wrong.", "",
+        "### ⚠️ Low-confidence", "", "_None._", "",
+        "### ✅ Resolved since last review", "", resolved, "",
+        "### 📜 Review history", "", "- 2026-08-10T00:00:00Z — initial review (abc1234)", "",
+    ]
+    return "\n".join(parts) + "\n"
+
+
+def published(*bodies: str) -> str:
+    """Wrap logical bodies the way `pinned-comment.sh fetch` emits them."""
+    footer = f"\n{ss.FOOTER_SENTINEL}\n\n---\n\n- **Refresh this review** — comment `@claude`.\n"
+    return f"\n{ss.PART_DELIMITER}\n".join(b + footer for b in bodies)
+
+
+# ---- reassembly ---------------------------------------------------------------
+
+
+def test_reassemble_strips_marker_and_footer():
+    out = ss.reassemble(published(body()))
+    assert ss.FOOTER_SENTINEL not in out
+    assert "<!-- CLAUDE_REVIEW" not in out
+    assert len(ss.extract_trail_records_of(out)) == 3
+
+
+def test_reassemble_rejoins_a_split_details_block():
+    """A <details> spilling across parts must not read as two blocks."""
+    part1 = ("<!-- CLAUDE_REVIEW 1/2 -->\n"
+             f"### {TRAIL}\n\n<details>\n<summary><strong>2 claims</strong></summary>\n\n"
+             '- L10 in `a.md` "one" → ✅ verified (evidence: e; source: s)\n'
+             "</details>\n")
+    part2 = ("<!-- CLAUDE_REVIEW 2/2 -->\n"
+             "<details>\n<summary><em>continued from previous comment</em></summary>\n\n"
+             '- L20 in `a.md` "two" → ✅ verified (evidence: e; source: s)\n\n</details>\n')
+    footer = f"\n{ss.FOOTER_SENTINEL}\n\nfooter text\n"
+    out = ss.reassemble(part1 + footer + f"\n{ss.PART_DELIMITER}\n" + part2 + footer)
+    assert "continued from previous comment" not in out
+    assert out.count("</details>") == 1, out
+    assert len(ss.extract_trail_records_of(out)) == 2
+
+
+# ---- the negative cases (a healthy body must come through untouched) ----------
+
+
+def test_identical_bodies_are_untouched():
+    b = body()
+    drops = ss.assess(ss.reassemble(published(b)), b)
+    assert drops == []
+
+
+def test_growth_is_allowed():
+    prior, new = body(trail_lines=3), body(trail_lines=9)
+    assert ss.assess(ss.reassemble(published(prior)), new) == []
+
+
+def test_findings_moving_to_resolved_does_not_trip_it():
+    """Normal refresh churn: a finding resolves, the trail is unchanged."""
+    prior = body(trail_lines=4)
+    new = body(trail_lines=4, resolved="- **[L10]** Fixed. (resolved in def5678)")
+    assert ss.assess(ss.reassemble(published(prior)), new) == []
+
+
+def test_no_prior_is_a_noop():
+    assert ss.reassemble("") == ""
+
+
+# ---- the positive cases --------------------------------------------------------
+
+
+def test_dropped_trail_is_restored_verbatim():
+    prior, new = body(trail_lines=40), body(trail_lines=0)
+    p = ss.reassemble(published(prior))
+    drops = ss.assess(p, new)
+    assert [d["section"] for d in drops] == [TRAIL]
+    out, applied = ss.restore(p, new, drops)
+    assert len(applied) == 1
+    assert len(ss.extract_trail_records_of(out)) == 40
+    # ...and nothing else moved.
+    assert "- **[L10]** `content/a.md` — Something is wrong." in out
+    assert out.count(f"### {TRAIL}") == 1
+
+
+def test_prose_pointer_collapse_is_caught():
+    """The measured failure: heading kept, 40 records replaced by a pointer."""
+    prior = body(trail_lines=40)
+    # Replace ONLY the trail section's contents — the rest of the body, balance
+    # section included, renders normally. That is what the failure looks like.
+    lines = prior.splitlines()
+    start, end = ss._vp.find_section(prior, TRAIL)
+    lines[start:end] = [
+        f"### {TRAIL}", "",
+        "The full 40-claim extraction/verification trail from the initial review is",
+        "unchanged by this push — see 🚨 Outstanding and ✅ Resolved below.", "",
+    ]
+    new = "\n".join(lines) + "\n"
+    p = ss.reassemble(published(prior))
+    drops = ss.assess(p, new)
+    assert [d["section"] for d in drops] == [TRAIL]
+    assert drops[0]["prior"] == 40 and drops[0]["new"] == 0
+    out, _ = ss.restore(p, new, drops)
+    assert len(ss.extract_trail_records_of(out)) == 40
+    assert "unchanged by this push" not in out
+
+
+def test_section_missing_entirely_is_reinserted_in_h3_order():
+    prior = body(trail_lines=5)
+    new = body(trail_lines=5).replace(
+        f"### {TRAIL}\n\n<details>\n<summary><strong>3 claims extracted</strong></summary>\n", "")
+    # Strip the whole section so the heading is gone.
+    lines, keep, drop_mode = new.splitlines(), [], False
+    for ln in lines:
+        if ln.startswith(f"### {TRAIL}"):
+            drop_mode = True
+            continue
+        if drop_mode and ln.startswith("### "):
+            drop_mode = False
+        if not drop_mode:
+            keep.append(ln)
+    new = "\n".join(keep) + "\n"
+    assert TRAIL not in new
+    p = ss.reassemble(published(prior))
+    out, applied = ss.restore(p, new, ss.assess(p, new))
+    assert applied and TRAIL in out
+    # Reinserted BEFORE 🚨 Outstanding, per MANDATORY_H3_SECTIONS.
+    assert out.index(f"### {TRAIL}") < out.index("### 🚨 Outstanding")
+
+
+def test_gutted_investigation_log_is_restored():
+    prior, new = body(), body(log=False)
+    p = ss.reassemble(published(prior))
+    drops = ss.assess(p, new)
+    assert any(d["section"] == "Investigation log" for d in drops)
+    out, applied = ss.restore(p, new, drops)
+    assert ss._log_bullet_count(ss._investigation_log(out)) == 8
+
+
+def test_gutted_editorial_balance_is_restored():
+    prior, new = body(), body(balance=False)
+    p = ss.reassemble(published(prior))
+    drops = ss.assess(p, new)
+    assert any(d["section"] == BALANCE for d in drops)
+    out, _ = ss.restore(p, new, drops)
+    assert "Vendor mentions: 4 Pulumi" in out
+    assert out.index(f"### {BALANCE}") > out.index(f"### {TRAIL}")
+
+
+def test_balance_reflow_does_not_trip_the_byte_threshold():
+    prior = body()
+    new = body().replace("Vendor mentions: 4 Pulumi / 2 Terraform. Tone: balanced.",
+                         "Vendor mentions: 4 Pulumi / 2 Terraform.\nTone: balanced.")
+    assert not any(d["section"] == BALANCE for d in ss.assess(ss.reassemble(published(prior)), new))
+
+
+# ---- real fixture --------------------------------------------------------------
+
+
+def test_real_47kb_body_roundtrips_untouched():
+    """The published review from pulumi/docs#20779 — 40 trail records."""
+    fixture = Path("/workspaces/src/scratch/2026-08-08-opus-update-lane-bench/"
+                   "fixtures/prior-pinned-body.md")
+    if not fixture.is_file():
+        return  # optional: the benchmark run folder is not part of the repo
+    real = fixture.read_text()
+    p = ss.reassemble(published(real))
+    assert len(ss.extract_trail_records_of(p)) == 40
+    assert ss.assess(p, real) == []
+
+
+# ---- runner --------------------------------------------------------------------
+
+
+def _run():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok  {t.__name__}")
+        except Exception:
+            failed += 1
+            print(f"FAIL  {t.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run())

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -520,6 +520,39 @@ jobs:
             --vale-findings .vale-findings.json \
             --annotate-pinned
 
+      # Surface the evidence-spine floor's verdict. The floor itself runs inside
+      # `pinned-comment.sh upsert`, which the MODEL calls from its own Bash tool
+      # — and this action does not echo tool output into the job log, so without
+      # this step the check is completely invisible from CI: a run where it held
+      # and a run where it never executed look identical.
+      #
+      # The ::warning:: on a restore is the point, not decoration. Every real
+      # restore is a production instance of the model dropping the review's
+      # evidence spine, which is exactly the rate the 2026-08-10 campaign had to
+      # measure synthetically. Surfaced here, the lane measures it on live
+      # traffic for free — and a run of them is the case for revisiting the
+      # model config rather than leaning harder on the repair.
+      - name: Report evidence-spine floor
+        if: steps.claude.outcome == 'success' && steps.pr-context.outputs.pr_number != ''
+        continue-on-error: true
+        run: |
+          if [ ! -f /tmp/splice-spine.json ]; then
+            echo "::warning::No evidence-spine floor report. pinned-comment.sh upsert did not run, or ran without reaching the floor check — the refreshed review published unguarded."
+            exit 0
+          fi
+          echo "evidence-spine floor report:"
+          cat /tmp/splice-spine.json
+          status=$(jq -r '.status // "unknown"' /tmp/splice-spine.json)
+          case "$status" in
+            restored)
+              secs=$(jq -r '[.restored[].section] | join(", ")' /tmp/splice-spine.json)
+              echo "::warning::The refreshed review dropped evidence-spine section(s) — $secs — and they were restored from the previous pinned comment. The published review is correct; the render was not."
+              ;;
+            error)
+              echo "::warning::The evidence-spine floor errored and the review published as rendered: $(jq -r '.error' /tmp/splice-spine.json)"
+              ;;
+          esac
+
       # Provenance spot-check. The full validate -> splice -> re-validate chain
       # does not run on this lane (the model renders the body freehand and
       # would fail most structural rules), but ONE rule earns its keep here:

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -472,8 +472,13 @@ jobs:
           # investigation log). opus-5 at medium effort was the only arm intact in
           # every cell (6/6); sonnet-5 with effort unset — what ran here before —
           # and opus-5 unset each lost the spine in 1 of 6. It also gets there in
-          # 0.43x the output tokens and 0.64x the turns, which is ~1.25x the cost
-          # today and ~0.83x once Sonnet 5's introductory rate lapses 2026-08-31.
+          # 0.43x the output tokens and 0.64x the turns — but Opus is 2.5x Sonnet
+          # per token, so it costs ~1.25x, about $0.27 more per refresh at the
+          # rate this lane fires. That premium is permanent: Sonnet 5's $2/$10
+          # introductory rate was made its standing price on 2026-08-10, so the
+          # crossover the first cut of this comment predicted never happens.
+          # It buys removing a failure that is unrecoverable (the pinned comment
+          # is the only copy of the trail) and unvalidated on this lane.
           #
           # `--effort low` stays OFF this lane. It rewrites the pinned review
           # without the trail's contents — keeping the heading and replacing 40

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -464,18 +464,29 @@ jobs:
 
             Advisory style findings are **not** tracked across reviews. Each `#update-review` run generates a fresh `.vale-findings.json` against the current PR head; render those findings each time, drop them silently when they disappear, do NOT move resolved advisory nits into ✅ Resolved. Blocker-tier `[style-blocker]` bullets ARE tracked like regular findings: when a fix-push resolves one, move it to ✅ Resolved. The diff-tracking rules in `update.md` (Case 1 fix-response: move resolved to ✅) apply to human-grade catches and `[style-blocker]` bullets, not advisory `[style]` bullets.
 
-          # Effort is deliberately left unset on this lane. A 2026-07-30 fork A/B
-          # found `--effort low` makes the re-entrant path rewrite the pinned
-          # review WITHOUT the 🔍 Verification trail, 📊 Editorial balance, and
-          # investigation-log blocks (2/2 runs; the control kept all three). The
-          # loss is permanent — later updates merge from the prior comment — and
-          # invisible, because this workflow runs only `validate-pinned.py
-          # count-buckets`, never the validate → splice → validator-fix chain.
-          # The 2026-07-24 measurement that motivated the flag compared cost and
-          # latency only, not output completeness. Don't re-add it here without
-          # wiring in full validation first; the composer lane in
-          # claude-code-review.yml is a different case and keeps its low effort.
-          claude_args: '--model claude-sonnet-5 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(gh pr:*),Bash(gh issue:*),Bash(gh api:*),Bash(gh search:*),Bash(gh release:*),Bash(gh repo view:*),Bash(gh repo list:*),Bash(git:*),Bash(bash .claude/commands/docs-review/scripts/pinned-comment.sh:*),Bash(bash /home/runner/work/pulumi.docs/pulumi.docs/.claude/commands/docs-review/scripts/pinned-comment.sh:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(file:*),Bash(stat:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(tr:*),Bash(cut:*),Bash(paste:*),Bash(sort:*),Bash(uniq:*),Bash(diff:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(true:*),Bash(false:*),Bash(test:*),Bash(which:*),Bash(command:*),Bash(curl:*),Bash(wget:*)"'
+          # Model and effort are set from the 2026-08-10 campaign
+          # (`2026-08-10-update-lane-model-config` in pulumi/docs-review-benchmarks),
+          # a synthetic replay of this lane: 4 arms x 3 reps x 2 chained refreshes,
+          # scored on whether the re-rendered pinned body keeps its evidence spine
+          # (the 🔍 Verification trail's line floor, 📊 Editorial balance, and the
+          # investigation log). opus-5 at medium effort was the only arm intact in
+          # every cell (6/6); sonnet-5 with effort unset — what ran here before —
+          # and opus-5 unset each lost the spine in 1 of 6. It also gets there in
+          # 0.43x the output tokens and 0.64x the turns, which is ~1.25x the cost
+          # today and ~0.83x once Sonnet 5's introductory rate lapses 2026-08-31.
+          #
+          # `--effort low` stays OFF this lane. It rewrites the pinned review
+          # without the trail's contents — keeping the heading and replacing 40
+          # claim lines with a "see the full trail in the prior pass" pointer that
+          # dangles, because the prior pass is the comment it just overwrote. One
+          # rep of three collapsed to 11 of 40 lines and held exactly 11 through
+          # the next refresh. The loss is permanent — later updates merge from the
+          # prior comment — and invisible, because this workflow runs only
+          # `validate-pinned.py count-buckets`, never the validate → splice →
+          # validator-fix chain. Don't re-add it without wiring in full validation
+          # first; the composer lane in claude-code-review.yml is a different job
+          # shape and keeps its low effort.
+          claude_args: '--model claude-opus-5 --effort medium --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(gh pr:*),Bash(gh issue:*),Bash(gh api:*),Bash(gh search:*),Bash(gh release:*),Bash(gh repo view:*),Bash(gh repo list:*),Bash(git:*),Bash(bash .claude/commands/docs-review/scripts/pinned-comment.sh:*),Bash(bash /home/runner/work/pulumi.docs/pulumi.docs/.claude/commands/docs-review/scripts/pinned-comment.sh:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(file:*),Bash(stat:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(tr:*),Bash(cut:*),Bash(paste:*),Bash(sort:*),Bash(uniq:*),Bash(diff:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(true:*),Bash(false:*),Bash(test:*),Bash(which:*),Bash(command:*),Bash(curl:*),Bash(wget:*)"'
 
       # Re-post the one-click style suggestions and reconcile the pinned
       # comment against what actually landed. Delete-and-repost, exactly like

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -111,8 +111,14 @@ jobs:
           # No `prompt:` argument → tag mode. The action auto-posts its
           # animated tracking comment with per-tool-call updates and
           # decides what to do based on the mention text and project
-          # context (CLAUDE.md / AGENTS.md). Sonnet handles ad-hoc work.
-          claude_args: '--model claude-sonnet-5 --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(gh pr:*),Bash(gh issue:*),Bash(gh api:*),Bash(gh search:*),Bash(gh release:*),Bash(gh repo view:*),Bash(gh repo list:*),Bash(git:*),Bash(bash .claude/commands/docs-review/scripts/pinned-comment.sh:*),Bash(bash /home/runner/work/pulumi.docs/pulumi.docs/.claude/commands/docs-review/scripts/pinned-comment.sh:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(file:*),Bash(stat:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(tr:*),Bash(cut:*),Bash(paste:*),Bash(sort:*),Bash(uniq:*),Bash(diff:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(true:*),Bash(false:*),Bash(test:*),Bash(which:*),Bash(command:*),Bash(curl:*),Bash(wget:*)"'
+          # context (CLAUDE.md / AGENTS.md).
+          #
+          # Matched to the update lane's model so a contributor gets the same
+          # capability whichever way they mention @claude. Note this lane is an
+          # UNMEASURED job shape: the 2026-08-10 campaign scored re-rendering a
+          # pinned review, not open-ended ad-hoc work, so this tracks that
+          # decision rather than being justified by it.
+          claude_args: '--model claude-opus-5 --effort medium --allowed-tools "Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,Bash(gh pr:*),Bash(gh issue:*),Bash(gh api:*),Bash(gh search:*),Bash(gh release:*),Bash(gh repo view:*),Bash(gh repo list:*),Bash(git:*),Bash(bash .claude/commands/docs-review/scripts/pinned-comment.sh:*),Bash(bash /home/runner/work/pulumi.docs/pulumi.docs/.claude/commands/docs-review/scripts/pinned-comment.sh:*),Bash(cd:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(file:*),Bash(stat:*),Bash(ls:*),Bash(grep:*),Bash(find:*),Bash(rg:*),Bash(awk:*),Bash(sed:*),Bash(tr:*),Bash(cut:*),Bash(paste:*),Bash(sort:*),Bash(uniq:*),Bash(diff:*),Bash(jq:*),Bash(echo:*),Bash(printf:*),Bash(tee:*),Bash(date:*),Bash(true:*),Bash(false:*),Bash(test:*),Bash(which:*),Bash(command:*),Bash(curl:*),Bash(wget:*)"'
 
 env:
   ESC_ACTION_OIDC_AUTH: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ The repository runs a tiered review pipeline on every PR. AI-assisted contributo
 Transitioning to **Ready for review** triggers:
 
 1. A re-triage to refresh labels (domain, trivial / frontmatter-only short-circuits, prose-flagged signal if applicable).
-1. The full Claude review (currently `claude-opus-4-8`), composed per touched domain. Findings post to a single pinned comment at the top of the PR — overflow is appended as additional pinned comments tagged `<!-- CLAUDE_REVIEW N/M -->`.
+1. The full Claude review (currently `claude-opus-5`), composed per touched domain. Findings post to a single pinned comment at the top of the PR — overflow is appended as additional pinned comments tagged `<!-- CLAUDE_REVIEW N/M -->`.
 
 Mark the PR ready when you're done iterating, not when you start. Each ready-transition produces one full review run; thrashing through draft → ready → draft burns review budget and produces stale pinned comments.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ If the PR was AI-drafted, leave the AI authoring trailers in commit messages (`C
 A pinned review goes **stale** when you push new commits after it ran. One case refreshes itself: when the review had outstanding findings and your push is small (≤80 changed lines) and touches only the flagged lines — the "I fixed what you flagged" push — a deterministic gate auto-fires the scoped `#update-review` path with no mention needed. Everything else stays stale until you refresh explicitly. Three ways:
 
 1. **`@claude` mention** — hashtag-driven routing. The re-entrant pipeline branches on what you put after `@claude`:
-    - **`@claude #update-review`** — refresh the pinned review against the current PR head. Runs `claude-sonnet-5`. Three patterns the update path understands, all of which can appear in the same mention (the pipeline addresses any embedded asks inline before re-rendering the review):
+    - **`@claude #update-review`** — refresh the pinned review against the current PR head. Runs `claude-opus-5`. Three patterns the update path understands, all of which can appear in the same mention (the pipeline addresses any embedded asks inline before re-rendering the review):
         - **Fix-response** ("I addressed your feedback"): re-verifies the previous outstanding findings against the new diff and moves the resolved ones into ✅ Resolved.
         - **Dispute** ("I disagree with the X finding because Y"): re-examines the disputed finding with your evidence; either concedes cleanly or explains why it's keeping the finding.
         - **Re-verify** (no specific request beyond the hashtag): re-checks outstanding findings only.


### PR DESCRIPTION
Makes it impossible for a review refresh to publish without its evidence spine, and moves the re-entrant lane to `claude-opus-5 --effort medium`.

The floor is the larger half. The model change reduces how often the failure happens; the floor stops it happening at all — and it's what makes a later move back to Sonnet safe to evaluate on its merits rather than on which model drops the trail least.

## The bug

`pinned-comment.sh upsert` is a transport. It splits the body it's handed, stamps markers, and PATCHes the existing comments in place. It fetches those comments' **IDs, never their bodies** — so nothing in the system compares what's about to be published against what's already there. A refresh that re-renders the review without its 🔍 Verification trail publishes cleanly and the job goes green.

On `claude-update.yml` that loss is permanent. The lane does a fresh shallow checkout and runs only Vale, so there are no claims artifacts to rebuild from, and the comment it just overwrote was the only copy. Later refreshes merge from the damaged body, so it compounds.

Campaign [`2026-08-10-update-lane-model-config`](https://github.com/pulumi/docs-review-benchmarks) measured it at **1 in 6 chained refreshes** on the shipping configuration and **3 in 6** at `--effort low` — one of those collapsing a 40-line trail to 11 lines and then holding exactly 11 through the next refresh, because the floor it was checked against had moved down with it.

## The fix

`splice-spine.py` restores the three sections that describe the review's own *investigation* rather than the findings' *state*, when a re-render shrank them:

| section | shrink test |
| :--- | :--- |
| 🔍 Verification trail | fewer parsed trail records than the prior body |
| Investigation log | fewer of the 8 mandatory bullets |
| 📊 Editorial balance | under half the prior section's bytes |

Growth is still allowed. This enforces the render contract's existing **"may add, never drop"** instead of hoping for it — and it closes a hole in the old check, which was relative to the *prior* body and so scored an already-collapsed trail as passing.

**It runs inside `cmd_upsert`,** because that's the only point in the system holding both bodies at once, and it runs *before* `split_body` — so it never sees the continuation-`<details>` artifacts that make a naive fetch → concatenate → re-upsert compound them (the trap documented at `claude-update.yml:506`).

**Unconditionally.** The model composes its own `pinned-comment.sh upsert` command and the Bash allow-list is a prefix match, so a `--spine-floor` flag could simply be omitted — the same reasoning that already makes the ✏️ marks workflow-written. `SPLICE_SPINE=0` opts out and doesn't match the allow-list pattern, so it's reachable by a human or a workflow step and not by the model.

**Scoped by capability, not lane name.** `cmd_upsert_validated` delegates to `cmd_upsert`, so this also runs on the composer lane — where it can be *wrong*: that lane recomposes the trail from `.verified-claims.json` against the current diff, so if an author force-pushes a smaller change and re-requests review, a shorter trail is correct there. Restoring the old one would inject records for lines that no longer exist. The gate tests for claims artifacts: present → the caller owns the trail, stand down; absent → the pinned comment is the only copy, hold.

**Safety posture.** Every ambiguous case no-ops rather than guessing, and any internal failure exits 0 and publishes as rendered. This runs on a body nobody has seen yet, so a wrong repair would corrupt a good review, and a repair pass must never be why a review fails to publish.

## It also measures

A **Report evidence-spine floor** step prints the verdict and raises a `::warning::` on any restore.

That's not decoration. The floor runs from the model's own Bash tool, and claude-code-action doesn't echo tool output into the job log — so without this step a run where the floor held and a run where it never executed look identical. (That bit me during the fork test: correct output, no way to tell what produced it.)

More usefully: **every warning is a live instance of the model dropping the evidence spine** — the rate the campaign had to measure synthetically. The lane now measures it on real traffic for free, and a run of warnings is the argument for revisiting the model config rather than leaning harder on the repair.

## The model change

`claude-update.yml` ran `--model claude-sonnet-5` with no `--effort` — not a measured configuration, but residue: the 2026-07-24 battery shipped `--effort low` on a cost/latency win, and a 2026-07-30 fork A/B reversed the flag six days later when it turned out to strip the spine. Models had never been compared on this lane.

4 arms × 3 reps × 2 chained refreshes, scored deterministically:

| arm | spine intact | trail lines (of 40) | validator viol. | output tok |
| :--- | ---: | ---: | ---: | ---: |
| sonnet-5, no `--effort` (**what ran here**) | 0.833 | 40 | 1.833 | 355,907 |
| opus-5, no `--effort` | 0.833 | 39.8 | 1.167 | 220,511 |
| **opus-5 `--effort medium`** | **1.0** | 40.7 | 2.333 | 154,561 |
| sonnet-5 `--effort low` | 0.5 | 29.5 | 5.667 | 137,513 |

Cost: **$8.14 vs $6.54** — 1.25×, about **$0.27 per refresh**, permanent. (An earlier version of this description said the premium would invert to a ~17% saving on 2026-08-31 when Sonnet 5's introductory rate lapsed. That rate is now Sonnet 5's standing price, so the crossover never happens.) At this lane's observed ~30 runs/week that's on the order of $400/year.

**The quality signal is one cell: 6/6 against 5/6, at n=6.** It isn't statistically separated and no affordable number of reps would separate it. The case is the asymmetry, not the significance — and with the floor in place the asymmetry mostly goes away, which is the point of shipping both together.

`claude.yml` (the ad-hoc `@claude` lane) moves to the same model, so a contributor gets the same capability whichever way they mention `@claude`. Flagged in the comment as an unmeasured job shape — it tracks the decision, it isn't justified by it.

Also resolves the campaign's biggest open caveat: `claude-code-action` does nothing with `--effort` (it passes `claude_args` straight through, and the strings `high`/`xhigh` appear nowhere in its source), and the Agent SDK it pins documents `'high' — Deep reasoning (default)` twice. **Unset was the API's `high`**, so the control was the shipping configuration.

## Verification

| check | result |
| :--- | :--- |
| Unit tests (`test_splice_spine.py`) | 13/13 |
| Full docs-review script suite | 167 passed |
| **40 real published bodies, healthy** | 40/40 untouched (13 multi-part) |
| **40 real published bodies, gutted trail** | 40/40 restored exactly |
| `validate-pinned.py` on repaired vs original | identical status, 15/15 |
| End-to-end `upsert` with stubbed `gh` | 0 → 40 published, caller's file untouched, re-split to 2/2 and round-trips |
| Capability gate | fires without claims artifacts, stands down with them |
| `make lint` | clean |

Multi-part bodies matter most — they exercise reassembly of the continuation-`<details>` artifacts `split_body` inserts.

### Fork smoke test (CamSoper/pulumi.docs#234)

| # | scenario | result |
| ---: | :--- | :--- |
| 1 | Initial review (composer lane) | Posted; 19 records, balance, 8 log bullets |
| 2 | Refresh at `opus-5 --effort medium` | Spine 19→19, no spurious edits |
| 3 | Refresh at `sonnet-5 --effort low` | Spine held |
| 4 | Refresh, trail inflated to 44 | Floor ran, reported `noop` correctly |
| 5 | Refresh with a forced trail drop | **Restored 0 → 44, warning fired** |

Run 5's report, from the real job log:

```json
{ "restored": [ { "section": "🔍 Verification trail",
                  "prior": 44, "new": 0, "unit": "trail records" } ],
  "status": "restored" }
```

Published body: 44 records, all 25 injected records byte-preserved, pointer prose gone, balance and log intact. Runs 2–4 are the negative cases, and they matter more — they show it doesn't touch healthy reviews.

`cam-fork/master` has been reset to the incumbent.

## Follow-ups this doesn't do

- **Doesn't fix disputes.** All arms were indistinguishable across 56 dispute cells, and the ledger agrees: 137 PRs, 10 dispute events, 10 conceded, **0 held**. That's the lane conceding whenever nothing settles the question — an `update.md` Case 2 change, not a model choice.
- **Doesn't fix the other contract failures.** ✏️ marks carried over in 6/6 cells; correct ✅ moves land 0.167–0.667; quotes survive verbatim under a third of the time. No arm fixes those.
- **Doesn't touch the composer lane's `--effort low`** — that was a measured 2026-07-24 decision, and `#new-review` routes through it (`claude-new.yml` has no model of its own; it dispatches `claude-code-review.yml`).
- **Worth re-running the compose surface with the floor in place**, to see whether the arms converge enough to drop back to Sonnet as its own one-axis change.
