### PR TITLE
Split word-preference swaps out of Pulumi.Substitutions so they stop blocking

### DIFF
--- a/.claude/commands/docs-review/scripts/vale-deterministic-fixes.yaml
+++ b/.claude/commands/docs-review/scripts/vale-deterministic-fixes.yaml
@@ -22,7 +22,8 @@
 # reviewer can verify rather than compose; anything requiring an editorial
 # rewrite or a context-dependent choice is deliberately excluded (see below).
 deterministic_fix:
-  - Pulumi.Substitutions        # Fixed swaps: click->select, public beta->public preview, ...
+  - Pulumi.Substitutions        # Fixed terminology swaps: public beta->public preview, CrossGuard->Pulumi Policies, ...
+  - Pulumi.WordChoice           # Fixed word-preference swaps: click->select, go to->navigate to.
   - Pulumi.Nomenclature         # Canonical product-name spellings: pulumi esc->Pulumi ESC, ...
   - Pulumi.CrossReferenceHeadings  # Closed-set cross-reference heading rename to Next steps / Learn more.
   - Google.Spelling             # Single suggested spelling for an unambiguous misspelling.
@@ -39,11 +40,16 @@ deterministic_fix:
 # exempts blockers from the per-file/total caps so one is never silently
 # dropped.
 blocker:
-  - Pulumi.Substitutions        # Banned term with a fixed correct replacement.
+  - Pulumi.Substitutions        # Wrong term (dead brand name, misstated lifecycle stage) with a fixed correct replacement.
   - Pulumi.Nomenclature         # Misspelled/miscased Pulumi product name.
   - Pulumi.PoliciesSingular     # Grammatical agreement error ("policies is").
   - Google.Spelling             # Unambiguous misspelling.
   - Pulumi.DeprecatedProductNames  # "Pulumi Service" is always wrong; the replacement (Cloud/ESC/Deployments) is the author's call, but shipping the dead name is not.
+# Pulumi.WordChoice (click->select, go to->navigate to) is deliberately absent
+# from `blocker:` despite having a deterministic fix — those swaps are house
+# word preferences, not correctness errors, so they fail this list's admission
+# criterion and stay advisory. That distinction is why WordChoice was split out
+# of Substitutions in the first place (styles/Pulumi/WordChoice.yml).
 
 # Deliberately NOT listed ABOVE IN `deterministic_fix` (no fixed replacement --
 # the reviewer must compose the fix) and why. Note this says nothing about

--- a/.claude/commands/docs-review/scripts/vale-findings-filter.py
+++ b/.claude/commands/docs-review/scripts/vale-findings-filter.py
@@ -103,6 +103,7 @@ DETERMINISTIC_FIX_RULES, BLOCKER_RULES = load_rule_lists()
 # Unmapped rules fall back to "style".
 RULE_CATEGORIES: dict[str, str] = {
     "Pulumi.Substitutions": "substitution",
+    "Pulumi.WordChoice": "word choice",
     "Pulumi.Nomenclature": "nomenclature",
     "Pulumi.DeprecatedProductNames": "deprecated product name",
     "Pulumi.BannedWords": "inclusive language",

--- a/styles/Pulumi/Substitutions.yml
+++ b/styles/Pulumi/Substitutions.yml
@@ -1,3 +1,10 @@
+# Terminology-correctness substitutions: each flagged term is *wrong* (a dead
+# brand name, a misstated product lifecycle stage, or non-canonical package
+# terminology) and has one fixed correct replacement. Word-choice *preferences*
+# (click -> select, go to -> navigate to) live in WordChoice.yml instead — this
+# split is what lets the pinned PR review treat Substitutions findings as
+# blockers while WordChoice stays advisory (see the `blocker:` list in
+# .claude/commands/docs-review/scripts/vale-deterministic-fixes.yaml).
 extends: substitution
 message: "Use '%s' instead of '%s' (STYLE-GUIDE.md)."
 level: error
@@ -5,8 +12,6 @@ ignorecase: true
 action:
   name: replace
 swap:
-  '\bclick\b': select
-  '\bgo to\b': navigate to
   '\bpublic beta\b': public preview
   '\bcross-language package\b': Pulumi package
   '\bsingle-language package\b': native language package

--- a/styles/Pulumi/WordChoice.yml
+++ b/styles/Pulumi/WordChoice.yml
@@ -1,0 +1,18 @@
+# Word-choice preferences from STYLE-GUIDE.md: the flagged word isn't *wrong*,
+# the house style just prefers another one ("select" is device-neutral where
+# "click" assumes a mouse). Split out of Substitutions.yml, which holds only
+# terminology-correctness swaps, so the pinned PR review can tier them apart:
+# Substitutions findings are blockers, WordChoice findings stay advisory (see
+# the `blocker:` list in
+# .claude/commands/docs-review/scripts/vale-deterministic-fixes.yaml).
+# Warning, not error: these must still clear MinAlertLevel = warning in
+# .vale.ini to surface as advisory nags at all.
+extends: substitution
+message: "Use '%s' instead of '%s' (STYLE-GUIDE.md)."
+level: warning
+ignorecase: true
+action:
+  name: replace
+swap:
+  '\bclick\b': select
+  '\bgo to\b': navigate to


### PR DESCRIPTION
### Proposed changes

#20663 elevated `Pulumi.Substitutions` to the pinned review's blocker tier, but that rule mixed two kinds of swap: terminology-correctness fixes (`public beta` → public preview, `CrossGuard` → Pulumi Policies, package naming) and house word preferences (`click` → select, `go to` → navigate to). Blocker status is stamped per rule name, so the preferences rode along — on #20528, 5 of the 6 `[style-blocker]` findings were "click" → "select", which fails the blocker list's own admission criterion ("a *correctness* error … not a style preference"). One of them ("click to deploy", a Pulumi Deployments trigger name) even required an editorial rewrite rather than the fixed swap.

This splits the Vale rule instead of complicating the tiering machinery:

- **New `styles/Pulumi/WordChoice.yml`** (`level: warning`) carries the two word-preference swaps. Picked up automatically via `BasedOnStyles = Pulumi`; warning level clears `MinAlertLevel` so the findings still surface as advisory nags.
- **`Pulumi.Substitutions`** keeps only the terminology-correctness swaps and stays on the `blocker:` list unchanged.
- **`vale-deterministic-fixes.yaml`**: `Pulumi.WordChoice` added to `deterministic_fix:` (the swap is still fixed, and review-existing-content's judgment gate handles "click event"-type contexts), deliberately absent from `blocker:`, with a comment recording why.
- **`vale-findings-filter.py`**: `Pulumi.WordChoice` maps to the "word choice" category in PR-facing copy.

No changes needed elsewhere: the blocker-tier contract copy in `output-format.md` / `STYLE-GUIDE.md` §Automated checks describes the tier generically and stays accurate, and the test fixtures reference rule names that still exist.

**Verification:** vale 3.14.1 fixture run (WordChoice flags click/go to at warning, Substitutions flags public beta/CrossGuard at error); filter smoke test stamps `blocker: false` / `deterministic_fix: true` for WordChoice findings; all docs-review script test suites pass (incl. `test_style_blocker_provenance.py`, 53 pytest cases in `test_post_style_suggestions.py`) plus the `verify-fix-scope.py` self-tests; `make lint` clean.

### Unreleased product version (optional)

N/A

### Related issues (optional)

Follow-up to #20663; motivated by the blocker tier's behavior on #20528.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU3m2V9YYU2Uk1tqdg5GJz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DU3m2V9YYU2Uk1tqdg5GJz)_