### PR TITLE
Self-hosted changelog: tightened ESC environment encryption checks (August 2026)

### DIFF
--- a/content/docs/administration/self-hosting/changelog.md
+++ b/content/docs/administration/self-hosting/changelog.md
@@ -19,6 +19,14 @@ aliases:
 
 ## 2026
 
+### August
+
+* Tightened encryption checks for Pulumi ESC environments: ciphertext that was copied from another environment is now blocked when the environment is opened
+
+{{< notes type="info" >}}
+If an environment fails to open because of this check, set the `PULUMI_DISABLE_CRYPTO_ACCESS_ENFORCEMENT=true` environment variable, create a new revision of the affected environment from its plaintext values, and then remove the environment variable again.
+{{< /notes >}}
+
 ### April
 
 * Added SSRF (server-side request forgery) protection to Pulumi ESC providers to prevent requests to private, loopback, and link-local IP addresses


### PR DESCRIPTION
Adds an August 2026 entry to the self-hosted changelog covering the tightened Pulumi ESC environment encryption checks that ship with the next self-hosted release (pulumi/pulumi-service#47469): ciphertext that was copied from another environment is now blocked when the environment is opened.

The accompanying note tells admins who hit the check what to do: set `PULUMI_DISABLE_CRYPTO_ACCESS_ENFORCEMENT=true`, create a new revision of the affected environment from its plaintext values, then remove the env var again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)