### PR TITLE
Keep the 📋 Triaged section's <details> wrapper

### DIFF
--- a/.claude/commands/docs-review/scripts/splicer.py
+++ b/.claude/commands/docs-review/scripts/splicer.py
@@ -88,6 +88,7 @@ EMPTY_FORMS = {
 # bucket-bullet prefix prepends run last so trail records are stable.
 APPLY_ORDER = [
     "mandatory-h3-order",
+    "triaged-details-wrapper",
     "internal-link-existence",
     "shortcode-existence",
     "verified-claims-trail-faithful",
@@ -328,6 +329,47 @@ def splice_mandatory_h3_order(lines: list[str], violation: dict) -> tuple[list[s
 
     block = empty_form.split("\n") + [""]
     return lines[:insert_idx] + block + lines[insert_idx:], True
+
+
+TRIAGED_HEADING = "📋 Triaged verifier findings"
+TRIAGED_SUMMARY_LINE = (
+    "<summary><em>I double-checked these and realized they weren't real findings "
+    "— click to expand</em></summary>"
+)
+
+
+def splice_triaged_details_wrapper(lines: list[str], violation: dict) -> tuple[list[str], bool]:
+    """Re-wrap the 📋 section's bullets in their collapsed `<details>`.
+
+    Purely additive: the bullets are kept byte-for-byte and only the wrapper is
+    rebuilt around them. That is what makes this surgical rather than a
+    re-render — the editorial pass's triage prose is the valuable part and this
+    never touches it.
+
+    Defers to fallback if a `<details>` is already open in the section (a
+    partial wrapper is ambiguous — we would have to guess whether the bullets
+    belong inside it), or if the section has no bullets (nothing to wrap;
+    strip-empty-triaged.py owns that case).
+    """
+    span = _section_span(lines, TRIAGED_HEADING)
+    if span is None:
+        return lines, False
+    start, end = span
+    body = lines[start:end]
+    if any(ln.strip().startswith("<details>") for ln in body):
+        return lines, False
+
+    # Split heading from content, preserving the bullets exactly.
+    content = body[1:]
+    while content and not content[0].strip():
+        content.pop(0)
+    while content and not content[-1].strip():
+        content.pop()
+    if not content:
+        return lines, False
+
+    rebuilt = [body[0], "", "<details>", TRIAGED_SUMMARY_LINE, "", *content, "", "</details>", ""]
+    return lines[:start] + rebuilt + lines[end:], True
 
 
 def splice_trail_per_verdict_emoji(lines: list[str], violation: dict) -> tuple[list[str], bool]:
@@ -672,6 +714,7 @@ SPLICERS = {
     "internal-link-existence": splice_internal_link_existence,
     "shortcode-existence": splice_shortcode_existence,
     "mandatory-h3-order": splice_mandatory_h3_order,
+    "triaged-details-wrapper": splice_triaged_details_wrapper,
     "trail-per-verdict-emoji": splice_trail_per_verdict_emoji,
     "trail-canonical-verdict-word": splice_trail_canonical_verdict_word,
     "verified-claims-trail-faithful": splice_verified_claims_trail_faithful,

--- a/.claude/commands/docs-review/scripts/splicer.py
+++ b/.claude/commands/docs-review/scripts/splicer.py
@@ -346,17 +346,25 @@ def splice_triaged_details_wrapper(lines: list[str], violation: dict) -> tuple[l
     re-render — the editorial pass's triage prose is the valuable part and this
     never touches it.
 
-    Defers to fallback if a `<details>` is already open in the section (a
-    partial wrapper is ambiguous — we would have to guess whether the bullets
-    belong inside it), or if the section has no bullets (nothing to wrap;
+    Defers to fallback if EITHER `<details>` tag is already present in the
+    section — a partial wrapper is ambiguous and we would have to guess where
+    the bullets belong — or if the section has no bullets (nothing to wrap;
     strip-empty-triaged.py owns that case).
+
+    Both tags, not just the opener. An editorial pass that deleted the
+    `<details>` line but left `</details>` behind would otherwise take the wrap
+    path and produce `<details>` → summary → some bullets → stray `</details>`
+    → the rest of the bullets → `</details>`: the section closes early, the
+    trailing bullets render expanded, and the re-validate pass sees a wrapper
+    and a summary and calls it clean. That ships silently, which is worse than
+    the defect this rule exists to fix. Deferring hands it to the model lane.
     """
     span = _section_span(lines, TRIAGED_HEADING)
     if span is None:
         return lines, False
     start, end = span
     body = lines[start:end]
-    if any(ln.strip().startswith("<details>") for ln in body):
+    if any(ln.strip().startswith(("<details>", "</details>")) for ln in body):
         return lines, False
 
     # Split heading from content, preserving the bullets exactly.

--- a/.claude/commands/docs-review/scripts/test_splicer.py
+++ b/.claude/commands/docs-review/scripts/test_splicer.py
@@ -545,60 +545,6 @@ def test_apply_order_processes_trail_faithful_before_per_verdict_emoji():
 # ---- Test runner -----------------------------------------------------------
 
 
-TESTS = [
-    test_internal_link_existence_unwraps_markdown_link,
-    test_shortcode_existence_deletes_line,
-    test_mandatory_h3_order_inserts_missing_section,
-    test_mandatory_h3_order_inserts_triaged_with_details_wrapper,
-    test_mandatory_h3_order_defers_when_already_present,
-    test_trail_per_verdict_emoji_replaces_legacy_glyph,
-    test_trail_canonical_verdict_word_replaces_freelanced_token,
-    test_verified_claims_trail_faithful_restores_artifact_verdict,
-    test_verified_claims_trail_faithful_file_filter_skips_cross_file_overlap,
-    test_verified_claims_trail_faithful_strict_pairing_defers_on_anchor_mismatch,
-    test_verified_claims_trail_faithful_idempotent_across_duplicate_violations,
-    test_verified_claims_trail_faithful_matches_by_range_overlap,
-    test_pass3_unverifiable_evidence_inserts_pointer,
-    test_pass3_unverifiable_evidence_idempotent,
-    test_trail_canonical_verdict_word_idempotent,
-    test_external_claim_state_format_defers_to_fallback,
-    test_external_claim_dispatch_metadata_appends_segment,
-    test_external_claim_routed_metadata_appends_segment,
-    test_external_claim_pass2_outcome_drops_zero_parenthetical,
-    test_external_claim_pass2_outcome_defers_when_f_positive,
-    test_bucket_bullet_line_range_prefix_prepends_anchor,
-    test_empty_violations_no_op,
-    test_non_surgical_only_passes_through,
-    test_mixed_surgical_and_nonsurgical_applies_surgical,
-    test_apply_order_processes_trail_faithful_before_per_verdict_emoji,
-]
-
-
-def main() -> int:
-    failures: list[tuple[str, str]] = []
-    for t in TESTS:
-        name = t.__name__
-        try:
-            t()
-            print(f"  ok  {name}")
-        except AssertionError as e:
-            failures.append((name, str(e) or "assertion failed"))
-            print(f"  FAIL {name}: {e}")
-        except Exception:
-            failures.append((name, traceback.format_exc()))
-            print(f"  ERROR {name}:\n{traceback.format_exc()}")
-    print()
-    if failures:
-        print(f"{len(failures)}/{len(TESTS)} tests failed")
-        return 1
-    print(f"{len(TESTS)}/{len(TESTS)} tests passed")
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
-
-
 TRIAGED_UNWRAPPED = (
     "### ⚠️ Low-confidence\n\n"
     "_No low-confidence findings._\n\n"
@@ -651,3 +597,77 @@ def test_triaged_details_wrapper_defers_on_partial_wrapper():
         "### 📋 Triaged verifier findings\n\n<details>\n<summary><em>something else</em></summary>\n\n")
     _, applied, fallback = splicer.apply_splices(partial, [TRIAGED_VIOLATION])
     assert applied == [] and fallback == ["triaged-details-wrapper"]
+
+
+def test_triaged_details_wrapper_defers_on_orphan_closing_tag():
+    """An orphan `</details>` must defer too — wrapping it would nest badly.
+
+    The dangerous asymmetry: guarding only on the OPENING tag lets a section
+    whose `<details>` was deleted but whose `</details>` survived take the wrap
+    path. The result closes the block early, leaves the trailing bullets
+    expanded, and then PASSES re-validation because a wrapper and a summary are
+    both present — silent corruption, where deferring to the model lane is the
+    documented posture.
+    """
+    orphan = TRIAGED_UNWRAPPED.replace(
+        "### 💡 Pre-existing", "</details>\n\n### 💡 Pre-existing")
+    new_body, applied, fallback = splicer.apply_splices(orphan, [TRIAGED_VIOLATION])
+    assert applied == [] and fallback == ["triaged-details-wrapper"], (applied, fallback)
+    assert new_body == orphan, "must not rewrite a section it deferred on"
+
+
+TESTS = [
+    test_internal_link_existence_unwraps_markdown_link,
+    test_shortcode_existence_deletes_line,
+    test_mandatory_h3_order_inserts_missing_section,
+    test_mandatory_h3_order_inserts_triaged_with_details_wrapper,
+    test_mandatory_h3_order_defers_when_already_present,
+    test_trail_per_verdict_emoji_replaces_legacy_glyph,
+    test_trail_canonical_verdict_word_replaces_freelanced_token,
+    test_verified_claims_trail_faithful_restores_artifact_verdict,
+    test_verified_claims_trail_faithful_file_filter_skips_cross_file_overlap,
+    test_verified_claims_trail_faithful_strict_pairing_defers_on_anchor_mismatch,
+    test_verified_claims_trail_faithful_idempotent_across_duplicate_violations,
+    test_verified_claims_trail_faithful_matches_by_range_overlap,
+    test_pass3_unverifiable_evidence_inserts_pointer,
+    test_pass3_unverifiable_evidence_idempotent,
+    test_trail_canonical_verdict_word_idempotent,
+    test_external_claim_state_format_defers_to_fallback,
+    test_external_claim_dispatch_metadata_appends_segment,
+    test_external_claim_routed_metadata_appends_segment,
+    test_external_claim_pass2_outcome_drops_zero_parenthetical,
+    test_external_claim_pass2_outcome_defers_when_f_positive,
+    test_bucket_bullet_line_range_prefix_prepends_anchor,
+    test_empty_violations_no_op,
+    test_non_surgical_only_passes_through,
+    test_mixed_surgical_and_nonsurgical_applies_surgical,
+    test_apply_order_processes_trail_faithful_before_per_verdict_emoji,
+    test_triaged_details_wrapper_rewraps_without_touching_bullets,
+    test_triaged_details_wrapper_is_idempotent,
+    test_triaged_details_wrapper_defers_on_partial_wrapper,
+    test_triaged_details_wrapper_defers_on_orphan_closing_tag,
+]
+
+
+def main() -> int:
+    failures: list[tuple[str, str]] = []
+    for t in TESTS:
+        name = t.__name__
+        try:
+            t()
+            print(f"  ok  {name}")
+        except AssertionError as e:
+            failures.append((name, str(e) or "assertion failed"))
+            print(f"  FAIL {name}: {e}")
+        except Exception:
+            failures.append((name, traceback.format_exc()))
+            print(f"  ERROR {name}:\n{traceback.format_exc()}")
+    print()
+    if failures:
+        print(f"{len(failures)}/{len(TESTS)} tests failed")
+        return 1
+    print(f"{len(TESTS)}/{len(TESTS)} tests passed")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/commands/docs-review/scripts/test_splicer.py
+++ b/.claude/commands/docs-review/scripts/test_splicer.py
@@ -597,3 +597,57 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+
+
+TRIAGED_UNWRAPPED = (
+    "### ⚠️ Low-confidence\n\n"
+    "_No low-confidence findings._\n\n"
+    "### 📋 Triaged verifier findings\n\n"
+    "- **[L107]** `a.md` — *\"claim one\"* — **Spurious:** verifier compared the wrong sibling.\n\n"
+    "- **[L60]** `b.md` — *\"claim two\"* — **Mis-sourced:** cited URL is unrelated.\n\n"
+    "- ~~**[L405]** `c.md` — **Mis-sourced.**~~ **This triage was wrong** — promoted to 🚨.\n\n"
+    "### 💡 Pre-existing issues in touched files (optional)\n\n"
+    "_No pre-existing issues in touched files._\n"
+)
+TRIAGED_VIOLATION = {
+    "rule_id": "triaged-details-wrapper",
+    "line_ref": "<### 📋 Triaged verifier findings>",
+    "expected": "bullets wrapped in <details> with the summary line",
+    "actual": "section has bullets but no <details> wrapper",
+    "hint": "Re-wrap the bullets.",
+}
+
+
+def test_triaged_details_wrapper_rewraps_without_touching_bullets():
+    """The editorial pass can replace the placeholder AND the wrapper around it.
+
+    Re-wrapping must be purely additive — the triage prose is the valuable part
+    and the splicer must not reflow, reorder, or drop any of it, including the
+    struck-through 'this triage was wrong' form that isn't a bucket bullet.
+    """
+    new_body, applied, fallback = splicer.apply_splices(TRIAGED_UNWRAPPED, [TRIAGED_VIOLATION])
+    assert applied == ["triaged-details-wrapper"], (applied, fallback)
+    assert "<summary><em>I double-checked these" in new_body
+    for original in ("claim one", "claim two", "**Spurious:**", "**Mis-sourced:**",
+                     "~~**[L405]**", "This triage was wrong"):
+        assert original in new_body, original
+    # Wrapper encloses the bullets, and the neighbouring sections are untouched.
+    assert new_body.index("<details>") < new_body.index("**[L107]**") < new_body.index("</details>")
+    assert new_body.index("⚠️ Low-confidence") < new_body.index("📋 Triaged")
+    assert new_body.index("📋 Triaged") < new_body.index("💡 Pre-existing")
+
+
+def test_triaged_details_wrapper_is_idempotent():
+    once, _, _ = splicer.apply_splices(TRIAGED_UNWRAPPED, [TRIAGED_VIOLATION])
+    twice, applied, fallback = splicer.apply_splices(once, [TRIAGED_VIOLATION])
+    assert applied == [] and fallback == ["triaged-details-wrapper"], (applied, fallback)
+    assert once == twice
+
+
+def test_triaged_details_wrapper_defers_on_partial_wrapper():
+    """A <details> already open in the section is ambiguous — don't guess."""
+    partial = TRIAGED_UNWRAPPED.replace(
+        "### 📋 Triaged verifier findings\n\n",
+        "### 📋 Triaged verifier findings\n\n<details>\n<summary><em>something else</em></summary>\n\n")
+    _, applied, fallback = splicer.apply_splices(partial, [TRIAGED_VIOLATION])
+    assert applied == [] and fallback == ["triaged-details-wrapper"]

--- a/.claude/commands/docs-review/scripts/test_triaged_wrapper.py
+++ b/.claude/commands/docs-review/scripts/test_triaged_wrapper.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Tests for the `triaged-details-wrapper` rule (validate-pinned side).
+
+The splicer side lives in test_splicer.py. Self-contained:
+`python3 test_triaged_wrapper.py`, and it also collects under pytest.
+
+The negative cases carry the weight. This rule fires on a section that is
+OPTIONAL, so a false positive would soft-floor a perfectly good review over
+cosmetics — worse than the defect it catches.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, HERE / filename)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod  # so dataclasses resolve their defining module
+    spec.loader.exec_module(mod)
+    return mod
+
+
+vp = _load("validate_pinned", "validate-pinned.py")
+
+SUMMARY = ("<summary><em>I double-checked these and realized they weren't real "
+           "findings — click to expand</em></summary>")
+BULLETS = (
+    "- **[L107]** `a.md` — *\"claim one\"* — **Spurious:** wrong sibling compared.\n\n"
+    "- **[L60]** `b.md` — *\"claim two\"* — **Mis-sourced:** cited URL unrelated.\n"
+)
+
+
+def body_with(triaged: str) -> str:
+    return (
+        "### ⚠️ Low-confidence\n\n_No low-confidence findings._\n\n"
+        f"{triaged}"
+        "### 💡 Pre-existing issues in touched files (optional)\n\n"
+        "_No pre-existing issues in touched files._\n"
+    )
+
+
+def viols(body: str) -> list[str]:
+    ctx = vp.Context(body=body, body_lines=body.splitlines(), pr=None, repo=None,
+                     diff_files=[], diff_files_added=set(), diff_text="",
+                     repo_root=Path("."), is_blog=False)
+    return [v.rule_id for v in vp.check_triaged_details_wrapper(ctx)]
+
+
+WRAPPED = f"### 📋 Triaged verifier findings\n\n<details>\n{SUMMARY}\n\n{BULLETS}\n</details>\n\n"
+UNWRAPPED = f"### 📋 Triaged verifier findings\n\n{BULLETS}\n"
+EMPTY_WRAPPED = (f"### 📋 Triaged verifier findings\n\n<details>\n{SUMMARY}\n\n"
+                 "_No triaged findings._\n\n</details>\n\n")
+
+
+def test_wrapped_section_is_clean():
+    assert viols(body_with(WRAPPED)) == []
+
+
+def test_unwrapped_section_with_bullets_is_flagged():
+    assert viols(body_with(UNWRAPPED)) == ["triaged-details-wrapper"]
+
+
+def test_absent_section_is_clean():
+    """📋 is optional and not in MANDATORY_H3_SECTIONS — absence is not a defect."""
+    assert viols(body_with("")) == []
+
+
+def test_empty_placeholder_section_is_clean():
+    """An empty-but-wrapped section is strip-empty-triaged.py's business."""
+    assert viols(body_with(EMPTY_WRAPPED)) == []
+
+
+def test_unwrapped_but_bulletless_is_clean():
+    """No bullets means nothing to wrap; don't manufacture a violation."""
+    assert viols(body_with(
+        "### 📋 Triaged verifier findings\n\n_No triaged findings._\n\n")) == []
+
+
+def test_details_present_but_summary_missing_is_flagged():
+    assert viols(body_with(
+        f"### 📋 Triaged verifier findings\n\n<details>\n\n{BULLETS}\n</details>\n\n"
+    )) == ["triaged-details-wrapper"]
+
+
+def test_quoted_heading_in_a_bullet_does_not_create_a_section():
+    """A docs-review meta PR quotes the review format in its own findings.
+
+    pulumi/docs#19777 does exactly this, and a substring search for the heading
+    matches inside the quote — which is how this defect's rate was initially
+    over-counted. `find_section` requires a real column-0 H3, so the rule must
+    stay silent here.
+    """
+    body = (
+        "### 🚨 Outstanding in this PR\n\n"
+        "- **[L57]** `STYLE-GUIDE.md` — *\"### 📋 Triaged verifier findings is rendered "
+        "collapsed\"* — the guide is out of date.\n"
+    )
+    assert viols(body) == []
+
+
+def test_rule_is_registered_with_a_hint():
+    rule = next((r for r in vp.RULES if r["id"] == "triaged-details-wrapper"), None)
+    assert rule is not None, "rule must be in RULES or it never runs"
+    assert rule["hint"], "validator refuses to start without a hint"
+    assert rule["check"] is vp.check_triaged_details_wrapper
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok  {t.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL  {t.__name__}: {exc}")
+    print(f"\n{len(tests) - failed}/{len(tests)} tests passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/commands/docs-review/scripts/validate-pinned.py
+++ b/.claude/commands/docs-review/scripts/validate-pinned.py
@@ -132,7 +132,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-SCHEMA_VERSION = 19
+SCHEMA_VERSION = 20
 
 DEFAULT_OUTPUT_JSON = "/tmp/validate-pinned.fix-me.json"
 DEFAULT_OUTPUT_MARKDOWN = "/tmp/validate-pinned.fix-me.md"
@@ -2279,6 +2279,61 @@ def check_no_placeholder_empty_form(ctx: Context) -> list[Violation]:
     return violations
 
 
+TRIAGED_SUMMARY = "I double-checked these and realized they weren't real findings"
+
+
+def check_triaged_details_wrapper(ctx: Context) -> list[Violation]:
+    """📋 Triaged verifier findings keeps its collapsed `<details>` wrapper.
+
+    `compose-review.py:render_triaged` always emits the section inside a
+    `<details>` whose `<summary>` carries the line telling a reader what the
+    section IS — findings the reviewer checked and concluded were verifier
+    noise, not things to act on. The editorial pass then replaces the
+    `_No triaged findings._` placeholder with the real `**Spurious:**` /
+    `**Mis-sourced:**` bullets, and can take the wrapper out with it. The
+    section then renders expanded and unexplained, so triaged NON-findings sit
+    open on the page looking exactly like the real findings above them — the
+    opposite of what the triage was for.
+
+    Nothing else noticed: no rule covered this, `splicer.py`'s canonical block
+    only lands when the section is missing ENTIRELY, and
+    `strip-empty-triaged.py` keys on the placeholder the editorial pass just
+    removed. Rare but real — 1 of 28 published reviews carrying the section
+    (pulumi/docs#20781), and it came from the composer lane's own editorial
+    pass, not from a re-render.
+
+    Fires only when the section exists AND carries bullets. The section is
+    optional and absent from MANDATORY_H3_SECTIONS, and an empty one belongs to
+    `strip-empty-triaged.py`, not to this rule.
+    """
+    span = find_section(ctx.body, "📋 Triaged verifier findings")
+    if span is None:
+        return []
+    start, end = span
+    section = "\n".join(ctx.body_lines[start:end])
+    if not extract_bucket_bullets(ctx.body, "📋 Triaged verifier findings"):
+        return []
+    if TRIAGED_SUMMARY in section and "<details>" in section:
+        return []
+    missing = "<summary>" if "<details>" in section else "<details> wrapper"
+    return [Violation(
+        rule_id="triaged-details-wrapper",
+        line_ref="<### 📋 Triaged verifier findings>",
+        expected=(
+            "the 📋 section's bullets wrapped in `<details>` with "
+            f"`<summary><em>{TRIAGED_SUMMARY} — click to expand</em></summary>`"
+        ),
+        actual=f"section has bullets but no {missing}",
+        hint=(
+            "Re-wrap the bullets: `### 📋 Triaged verifier findings`, blank line, "
+            "`<details>`, `<summary><em>I double-checked these and realized they "
+            "weren't real findings — click to expand</em></summary>`, blank line, the "
+            "bullets, blank line, `</details>`. Keep the bullets exactly as they are — "
+            "only the wrapper is missing."
+        ),
+    )]
+
+
 def check_no_todo_tokens(ctx: Context) -> list[Violation]:
     """No `<TODO: …>` (or bare `<TODO>`) placeholder survives to the published body.
 
@@ -2558,6 +2613,12 @@ RULES = [
         "desc": "Schema v11: an explicit-empty-form line (`_No …._`) must be reader-facing — no leftover composer instructions (`per ci.md §`, `surfaced by the composer`, `docs-review:references:`, `pre-stubbed`).",
         "hint": "Replace the placeholder line with the clean reader-facing empty form (e.g. `_No pre-existing issues in touched files._`, `_No items resolved since the last review._`); 'what to add here' guidance belongs in ci.md §3, not the published body.",
         "check": check_no_placeholder_empty_form,
+    },
+    {
+        "id": "triaged-details-wrapper",
+        "desc": "Schema v20: a 📋 Triaged verifier findings section with bullets keeps its collapsed <details> wrapper and the summary line explaining what the section is.",
+        "hint": "Re-wrap the bullets in `<details>` + `<summary><em>I double-checked these and realized they weren't real findings — click to expand</em></summary>`; leave the bullets themselves alone.",
+        "check": check_triaged_details_wrapper,
     },
 ]
 


### PR DESCRIPTION
The 📋 Triaged verifier findings section is meant to render collapsed, behind a summary line that tells a reader what it *is* — findings the reviewer checked and concluded were verifier noise, not things to act on:

```markdown
### 📋 Triaged verifier findings

<details>
<summary><em>I double-checked these and realized they weren't real findings — click to expand</em></summary>
…
</details>
```

`compose-review.py:render_triaged` always emits that. The **editorial pass** then swaps the `_No triaged findings._` placeholder for the real `**Spurious:**` / `**Mis-sourced:**` bullets — and can take the wrapper out with it. The section then renders expanded and unexplained, so triaged **non**-findings sit open on the page looking exactly like the real findings above them. That's the opposite of what the triage was for.

## Why nothing caught it

- **No rule.** `validate-pinned.py` had nothing covering the wrapper — it only counted the bullets.
- **`splicer.py`'s canonical block only lands when the section is missing *entirely*** (via `mandatory-h3-order`), not when it's present-but-unwrapped.
- **`strip-empty-triaged.py`** keys on the `_No triaged findings._` placeholder — the exact thing the editorial pass had just removed.

Found on pulumi/docs#20781, which has rendered that way since its first review on 2026-08-09.

## The fix

`triaged-details-wrapper` (schema v20) plus a surgical splicer, so the composer lane repairs it before publish instead of soft-flooring.

**The splice is purely additive.** It rebuilds the wrapper around the bullets and never reflows, reorders, or drops any of them — including the struck-through "this triage was wrong" form that isn't a bucket bullet. The triage prose is the valuable part; only the furniture was missing. It defers to the fallback lane if a `<details>` is already open in the section, because a partial wrapper is ambiguous and guessing would be worse than not fixing.

**The rule fires only when the section exists *and* has bullets.** 📋 is optional and absent from `MANDATORY_H3_SECTIONS`, and an empty one is `strip-empty-triaged.py`'s business. A false positive here would soft-floor a good review over cosmetics — worse than the defect.

## Verification

| check | result |
| :--- | :--- |
| New rule tests | 8/8 |
| Splicer tests | 25/25 |
| Full docs-review suite | 183 passed |
| **40 real published reviews** | 0 flagged, 27 correctly wrapped, 13 no such section |
| **Full validator vs `origin/master` on those 40** | byte-identical exit codes, 40/40 |
| Real defective body (#20781) | flagged → spliced → 0 remaining, 0 content lost |
| Workflow chain replicated at the CLI | validate → fix-me JSON → splicer → re-validate, emoji `line_ref` survives the JSON round-trip |

### Fork smoke test (CamSoper/pulumi.docs#235)

1. **Normal composer run** — review published, validator `rc=0`, no 📋 section (nothing was triaged, so `strip-empty-triaged.py` correctly removed the placeholder). No regression.
2. **Fault-injected run** — a fork-only prompt instruction forced an unwrapped section with two `**Spurious:**` bullets. Job log:

   ```
   splicer.py: applied surgical fixes for rule(s): triaged-details-wrapper
   ```

   Published body: wrapper present, both bullets preserved, `<details>` balanced, validator `rc=0`.

`cam-fork/master` has been reset to the incumbent.

## One note on how rare this is

I first measured it as 2 of 28 published reviews. That was wrong, and the second "case" is instructive: pulumi/docs#19777 is a docs-review meta PR whose own findings *quote* the review format, so a substring search for the heading matched in a body that has no such section. `find_section` requires a real column-0 H3. The real rate is **1 of 28**, and there's a regression test for exactly that trap.