### PR TITLE
Add optional social + company links to event presenters

### DIFF
--- a/content/events/beyond-the-hyperscalers-sovereignty-panel/index.md
+++ b/content/events/beyond-the-hyperscalers-sovereignty-panel/index.md
@@ -59,12 +59,14 @@ presenters:
     - name: Waldemar Kindler
       role: CEO & Co-Founder, Think Ahead Technologies
       photo: /events/beyond-the-hyperscalers-sovereignty-panel/waldemar-kindler.png
+      company: Think Ahead Technologies
       company_url: https://think-ahead.tech/en
       social:
           linkedin: waldemar-kindler
     - name: Jim Dowling
       role: Co-Founder & CEO, Hopsworks
       photo: /events/beyond-the-hyperscalers-sovereignty-panel/jim-dowling.png
+      company: Hopsworks
       company_url: https://www.hopsworks.ai
       social:
           linkedin: jim-dowling-206a98
@@ -72,6 +74,7 @@ presenters:
     - name: Sarbjeet Johal
       role: Cloud Economist; Founder & CEO, StackPane
       photo: /events/beyond-the-hyperscalers-sovereignty-panel/sarbjeet-johal.png
+      company: StackPane
       company_url: https://stackpane.com
       social:
           linkedin: sarbjeetjohal
@@ -80,9 +83,6 @@ presenters:
       role: Community Engineer, Pulumi
       photo: /images/team/adam-gordon-bell.jpg
       host: true
-      social:
-          linkedin: adamgordonbell
-          x: adamgordonbell
 
 # case-sensitive
 tags:

--- a/content/events/beyond-the-hyperscalers-sovereignty-panel/index.md
+++ b/content/events/beyond-the-hyperscalers-sovereignty-panel/index.md
@@ -59,16 +59,30 @@ presenters:
     - name: Waldemar Kindler
       role: CEO & Co-Founder, Think Ahead Technologies
       photo: /events/beyond-the-hyperscalers-sovereignty-panel/waldemar-kindler.png
+      company_url: https://think-ahead.tech/en
+      social:
+          linkedin: waldemar-kindler
     - name: Jim Dowling
       role: Co-Founder & CEO, Hopsworks
       photo: /events/beyond-the-hyperscalers-sovereignty-panel/jim-dowling.png
+      company_url: https://www.hopsworks.ai
+      social:
+          linkedin: jim-dowling-206a98
+          x: jim_dowling
     - name: Sarbjeet Johal
       role: Cloud Economist; Founder & CEO, StackPane
       photo: /events/beyond-the-hyperscalers-sovereignty-panel/sarbjeet-johal.png
+      company_url: https://stackpane.com
+      social:
+          linkedin: sarbjeetjohal
+          x: sarbjeetjohal
     - name: Adam Gordon Bell
       role: Community Engineer, Pulumi
       photo: /images/team/adam-gordon-bell.jpg
       host: true
+      social:
+          linkedin: adamgordonbell
+          x: adamgordonbell
 
 # case-sensitive
 tags:

--- a/content/events/beyond-the-hyperscalers-sovereignty-panel/index.md
+++ b/content/events/beyond-the-hyperscalers-sovereignty-panel/index.md
@@ -57,14 +57,14 @@ learn:
 # The event presenters
 presenters:
     - name: Waldemar Kindler
-      role: CEO & Co-Founder, Think Ahead Technologies
+      role: CEO & Co-Founder
       photo: /events/beyond-the-hyperscalers-sovereignty-panel/waldemar-kindler.png
       company: Think Ahead Technologies
       company_url: https://think-ahead.tech/en
       social:
           linkedin: waldemar-kindler
     - name: Jim Dowling
-      role: Co-Founder & CEO, Hopsworks
+      role: Co-Founder & CEO
       photo: /events/beyond-the-hyperscalers-sovereignty-panel/jim-dowling.png
       company: Hopsworks
       company_url: https://www.hopsworks.ai
@@ -72,7 +72,7 @@ presenters:
           linkedin: jim-dowling-206a98
           x: jim_dowling
     - name: Sarbjeet Johal
-      role: Cloud Economist; Founder & CEO, StackPane
+      role: Cloud Economist; Founder & CEO
       photo: /events/beyond-the-hyperscalers-sovereignty-panel/sarbjeet-johal.png
       company: StackPane
       company_url: https://stackpane.com

--- a/layouts/partials/events/speakers-template.html
+++ b/layouts/partials/events/speakers-template.html
@@ -9,8 +9,10 @@
       - social: map of platform → handle (github, linkedin, twitter, x,
         bluesky), rendered as icons via widgets/social-icons.html — the same
         shape the team data files use.
-      - company_url: full URL to the presenter's company site, rendered as a
-        short domain-name link.
+      - company + company_url: `company` names the company as it appears
+        inside the role string, and that occurrence is rendered as a link to
+        `company_url`. Both must be present (and `company` must match the
+        role text) for the link to appear.
 
     Optional: mark a presenter with `host: true` in front matter to split them
     out into a secondary "Host" row below the main grid — for panels where the
@@ -39,13 +41,16 @@
                 <img class="event-speaker-photo" src="{{ $presenter.photo | default "/images/avatars/avatar-generic.svg" }}" alt="{{ $presenter.name }}" />
                 <div>
                     <div class="event-speaker-name">{{ $presenter.name }}</div>
-                    <div class="event-speaker-role">{{ $presenter.role }}</div>
-                    {{ if or $presenter.social $presenter.company_url }}
-                        <div class="event-speaker-links mt-1 flex items-center gap-3">
-                            {{ partial "widgets/social-icons.html" (dict "social" $presenter.social) }}
-                            {{ with $presenter.company_url }}
-                                <a class="text-sm" href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ strings.TrimPrefix "www." (urls.Parse .).Host }}</a>
-                            {{ end }}
+                    <div class="event-speaker-role">
+                        {{- if and $presenter.company $presenter.company_url (in $presenter.role $presenter.company) -}}
+                            {{ replace $presenter.role $presenter.company (printf `<a class="link hover:underline" href="%s" target="_blank" rel="noopener noreferrer">%s</a>` $presenter.company_url $presenter.company) | safeHTML }}
+                        {{- else -}}
+                            {{ $presenter.role }}
+                        {{- end -}}
+                    </div>
+                    {{ with $presenter.social }}
+                        <div class="event-speaker-links mt-1">
+                            {{ partial "widgets/social-icons.html" (dict "social" .) }}
                         </div>
                     {{ end }}
                 </div>
@@ -62,13 +67,16 @@
                         <img class="event-speaker-photo event-host-photo" src="{{ $host.photo | default "/images/avatars/avatar-generic.svg" }}" alt="{{ $host.name }}" />
                         <div>
                             <div class="event-speaker-name">{{ $host.name }}</div>
-                            <div class="event-speaker-role">{{ $host.role }}</div>
-                            {{ if or $host.social $host.company_url }}
-                                <div class="event-speaker-links mt-1 flex items-center gap-3">
-                                    {{ partial "widgets/social-icons.html" (dict "social" $host.social) }}
-                                    {{ with $host.company_url }}
-                                        <a class="text-sm" href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ strings.TrimPrefix "www." (urls.Parse .).Host }}</a>
-                                    {{ end }}
+                            <div class="event-speaker-role">
+                                {{- if and $host.company $host.company_url (in $host.role $host.company) -}}
+                                    {{ replace $host.role $host.company (printf `<a class="link hover:underline" href="%s" target="_blank" rel="noopener noreferrer">%s</a>` $host.company_url $host.company) | safeHTML }}
+                                {{- else -}}
+                                    {{ $host.role }}
+                                {{- end -}}
+                            </div>
+                            {{ with $host.social }}
+                                <div class="event-speaker-links mt-1">
+                                    {{ partial "widgets/social-icons.html" (dict "social" .) }}
                                 </div>
                             {{ end }}
                         </div>

--- a/layouts/partials/events/speakers-template.html
+++ b/layouts/partials/events/speakers-template.html
@@ -9,10 +9,9 @@
       - social: map of platform → handle (github, linkedin, twitter, x,
         bluesky), rendered as icons via widgets/social-icons.html — the same
         shape the team data files use.
-      - company + company_url: `company` names the company as it appears
-        inside the role string, and that occurrence is rendered as a link to
-        `company_url`. Both must be present (and `company` must match the
-        role text) for the link to appear.
+      - company + company_url: when `company` is set, it renders on its own
+        line below the role (so keep the company out of the `role` string),
+        linked to `company_url` when that's present too.
 
     Optional: mark a presenter with `host: true` in front matter to split them
     out into a secondary "Host" row below the main grid — for panels where the
@@ -41,13 +40,16 @@
                 <img class="event-speaker-photo" src="{{ $presenter.photo | default "/images/avatars/avatar-generic.svg" }}" alt="{{ $presenter.name }}" />
                 <div>
                     <div class="event-speaker-name">{{ $presenter.name }}</div>
-                    <div class="event-speaker-role">
-                        {{- if and $presenter.company $presenter.company_url (in $presenter.role $presenter.company) -}}
-                            {{ replace $presenter.role $presenter.company (printf `<a class="link hover:underline" href="%s" target="_blank" rel="noopener noreferrer">%s</a>` $presenter.company_url $presenter.company) | safeHTML }}
-                        {{- else -}}
-                            {{ $presenter.role }}
-                        {{- end -}}
-                    </div>
+                    <div class="event-speaker-role">{{ $presenter.role }}</div>
+                    {{ with $presenter.company }}
+                        <div class="event-speaker-role">
+                            {{- with $presenter.company_url -}}
+                                <a class="link hover:underline" href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ $presenter.company }}</a>
+                            {{- else -}}
+                                {{ . }}
+                            {{- end -}}
+                        </div>
+                    {{ end }}
                     {{ with $presenter.social }}
                         <div class="event-speaker-links mt-1">
                             {{ partial "widgets/social-icons.html" (dict "social" .) }}
@@ -67,13 +69,16 @@
                         <img class="event-speaker-photo event-host-photo" src="{{ $host.photo | default "/images/avatars/avatar-generic.svg" }}" alt="{{ $host.name }}" />
                         <div>
                             <div class="event-speaker-name">{{ $host.name }}</div>
-                            <div class="event-speaker-role">
-                                {{- if and $host.company $host.company_url (in $host.role $host.company) -}}
-                                    {{ replace $host.role $host.company (printf `<a class="link hover:underline" href="%s" target="_blank" rel="noopener noreferrer">%s</a>` $host.company_url $host.company) | safeHTML }}
-                                {{- else -}}
-                                    {{ $host.role }}
-                                {{- end -}}
-                            </div>
+                            <div class="event-speaker-role">{{ $host.role }}</div>
+                            {{ with $host.company }}
+                                <div class="event-speaker-role">
+                                    {{- with $host.company_url -}}
+                                        <a class="link hover:underline" href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ $host.company }}</a>
+                                    {{- else -}}
+                                        {{ . }}
+                                    {{- end -}}
+                                </div>
+                            {{ end }}
                             {{ with $host.social }}
                                 <div class="event-speaker-links mt-1">
                                     {{ partial "widgets/social-icons.html" (dict "social" .) }}

--- a/layouts/partials/events/speakers-template.html
+++ b/layouts/partials/events/speakers-template.html
@@ -4,7 +4,13 @@
     Displays event presenters as a clean, borderless section.
 
     Parameters:
-    - presenters: Array of presenter objects with name, role, and photo
+    - presenters: Array of presenter objects with name, role, and photo.
+      Each may optionally carry:
+      - social: map of platform → handle (github, linkedin, twitter, x,
+        bluesky), rendered as icons via widgets/social-icons.html — the same
+        shape the team data files use.
+      - company_url: full URL to the presenter's company site, rendered as a
+        short domain-name link.
 
     Optional: mark a presenter with `host: true` in front matter to split them
     out into a secondary "Host" row below the main grid — for panels where the
@@ -34,6 +40,14 @@
                 <div>
                     <div class="event-speaker-name">{{ $presenter.name }}</div>
                     <div class="event-speaker-role">{{ $presenter.role }}</div>
+                    {{ if or $presenter.social $presenter.company_url }}
+                        <div class="event-speaker-links mt-1 flex items-center gap-3">
+                            {{ partial "widgets/social-icons.html" (dict "social" $presenter.social) }}
+                            {{ with $presenter.company_url }}
+                                <a class="text-sm" href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ strings.TrimPrefix "www." (urls.Parse .).Host }}</a>
+                            {{ end }}
+                        </div>
+                    {{ end }}
                 </div>
             </div>
         {{ end }}
@@ -49,6 +63,14 @@
                         <div>
                             <div class="event-speaker-name">{{ $host.name }}</div>
                             <div class="event-speaker-role">{{ $host.role }}</div>
+                            {{ if or $host.social $host.company_url }}
+                                <div class="event-speaker-links mt-1 flex items-center gap-3">
+                                    {{ partial "widgets/social-icons.html" (dict "social" $host.social) }}
+                                    {{ with $host.company_url }}
+                                        <a class="text-sm" href="{{ . }}" target="_blank" rel="noopener noreferrer">{{ strings.TrimPrefix "www." (urls.Parse .).Host }}</a>
+                                    {{ end }}
+                                </div>
+                            {{ end }}
                         </div>
                     </div>
                 {{ end }}


### PR DESCRIPTION
Speakers on event pages had no way to link out — name, role, and photo only. Panelists (starting with the sovereignty panel) have asked for backlinks to their profiles and companies.

This adds optional per-presenter fields to the event `presenters` front matter:

- `social:` — platform → handle map (github / linkedin / twitter / x / bluesky), rendered as icons by the existing `widgets/social-icons.html` partial — the same shape the team data files and Puluminaries page use.
- `company:` + `company_url:` — the company renders on its own line under the role, as a link (site `.link` style) when `company_url` is present:

  > **Waldemar Kindler**
  > CEO & Co-Founder
  > [Think Ahead Technologies](https://think-ahead.tech/en)

All opt-in, so every existing event page renders unchanged. The sovereignty panel page (`beyond-the-hyperscalers-sovereignty-panel`) opts in for the three external panelists.

Note: intentionally scoped to `speakers-template.html` internals + one content page so it composes cleanly with #20794, which changes this partial's call sites but not the partial itself — presenter maps pass through its dedup logic untouched.
