### PR TITLE
Close the three deferred pipeline items from #20811

### DIFF
--- a/.claude/commands/docs-review/references/update.md
+++ b/.claude/commands/docs-review/references/update.md
@@ -22,9 +22,36 @@ The skill loads everything else for itself:
 bash .claude/commands/docs-review/scripts/pinned-comment.sh fetch --pr "$PR_NUMBER"
 # Returns the full body of every CLAUDE_REVIEW N/M comment, in order, separated by markers.
 
-# Diff since the last review
+# Diff since the last review.
+#
+# NOT `gh pr diff --range` — that flag does not exist, so the call failed with
+# "unknown flag" on every invocation and this lane silently re-read the whole
+# PR every time. The compare API also works under CI's shallow checkout, which
+# a local `git diff "$LAST_SHA..HEAD"` would not.
+#
+# Branch on `.status`, NOT on the exit code. A force-pushed-away commit usually
+# still exists in the repo network, so comparing against it returns HTTP 200
+# with status "diverged" — only a SHA GitHub has never seen 404s. Keying the
+# force-push fallback on a non-zero exit would therefore never fire it.
 LAST_SHA=$(bash .claude/commands/docs-review/scripts/pinned-comment.sh last-reviewed-sha --pr "$PR_NUMBER")
-gh pr diff "$PR_NUMBER" --range "$LAST_SHA..HEAD"
+HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)
+CMP=$(gh api "repos/{owner}/{repo}/compare/$LAST_SHA...$HEAD_SHA" 2>/dev/null || echo '')
+STATUS=$(printf '%s' "$CMP" | jq -r '.status // empty')
+
+case "$STATUS" in
+  identical)  : ;;   # no new commits — Range-empty case below
+  ahead)
+    # Scope to files the PR itself touches. `compare` is three-dot, so when the
+    # author rebased or merged master forward between reviews the range also
+    # carries master's own commits — reviewing those would raise findings on
+    # files the author never touched.
+    KEEP=$(gh pr view "$PR_NUMBER" --json files --jq '[.files[].path]')
+    printf '%s' "$CMP" | jq -r --argjson keep "$KEEP" '
+      .files[] | select(.filename as $f | $keep | index($f))
+      | "--- \(.filename)\n\(.patch // "(no patch: binary, or file too large)")"'
+    ;;
+  *)          : ;;   # diverged / behind / empty → history rewritten; see fallbacks
+esac
 
 # Current PR state (including draft status)
 gh pr view "$PR_NUMBER" --json title,body,isDraft,labels,files,headRefOid,headRefName
@@ -39,7 +66,7 @@ When `MENTION_AUTHOR` is `auto-refresh`, there is no human mention: the run was 
 **Fallback rules when `last-reviewed-sha` is unusable:**
 
 - **Empty output** (history line missing, comment corrupted): fall back to a full `gh pr diff "$PR_NUMBER"` (no range). Treat the whole PR as new content; this is equivalent to starting over.
-- **SHA unreachable** (author force-pushed and rewrote history, or CI's shallow checkout doesn't have it): `gh pr diff --range "$LAST_SHA..HEAD"` will fail with "unknown revision" or similar. Detect the non-zero exit (and any `git rev-parse --verify` failure) and fall back to full `gh pr diff "$PR_NUMBER"`. Append a 📜 Review history line noting the force-push detection: `<timestamp> — history rewritten since last review; re-reviewed against HEAD (<SHA>)`.
+- **History rewritten** (author force-pushed, so the recorded SHA is no longer an ancestor of HEAD): `.status` comes back `diverged` or `behind` — **not** a 404 and **not** a non-zero exit. GitHub keeps force-pushed-away commits in the repo network, so the compare still succeeds with HTTP 200; only a SHA it has never seen 404s. Fall back to full `gh pr diff "$PR_NUMBER"` and append a 📜 Review history line: `<timestamp> — history rewritten since last review; re-reviewed against HEAD (<SHA>)`. Keying this on the exit code instead of `.status` would mean the fallback never fires and the lane silently reviews a merge-base diff while recording that it reviewed the delta.
 - **Range empty** (`LAST_SHA` points at `HEAD`): no new commits since last review. Treat as Case 3 re-verify with no new content; do not re-extract claims.
 
 ---

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -365,8 +365,34 @@ jobs:
           fi
           vale --no-exit --output=JSON $CHANGED > .vale-raw.json 2>/dev/null \
             || echo '{}' > .vale-raw.json
+          # Vale renders markdown to HTML before applying rules, so bracket
+          # constructions (`[here](url)`, `![](url)`) are gone before tokens
+          # match. markdown-syntax-findings.py scans the raw markdown and emits
+          # Vale-shaped JSON, merged in before filtering. This block mirrors
+          # claude-code-review.yml — without it a refresh dropped the two rules
+          # it contributes (Pulumi.EmptyAltText, Pulumi.LinkText) from a review
+          # the initial pass had raised them on.
+          #
+          # This affects the ADVISORY tier only. Neither rule is blocker-tier
+          # (see vale-deterministic-fixes.yaml), so the [style-blocker] set is
+          # byte-identical with and without this merge, and the provenance
+          # check downstream is unaffected. Note Pulumi.LinkText flags *vague*
+          # link text — there is no broken-link detector here.
+          python3 .claude/commands/docs-review/scripts/markdown-syntax-findings.py \
+            $CHANGED > .syntax-findings.json \
+            || echo '{}' > .syntax-findings.json
+          # Concatenate per-file alert arrays (jq's `*` shallow-merges and would
+          # *replace* Vale's array with the script's for any overlapping file).
+          jq -s 'reduce .[] as $o ({}; reduce ($o | keys_unsorted[]) as $k (.; .[$k] = ((.[$k] // []) + $o[$k])))' \
+            .vale-raw.json .syntax-findings.json > .vale-raw.merged.json \
+            && mv .vale-raw.merged.json .vale-raw.json \
+            || true
+          # No 2>/dev/null on the filter: it has no safe_main wrapper, so the
+          # redirect discarded the only trace of a crash. (Vale's own stderr
+          # above is still redirected — it is noisy and exits 0 regardless.)
+          # The `||` fallback still keeps the lane green.
           python3 .claude/commands/docs-review/scripts/vale-findings-filter.py \
-            --pr "$PR" --in .vale-raw.json --out .vale-findings.json 2>/dev/null \
+            --pr "$PR" --in .vale-raw.json --out .vale-findings.json \
             || echo '[]' > .vale-findings.json
 
       # Post a transient <!-- CLAUDE_PROGRESS --> comment so the author

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -306,8 +306,7 @@ jobs:
             || echo "review ledger unavailable; selection proceeds on git staleness alone"
 
       # Deterministic selection: the model never chooses what to review.
-      # Writes has_articles= / halted= / count= to $GITHUB_OUTPUT for the
-      # gates below.
+      # Writes has_articles= / halted= to $GITHUB_OUTPUT for the gates below.
       - name: Select articles
         id: select
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,10 @@ _vendor/
 /.cross-sibling-discovery.json
 /.readthrough-findings.json
 /.syntax-findings.json
+# Intermediate of the Vale + markdown-syntax merge. Survives exactly when the
+# `jq` merge fails, which is the case its `|| true` exists to tolerate — and the
+# update lane runs with contents: write.
+/.vale-raw.merged.json
 /.editorial-balance.json
 /.hugo-build.json
 /.pr-body-draft.md

--- a/scripts/blog-review/select-posts.py
+++ b/scripts/blog-review/select-posts.py
@@ -62,28 +62,54 @@ Usage:
 
 `--paths` bypasses scoring entirely (workflow_dispatch testing). `--today`
 exists for tests. When `$GITHUB_OUTPUT` is set, the script appends
-`has_posts=`, `halted=`, and `count=` for workflow gating.
+`has_posts=` and `halted=` for workflow gating.
 """
 
 from __future__ import annotations
 
 import argparse
-import csv
-import io
 import json
 import math
-import os
-import re
-import subprocess
 import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
 
 import yaml
 
+# Infrastructure this selector shares with scripts/content-review/select-articles.py —
+# see _selector_common.py's docstring for why it is shared rather than copied. The
+# shared module lives in the docs selector's directory, so put that directory on
+# the path explicitly: the workflow runs this script as
+# `python3 scripts/blog-review/select-posts.py` from the repo root, which puts
+# only *this* directory on sys.path.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "content-review"))
+
+from _selector_common import (  # noqa: E402  (needs the sys.path insert above)
+    FRONTMATTER_RE,
+    INCOMPLETE_STATUS,
+    Lane,
+    cmd_prune,
+    effective_last_review,
+    finish,
+    git_history_signals,
+    load_ledger,
+    load_traffic,
+    normalize_url_path,
+    parse_day,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_LEDGER_DIR = REPO_ROOT / "scripts/blog-review/ledger"
 CONTENT_DIR = "content/blog"
+
+# How the shared helpers in _selector_common.py address this lane.
+LANE = Lane(
+    prog="select-posts",
+    items_key="posts",
+    corpus_noun="post",
+    item_noun="post",
+    has_output="has_posts",
+)
 
 # An `incomplete` review (worker exited before recording valid findings)
 # never advances the staleness clock, so the post stays due and is retried
@@ -103,21 +129,6 @@ MIN_AGE_DAYS = 90
 # it reorders comparably stale peers without overriding staleness.
 GSC_MIN_IMPRESSIONS = 200  # below this, CTR is noise -> neutral
 GSC_BOOST_MAX = 0.25  # gsc multiplier in [1.0, 1.25]
-
-# Statuses a ledger entry can carry (set by record-findings.py). Any status
-# other than "incomplete" is a completed review whose date advances the clock.
-INCOMPLETE_STATUS = "incomplete"
-
-# "Pulumi Bot" (display name) is how the SDK-regen tooling authors its
-# commits; "pulumi-bot" is how the review workflows configure git. Both are
-# the same bot and neither resets a post's staleness clock, and neither does
-# "workprentice[bot]", the docs automation app.
-BOT_AUTHORS = {
-    "pulumi-bot", "Pulumi Bot", "workprentice[bot]",
-    "dependabot[bot]", "github-actions[bot]",
-}
-
-FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
 
 
 # ---- Path helpers -----------------------------------------------------------
@@ -145,10 +156,7 @@ def url_for(content_path: str) -> str:
 
 def content_path_for_url(url_path: str, known_paths: set[str]) -> str | None:
     """Map a live /blog/... URL path back to its content bundle, if it exists."""
-    p = url_path.split("#", 1)[0].split("?", 1)[0].strip()
-    if p.startswith("https://"):
-        p = re.sub(r"^https://[^/]+", "", p)
-    p = "/" + p.strip("/")
+    p = normalize_url_path(url_path)
     candidate = f"content{p}/index.md"
     if candidate in known_paths:
         return candidate
@@ -156,56 +164,6 @@ def content_path_for_url(url_path: str, known_paths: set[str]) -> str | None:
 
 
 # ---- Input loading ----------------------------------------------------------
-
-
-def load_traffic(traffic_file: Path | None, known_paths: set[str]) -> tuple[dict[str, int], dict]:
-    """Parse the S3 traffic snapshot (JSON or CSV) into {content_path: visits}.
-
-    Returns ({}, meta) when the file is missing/unreadable — selection then
-    drops the traffic term entirely (graceful degradation).
-    """
-    meta = {"source": None, "period": None, "pages_matched": 0}
-    if traffic_file is None or not traffic_file.is_file():
-        return {}, meta
-    raw = traffic_file.read_text(errors="replace").strip()
-    if not raw:
-        return {}, meta
-
-    pages: dict[str, int] = {}
-
-    def record(url_path: str, views) -> None:
-        try:
-            views = int(float(views))
-        except (TypeError, ValueError):
-            return
-        cp = content_path_for_url(str(url_path), known_paths)
-        if cp:
-            # A URL and its aliases may both appear; credit the same post once
-            # with the larger figure rather than double-counting.
-            pages[cp] = max(pages.get(cp, 0), views)
-
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        data = None
-
-    if isinstance(data, dict):
-        meta["source"] = data.get("source")
-        meta["period"] = data.get("period") or data.get("generated")
-        body = data.get("pages", data)
-        if isinstance(body, dict):
-            for url_path, views in body.items():
-                record(url_path, views)
-    elif data is None:
-        # CSV: `path,views` with an optional header row.
-        reader = csv.reader(io.StringIO(raw))
-        for row in reader:
-            if len(row) < 2:
-                continue
-            record(row[0], row[1])
-
-    meta["pages_matched"] = len(pages)
-    return pages, meta
 
 
 def load_reader_signals(
@@ -282,34 +240,6 @@ def load_reader_signals(
     return gsc, meta
 
 
-def load_ledger(ledger_dir: Path) -> dict[str, dict]:
-    """Return {content_path: ledger entry} from one-file-per-post JSON."""
-    entries: dict[str, dict] = {}
-    if not ledger_dir.is_dir():
-        # Not fatal — the workflow only passes --ledger-dir when the S3 sync
-        # produced one — but never silent: with no ledger every post scores as
-        # never-reviewed, which is a very different queue. DEFAULT_LEDGER_DIR is
-        # the in-repo path this script has never actually had, so a run that
-        # falls back to it is one that meant to read the S3 cache and didn't.
-        print(
-            f"select-posts: no ledger directory at {ledger_dir}; scoring every "
-            "post as never-reviewed",
-            file=sys.stderr,
-        )
-        return entries
-    for f in sorted(ledger_dir.glob("*.json")):
-        try:
-            entry = json.loads(f.read_text())
-        except (OSError, json.JSONDecodeError):
-            print(f"select-posts: unreadable ledger file {f}", file=sys.stderr)
-            continue
-        path = entry.get("path")
-        if path:
-            entry["_file"] = str(f)
-            entries[path] = entry
-    return entries
-
-
 # ---- Frontmatter ------------------------------------------------------------
 
 
@@ -341,97 +271,7 @@ def publish_date(fm: dict) -> date | None:
     return parse_day(str(d)) if d else None
 
 
-# ---- Git signals (single-pass, no per-file subprocess fan-out) ---------------
-
-
-def git_history_signals(repo: Path) -> tuple[dict[str, int], dict[str, int]]:
-    """Per-path git timestamps for content/blog, from one history pass.
-
-    Walks history newest-first and returns two maps of unix commit times:
-
-      newest_non_bot : the most recent commit by a *non-bot* author that
-                       touched the path (a human edit — resets the staleness
-                       clock). Absent for posts only ever touched by bots.
-      created        : the oldest commit that touched the path, the fallback
-                       clock when a post's frontmatter carries no usable date.
-    """
-    out = run_git(repo, ["log", "--name-only", "--format=%x01%ct%x01%an", "--", CONTENT_DIR])
-    newest_non_bot: dict[str, int] = {}
-    created: dict[str, int] = {}
-    current_ct = 0
-    author_is_bot = True
-    for line in out.splitlines():
-        if line.startswith("\x01"):
-            # Header line is "\x01<commit-time>\x01<author-name>".
-            parts = line.split("\x01")
-            ct = parts[1] if len(parts) > 1 else ""
-            an = parts[2] if len(parts) > 2 else ""
-            try:
-                current_ct = int(ct.strip())
-            except ValueError:
-                current_ct = 0
-            author_is_bot = an.strip() in BOT_AUTHORS
-        elif line.strip():
-            path = line.strip()
-            created[path] = current_ct  # last write wins -> oldest commit
-            if not author_is_bot and path not in newest_non_bot:
-                newest_non_bot[path] = current_ct
-    return newest_non_bot, created
-
-
-def run_git(repo: Path, args: list[str]) -> str:
-    proc = subprocess.run(
-        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=False
-    )
-    return proc.stdout
-
-
 # ---- Scoring -----------------------------------------------------------------
-
-
-def parse_day(s: str | None) -> date | None:
-    if not s:
-        return None
-    try:
-        return datetime.fromisoformat(str(s).replace("Z", "+00:00")).date()
-    except ValueError:
-        try:
-            return datetime.strptime(str(s), "%Y-%m-%d").date()
-        except ValueError:
-            return None
-
-
-def _ts_to_day(ts: int | None) -> date | None:
-    if not ts:
-        return None
-    return datetime.fromtimestamp(ts, tz=timezone.utc).date()
-
-
-def effective_last_review(
-    path: str,
-    entry: dict | None,
-    newest_non_bot: dict[str, int],
-    published: date | None,
-    created: dict[str, int],
-) -> date | None:
-    """The date the staleness clock is measured from.
-
-    max(completed bot review, newest human edit); an `incomplete` review does
-    not count, so the post stays due. Never-reviewed posts fall back to their
-    publish date (frontmatter `date`), then to the git creation date. None
-    only when the post has no usable date at all.
-    """
-    cands: list[date] = []
-    if entry:
-        reviewed = parse_day(entry.get("reviewed_at"))
-        if reviewed and entry.get("status") != INCOMPLETE_STATUS:
-            cands.append(reviewed)
-    human = _ts_to_day(newest_non_bot.get(path))
-    if human:
-        cands.append(human)
-    if cands:
-        return max(cands)
-    return published or _ts_to_day(created.get(path))
 
 
 def gsc_multiplier(
@@ -491,7 +331,7 @@ def score_post(
 
 
 def cmd_stats(ledger_dir: Path) -> int:
-    entries = load_ledger(ledger_dir)
+    entries = load_ledger(ledger_dir, LANE)
     counts = {"reviewed": 0, "clean": 0, "skipped": 0,
               "incomplete": 0, "capped": 0, "other": 0}
     with_issues = 0
@@ -513,31 +353,7 @@ def cmd_stats(ledger_dir: Path) -> int:
     return 0
 
 
-def cmd_prune(ledger_dir: Path, repo: Path, dry_run: bool) -> int:
-    pruned = []
-    for path, entry in load_ledger(ledger_dir).items():
-        if not (repo / path).is_file():
-            pruned.append(entry["_file"])
-            if not dry_run:
-                Path(entry["_file"]).unlink()
-    verb = "would prune" if dry_run else "pruned"
-    print(f"select-posts: {verb} {len(pruned)} orphaned ledger file(s)")
-    for f in pruned:
-        print(f"  {f}")
-    return 0
-
-
 # ---- Main ----------------------------------------------------------------------
-
-
-def write_github_output(queue: dict) -> None:
-    gh_out = os.environ.get("GITHUB_OUTPUT")
-    if not gh_out:
-        return
-    with open(gh_out, "a") as fh:
-        fh.write(f"has_posts={'true' if queue['posts'] else 'false'}\n")
-        fh.write(f"halted={queue.get('halted') or ''}\n")
-        fh.write(f"count={len(queue['posts'])}\n")
 
 
 def main() -> int:
@@ -562,12 +378,12 @@ def main() -> int:
     if args.stats:
         return cmd_stats(ledger_dir)
     if args.prune:
-        return cmd_prune(ledger_dir, repo, args.dry_run)
+        return cmd_prune(ledger_dir, repo, args.dry_run, LANE)
     if not args.out and not args.dry_run:
         p.error("--out is required (or use --dry-run/--stats/--prune)")
 
     today = parse_day(args.today) or datetime.now(timezone.utc).date()
-    ledger = load_ledger(ledger_dir)
+    ledger = load_ledger(ledger_dir, LANE)
 
     all_paths = sorted(
         str(f.relative_to(repo)) for f in (repo / CONTENT_DIR).glob("*/index.md")
@@ -576,7 +392,7 @@ def main() -> int:
     frontmatter = {path: read_frontmatter(repo / path) for path in all_paths}
 
     traffic, traffic_meta = load_traffic(
-        Path(args.traffic_file) if args.traffic_file else None, known
+        Path(args.traffic_file) if args.traffic_file else None, known, content_path_for_url
     )
     have_traffic = bool(traffic)
     visits_known = sorted(traffic.values())
@@ -642,9 +458,9 @@ def main() -> int:
                 print(f"select-posts: --paths entry not found: {path}", file=sys.stderr)
                 return 1
             queue["posts"].append(post(path, lane, None))
-        return finish(queue, args)
+        return finish(queue, args, LANE)
 
-    newest_non_bot, created = git_history_signals(repo)
+    newest_non_bot, created = git_history_signals(repo, CONTENT_DIR)
 
     candidates: list[str] = []
     capped: list[str] = []
@@ -678,8 +494,8 @@ def main() -> int:
                 max_visits,
                 median_visits,
                 effective_last_review(
-                    path, ledger.get(path), newest_non_bot,
-                    publish_date(frontmatter.get(path, {})), created,
+                    path, ledger.get(path), newest_non_bot, created,
+                    fallback=publish_date(frontmatter.get(path, {})),
                 ),
                 today,
                 have_traffic,
@@ -696,26 +512,7 @@ def main() -> int:
     for score, path in scored[: max(args.count, 0)]:
         queue["posts"].append(post(path, "priority", score))
 
-    return finish(queue, args)
-
-
-def finish(queue: dict, args) -> int:
-    queue["count"] = len(queue["posts"])
-    body = json.dumps(queue, indent=2)
-    if args.dry_run or not args.out:
-        print(body)
-    else:
-        out = Path(args.out)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(body + "\n")
-        print(
-            f"select-posts: {queue['count']} post(s)"
-            + (f" (halted: {queue['halted']})" if queue["halted"] else "")
-            + f" → {out}",
-            file=sys.stderr,
-        )
-    write_github_output(queue)
-    return 0
+    return finish(queue, args, LANE)
 
 
 if __name__ == "__main__":

--- a/scripts/blog-review/test_select_posts.py
+++ b/scripts/blog-review/test_select_posts.py
@@ -263,7 +263,9 @@ def _case_paths_override_and_output(tmp: Path) -> None:
     check(q["posts"][0]["slug"] == "recent-post", "slug is the bundle dir name")
     check(q["posts"][0]["url"] == "/blog/recent-post/", "url derived from the bundle")
     out = gh_out.read_text()
-    check("has_posts=true" in out and "count=1" in out and "halted=\n" in out,
+    # `count=` was written here but no workflow ever read it; asserting its
+    # absence keeps it from drifting back in.
+    check("has_posts=true" in out and "halted=\n" in out and "count=" not in out,
           f"GITHUB_OUTPUT contract, got: {out!r}")
 
     proc = subprocess.run(

--- a/scripts/content-review/_selector_common.py
+++ b/scripts/content-review/_selector_common.py
@@ -1,0 +1,346 @@
+"""Infrastructure shared by the two review-queue selectors.
+
+`scripts/content-review/select-articles.py` (docs pages) and
+`scripts/blog-review/select-posts.py` (blog posts) are deliberately separate
+selectors — they score different corpora against different signals — but they
+sit on the same plumbing: the same bot-author list, the same single-pass git
+history read, the same ledger loader, the same date parsing, the same
+`$GITHUB_OUTPUT` and queue-writing tail. This module is that plumbing, held in
+exactly one place.
+
+Why it exists, so nobody re-inlines it later
+--------------------------------------------
+BOT_AUTHORS was copied rather than shared, and the copies drifted. "Pulumi Bot"
+and "workprentice[bot]" were added to one selector's set after a bot touch was
+found resetting the staleness clock on ~65% of `content/docs` pages — and the
+fix was never back-ported, so on the other lane bot commits went on looking
+like human edits. That is the whole argument for this file: a duplicated
+constant does not stay in sync, and nothing in either script made the drift
+visible.
+
+So: anything genuinely common lives here and only here. "Keeping the selector
+self-contained" is precisely what caused the bug.
+
+What deliberately stays duplicated
+----------------------------------
+The *scoring* does not belong here — tier weights, the GSC/feedback tuning
+constants, the multipliers, each lane's URL-to-path mapping, and each lane's
+retry cap. Those legitimately differ per corpus, and a shared knob that
+silently retuned the other lane would be this bug wearing a different hat.
+Where a helper differs only in wording or in one value, the difference is
+passed in explicitly (see `Lane`) rather than smoothed over — a caller that has
+to name its own noun cannot accidentally inherit the other lane's behavior.
+
+Import path
+-----------
+`select-posts.py` lives in a sibling directory, so both scripts bootstrap onto
+this module with an explicit `sys.path` insert anchored on `__file__` (see the
+import block in each). That works for every way they are invoked: as
+`python3 scripts/<dir>/<name>.py` from the repo root (how the workflows run
+them), directly, and loaded by path via `importlib` from elsewhere in the tree
+(`record-review.py`, `check-retire-veto.py`, `record-claims.py`,
+`snippet-sweep/sweep.py` all do this).
+
+Standard library only — no third-party imports, so neither lane grows a
+dependency by reaching for a helper.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+# "Pulumi Bot" (display name) is how the SDK-regen tooling authors its commits
+# and "pulumi-bot" is how the review workflows configure git — the same bot
+# either way; "workprentice[bot]" is the docs automation app. None of them is a
+# human edit, so none resets a page's staleness clock. Missing names here are
+# expensive: a single bot touch would otherwise look like a fresh human edit and
+# park the page at the back of the queue.
+BOT_AUTHORS = {
+    "pulumi-bot", "Pulumi Bot", "workprentice[bot]",
+    "dependabot[bot]", "github-actions[bot]",
+}
+
+# Statuses a ledger entry can carry (set by record-review.py / record-findings.py).
+# Any status other than "incomplete" is a completed review whose date advances
+# the clock; legacy entries predating the field have no `status` and are treated
+# as completed.
+INCOMPLETE_STATUS = "incomplete"
+
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class Lane:
+    """Every per-lane string and flag a shared helper needs, in one object.
+
+    The helpers below are identical across the two selectors *except* for how
+    they address the reader: which prefix they log under, which key holds the
+    queue's items, what a corpus entry is called. Collecting those here keeps
+    the differences visible and reviewable in one place instead of scattered
+    through five keyword arguments — and makes each per-lane asymmetry hard
+    to acquire by accident.
+    """
+
+    prog: str  # log prefix: "select-articles" / "select-posts"
+    items_key: str  # queue key holding the selected items: "articles" / "posts"
+    corpus_noun: str  # what the corpus is made of: "page" / "post"
+    item_noun: str  # what a queue entry is: "article" / "post"
+    has_output: str  # $GITHUB_OUTPUT boolean key: "has_articles" / "has_posts"
+
+
+# ---- Git signals (single-pass, no per-file subprocess fan-out) ---------------
+
+
+def run_git(repo: Path, args: list[str]) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=False
+    )
+    return proc.stdout
+
+
+def git_history_signals(repo: Path, content_dir: str) -> tuple[dict[str, int], dict[str, int]]:
+    """Per-path git timestamps for `content_dir`, from one history pass.
+
+    Walks history newest-first and returns two maps of unix commit times:
+
+      newest_non_bot : the most recent commit by a *non-bot* author that
+                       touched the path (a human edit — resets the staleness
+                       clock). Absent for entries only ever touched by bots.
+      created        : the oldest commit that touched the path (its creation),
+                       the fallback clock when nothing else dates the entry.
+    """
+    out = run_git(repo, ["log", "--name-only", "--format=%x01%ct%x01%an", "--", content_dir])
+    newest_non_bot: dict[str, int] = {}
+    created: dict[str, int] = {}
+    current_ct = 0
+    author_is_bot = True
+    for line in out.splitlines():
+        if line.startswith("\x01"):
+            # Header line is "\x01<commit-time>\x01<author-name>".
+            parts = line.split("\x01")
+            ct = parts[1] if len(parts) > 1 else ""
+            an = parts[2] if len(parts) > 2 else ""
+            try:
+                current_ct = int(ct.strip())
+            except ValueError:
+                current_ct = 0
+            author_is_bot = an.strip() in BOT_AUTHORS
+        elif line.strip():
+            path = line.strip()
+            created[path] = current_ct  # last write wins -> oldest commit
+            if not author_is_bot and path not in newest_non_bot:
+                newest_non_bot[path] = current_ct
+    return newest_non_bot, created
+
+
+# ---- Dates -------------------------------------------------------------------
+
+
+def parse_day(s: str | None) -> date | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(str(s).replace("Z", "+00:00")).date()
+    except ValueError:
+        try:
+            return datetime.strptime(str(s), "%Y-%m-%d").date()
+        except ValueError:
+            return None
+
+
+def ts_to_day(ts: int | None) -> date | None:
+    if not ts:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).date()
+
+
+def effective_last_review(
+    path: str,
+    entry: dict | None,
+    newest_non_bot: dict[str, int],
+    created: dict[str, int],
+    fallback: date | None = None,
+) -> date | None:
+    """The date the staleness clock is measured from.
+
+    max(completed bot review, newest human edit); an `incomplete` review does
+    not count, so the entry stays due. Never-reviewed entries fall back to
+    `fallback` when the lane has a better date than git (the blog lane passes
+    the post's frontmatter publish date; the docs lane has no such field and
+    passes nothing), then to the git creation date. None only when the entry
+    has no usable date at all.
+    """
+    cands: list[date] = []
+    if entry:
+        reviewed = parse_day(entry.get("reviewed_at"))
+        if reviewed and entry.get("status") != INCOMPLETE_STATUS:
+            cands.append(reviewed)
+    human = ts_to_day(newest_non_bot.get(path))
+    if human:
+        cands.append(human)
+    if cands:
+        return max(cands)
+    return fallback or ts_to_day(created.get(path))
+
+
+# ---- Input loading ----------------------------------------------------------
+
+
+def normalize_url_path(url_path: str) -> str:
+    """Strip fragment, query, and origin from a reported URL; return "/a/b".
+
+    The half of URL-to-content-path resolution the two lanes share. Which
+    filenames a normalized path maps onto is lane-specific (docs tries both a
+    leaf `.md` and an `_index.md`; blogs are always bundles), so each selector
+    keeps its own `content_path_for_url` on top of this.
+    """
+    p = url_path.split("#", 1)[0].split("?", 1)[0].strip()
+    if p.startswith("https://"):
+        p = re.sub(r"^https://[^/]+", "", p)
+    return "/" + p.strip("/")
+
+
+def load_traffic(
+    traffic_file: Path | None,
+    known_paths: set[str],
+    resolve: Callable[[str, set[str]], str | None],
+) -> tuple[dict[str, int], dict]:
+    """Parse the S3 traffic snapshot (JSON or CSV) into {content_path: visits}.
+
+    `resolve` is the lane's URL-to-content-path mapper, which is the only part
+    of this that differs between corpora.
+
+    Returns ({}, meta) when the file is missing/unreadable — selection then
+    drops the traffic term entirely (graceful degradation).
+    """
+    meta = {"source": None, "period": None, "pages_matched": 0}
+    if traffic_file is None or not traffic_file.is_file():
+        return {}, meta
+    raw = traffic_file.read_text(errors="replace").strip()
+    if not raw:
+        return {}, meta
+
+    pages: dict[str, int] = {}
+
+    def record(url_path: str, views) -> None:
+        try:
+            views = int(float(views))
+        except (TypeError, ValueError):
+            return
+        cp = resolve(str(url_path), known_paths)
+        if cp:
+            # A URL and its aliases may both appear; credit the same file once
+            # with the larger figure rather than double-counting.
+            pages[cp] = max(pages.get(cp, 0), views)
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        data = None
+
+    if isinstance(data, dict):
+        meta["source"] = data.get("source")
+        meta["period"] = data.get("period") or data.get("generated")
+        body = data.get("pages", data)
+        if isinstance(body, dict):
+            for url_path, views in body.items():
+                record(url_path, views)
+    elif data is None:
+        # CSV: `path,views` with an optional header row.
+        reader = csv.reader(io.StringIO(raw))
+        for row in reader:
+            if len(row) < 2:
+                continue
+            record(row[0], row[1])
+
+    meta["pages_matched"] = len(pages)
+    return pages, meta
+
+
+def load_ledger(ledger_dir: Path, lane: Lane) -> dict[str, dict]:
+    """Return {content_path: ledger entry} from one-file-per-entry JSON."""
+    entries: dict[str, dict] = {}
+    if not ledger_dir.is_dir():
+        # Not fatal — the workflow only passes --ledger-dir when the S3 sync
+        # produced one — but never silent: with no ledger every entry scores as
+        # never-reviewed, which is a very different queue. DEFAULT_LEDGER_DIR is
+        # the in-repo path these scripts have never actually had, so a run that
+        # falls back to it is one that meant to read the S3 cache and didn't.
+        print(
+            f"{lane.prog}: no ledger directory at {ledger_dir}; scoring every "
+            f"{lane.corpus_noun} as never-reviewed",
+            file=sys.stderr,
+        )
+        return entries
+    for f in sorted(ledger_dir.glob("*.json")):
+        try:
+            entry = json.loads(f.read_text())
+        except (OSError, json.JSONDecodeError):
+            print(f"{lane.prog}: unreadable ledger file {f}", file=sys.stderr)
+            continue
+        path = entry.get("path")
+        if path:
+            entry["_file"] = str(f)
+            entries[path] = entry
+    return entries
+
+
+# ---- Subcommands -------------------------------------------------------------
+
+
+def cmd_prune(ledger_dir: Path, repo: Path, dry_run: bool, lane: Lane) -> int:
+    """GC ledger entries whose content file no longer exists."""
+    pruned = []
+    for path, entry in load_ledger(ledger_dir, lane).items():
+        if not (repo / path).is_file():
+            pruned.append(entry["_file"])
+            if not dry_run:
+                Path(entry["_file"]).unlink()
+    verb = "would prune" if dry_run else "pruned"
+    print(f"{lane.prog}: {verb} {len(pruned)} orphaned ledger file(s)")
+    for f in pruned:
+        print(f"  {f}")
+    return 0
+
+
+# ---- Output ------------------------------------------------------------------
+
+
+def write_github_output(queue: dict, lane: Lane) -> None:
+    gh_out = os.environ.get("GITHUB_OUTPUT")
+    if not gh_out:
+        return
+    items = queue[lane.items_key]
+    with open(gh_out, "a") as fh:
+        fh.write(f"{lane.has_output}={'true' if items else 'false'}\n")
+        fh.write(f"halted={queue.get('halted') or ''}\n")
+
+
+def finish(queue: dict, args, lane: Lane) -> int:
+    """Stamp the count, emit the queue (stdout or --out), and set job outputs."""
+    queue["count"] = len(queue[lane.items_key])
+    body = json.dumps(queue, indent=2)
+    if args.dry_run or not args.out:
+        print(body)
+    else:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(body + "\n")
+        print(
+            f"{lane.prog}: {queue['count']} {lane.item_noun}(s)"
+            + (f" (halted: {queue['halted']})" if queue["halted"] else "")
+            + f" → {out}",
+            file=sys.stderr,
+        )
+    write_github_output(queue, lane)
+    return 0

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -84,18 +84,35 @@ read from the queue JSON, which every consumer already has).
 from __future__ import annotations
 
 import argparse
-import csv
-import io
 import json
 import math
-import os
-import re
 import subprocess
 import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
 
 import yaml
+
+# Infrastructure this selector shares with scripts/blog-review/select-posts.py —
+# see _selector_common.py's docstring for why it is shared rather than copied.
+# The sys.path insert is anchored on this file's own location because the
+# selector is not always run with its directory on the path: scripts/snippet-
+# sweep/sweep.py loads it by path from a different directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _selector_common import (  # noqa: E402  (needs the sys.path insert above)
+    FRONTMATTER_RE,
+    INCOMPLETE_STATUS,
+    Lane,
+    cmd_prune,
+    effective_last_review,
+    finish,
+    git_history_signals,
+    load_ledger,
+    load_traffic,
+    normalize_url_path,
+    parse_day,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_TIERS = (
@@ -104,6 +121,17 @@ DEFAULT_TIERS = (
 )
 DEFAULT_LEDGER_DIR = REPO_ROOT / "scripts/content-review/ledger"
 CONTENT_DIR = "content/docs"
+
+# How the shared helpers in _selector_common.py address this lane.
+LANE = Lane(
+    prog="select-articles",
+    items_key="articles",
+    corpus_noun="page",
+    item_noun="article",
+    has_output="has_articles",
+    # No `count=`: every consumer of this lane's gate already reads the queue
+    # JSON, which carries the count.
+)
 
 BRANCH_PREFIX = "content-review/"
 MAX_OPEN_PRS = 9
@@ -140,24 +168,6 @@ FEEDBACK_BOOST_MAX = 0.30  # feedback multiplier in [1.0, 1.30]
 LOW_CTR_FLAG_MIN_IMPRESSIONS = 1000
 LOW_CTR_FLAG_RATIO = 0.5  # flag when ctr <= 0.5 * corpus median CTR
 
-# Statuses a ledger entry can carry (set by record-review.py). Any status other
-# than "incomplete" is a completed review whose date advances the clock; legacy
-# entries predating the field have no `status` and are treated as completed.
-INCOMPLETE_STATUS = "incomplete"
-
-# "Pulumi Bot" (display name) is how the SDK-regen tooling authors its commits
-# and "pulumi-bot" is how the review workflows configure git — the same bot
-# either way; "workprentice[bot]" is the docs automation app. None of them is a
-# human edit, so none resets a page's staleness clock. Missing names here are
-# expensive: a single bot touch would otherwise look like a fresh human edit and
-# park the page at the back of the queue.
-BOT_AUTHORS = {
-    "pulumi-bot", "Pulumi Bot", "workprentice[bot]",
-    "dependabot[bot]", "github-actions[bot]",
-}
-
-FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
-
 
 # ---- Path helpers -----------------------------------------------------------
 
@@ -188,10 +198,7 @@ def url_for(content_path: str) -> str:
 
 def content_path_for_url(url_path: str, known_paths: set[str]) -> str | None:
     """Map a live /docs/... URL path back to its content file, if it exists."""
-    p = url_path.split("#", 1)[0].split("?", 1)[0].strip()
-    if p.startswith("https://"):
-        p = re.sub(r"^https://[^/]+", "", p)
-    p = "/" + p.strip("/")
+    p = normalize_url_path(url_path)
     candidate_leaf = f"content{p}.md"
     candidate_index = f"content{p}/_index.md"
     if candidate_leaf in known_paths:
@@ -219,56 +226,6 @@ def tier_for(path: str, rules: list[dict]) -> tuple[int, bool]:
             no_retire = bool(rule.get("no_retire", False)) or tier == 1
             return tier, no_retire
     return 3, False
-
-
-def load_traffic(traffic_file: Path | None, known_paths: set[str]) -> tuple[dict[str, int], dict]:
-    """Parse the S3 traffic snapshot (JSON or CSV) into {content_path: visits}.
-
-    Returns ({}, meta) when the file is missing/unreadable — selection then
-    drops the traffic term entirely (graceful degradation).
-    """
-    meta = {"source": None, "period": None, "pages_matched": 0}
-    if traffic_file is None or not traffic_file.is_file():
-        return {}, meta
-    raw = traffic_file.read_text(errors="replace").strip()
-    if not raw:
-        return {}, meta
-
-    pages: dict[str, int] = {}
-
-    def record(url_path: str, views) -> None:
-        try:
-            views = int(float(views))
-        except (TypeError, ValueError):
-            return
-        cp = content_path_for_url(str(url_path), known_paths)
-        if cp:
-            # A URL and its aliases may both appear; credit the same file once
-            # with the larger figure rather than double-counting.
-            pages[cp] = max(pages.get(cp, 0), views)
-
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        data = None
-
-    if isinstance(data, dict):
-        meta["source"] = data.get("source")
-        meta["period"] = data.get("period") or data.get("generated")
-        body = data.get("pages", data)
-        if isinstance(body, dict):
-            for url_path, views in body.items():
-                record(url_path, views)
-    elif data is None:
-        # CSV: `path,views` with an optional header row.
-        reader = csv.reader(io.StringIO(raw))
-        for row in reader:
-            if len(row) < 2:
-                continue
-            record(row[0], row[1])
-
-    meta["pages_matched"] = len(pages)
-    return pages, meta
 
 
 def load_reader_signals(
@@ -372,79 +329,6 @@ def load_reader_signals(
     return gsc, feedback, meta
 
 
-def load_ledger(ledger_dir: Path) -> dict[str, dict]:
-    """Return {content_path: ledger entry} from one-file-per-page JSON."""
-    entries: dict[str, dict] = {}
-    if not ledger_dir.is_dir():
-        # Not fatal — the workflow only passes --ledger-dir when the S3 sync
-        # produced one — but never silent: with no ledger every page scores as
-        # never-bot-reviewed, which is a very different queue. DEFAULT_LEDGER_DIR
-        # is the in-repo path this script has never actually had, so a run that
-        # falls back to it is one that meant to read the S3 cache and didn't.
-        print(
-            f"select-articles: no ledger directory at {ledger_dir}; scoring every "
-            "page as never-reviewed",
-            file=sys.stderr,
-        )
-        return entries
-    for f in sorted(ledger_dir.glob("*.json")):
-        try:
-            entry = json.loads(f.read_text())
-        except (OSError, json.JSONDecodeError):
-            print(f"select-articles: unreadable ledger file {f}", file=sys.stderr)
-            continue
-        path = entry.get("path")
-        if path:
-            entry["_file"] = str(f)
-            entries[path] = entry
-    return entries
-
-
-# ---- Git signals (single-pass, no per-file subprocess fan-out) ---------------
-
-
-def git_history_signals(repo: Path) -> tuple[dict[str, int], dict[str, int]]:
-    """Per-path git timestamps for content/docs, from one history pass.
-
-    Walks history newest-first and returns two maps of unix commit times:
-
-      newest_non_bot : the most recent commit by a *non-bot* author that
-                       touched the path (a human edit — resets the staleness
-                       clock). Absent for pages only ever touched by bots.
-      created        : the oldest commit that touched the path (its creation),
-                       the fallback clock for never-bot-reviewed pages.
-    """
-    out = run_git(repo, ["log", "--name-only", "--format=%x01%ct%x01%an", "--", CONTENT_DIR])
-    newest_non_bot: dict[str, int] = {}
-    created: dict[str, int] = {}
-    current_ct = 0
-    author_is_bot = True
-    for line in out.splitlines():
-        if line.startswith("\x01"):
-            # Header line is "\x01<commit-time>\x01<author-name>".
-            parts = line.split("\x01")
-            ct = parts[1] if len(parts) > 1 else ""
-            an = parts[2] if len(parts) > 2 else ""
-            try:
-                current_ct = int(ct.strip())
-            except ValueError:
-                current_ct = 0
-            author_is_bot = an.strip() in BOT_AUTHORS
-        elif line.strip():
-            path = line.strip()
-            created[path] = current_ct  # last write wins -> oldest commit
-            if not author_is_bot and path not in newest_non_bot:
-                newest_non_bot[path] = current_ct
-    return newest_non_bot, created
-
-
-def run_git(repo: Path, args: list[str]) -> str:
-    proc = subprocess.run(
-        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=False
-    )
-    return proc.stdout
-
-
 # ---- GitHub signals ----------------------------------------------------------
 
 
@@ -479,49 +363,6 @@ def pr_state(pr_url: str, use_gh: bool) -> dict | None:
 
 
 # ---- Scoring -----------------------------------------------------------------
-
-
-def parse_day(s: str | None) -> date | None:
-    if not s:
-        return None
-    try:
-        return datetime.fromisoformat(str(s).replace("Z", "+00:00")).date()
-    except ValueError:
-        try:
-            return datetime.strptime(str(s), "%Y-%m-%d").date()
-        except ValueError:
-            return None
-
-
-def _ts_to_day(ts: int | None) -> date | None:
-    if not ts:
-        return None
-    return datetime.fromtimestamp(ts, tz=timezone.utc).date()
-
-
-def effective_last_review(
-    path: str,
-    entry: dict | None,
-    newest_non_bot: dict[str, int],
-    created: dict[str, int],
-) -> date | None:
-    """The date the staleness clock is measured from.
-
-    max(completed bot review, newest human edit); an `incomplete` review does
-    not count, so the page stays due. Never-bot-reviewed pages fall back to the
-    git creation date. None only when the page has no git history at all.
-    """
-    cands: list[date] = []
-    if entry:
-        reviewed = parse_day(entry.get("reviewed_at"))
-        if reviewed and entry.get("status") != INCOMPLETE_STATUS:
-            cands.append(reviewed)
-    human = _ts_to_day(newest_non_bot.get(path))
-    if human:
-        cands.append(human)
-    if cands:
-        return max(cands)
-    return _ts_to_day(created.get(path))
 
 
 def gsc_multiplier(
@@ -606,7 +447,7 @@ def score_page(
 
 
 def cmd_stats(ledger_dir: Path, use_gh: bool) -> int:
-    entries = load_ledger(ledger_dir)
+    entries = load_ledger(ledger_dir, LANE)
     counts = {"merged": 0, "closed": 0, "open": 0, "clean": 0,
               "incomplete": 0, "capped": 0, "unknown": 0}
     by_lane: dict[str, int] = {}
@@ -636,30 +477,7 @@ def cmd_stats(ledger_dir: Path, use_gh: bool) -> int:
     return 0
 
 
-def cmd_prune(ledger_dir: Path, repo: Path, dry_run: bool) -> int:
-    pruned = []
-    for path, entry in load_ledger(ledger_dir).items():
-        if not (repo / path).is_file():
-            pruned.append(entry["_file"])
-            if not dry_run:
-                Path(entry["_file"]).unlink()
-    verb = "would prune" if dry_run else "pruned"
-    print(f"select-articles: {verb} {len(pruned)} orphaned ledger file(s)")
-    for f in pruned:
-        print(f"  {f}")
-    return 0
-
-
 # ---- Main ----------------------------------------------------------------------
-
-
-def write_github_output(queue: dict) -> None:
-    gh_out = os.environ.get("GITHUB_OUTPUT")
-    if not gh_out:
-        return
-    with open(gh_out, "a") as fh:
-        fh.write(f"has_articles={'true' if queue['articles'] else 'false'}\n")
-        fh.write(f"halted={queue.get('halted') or ''}\n")
 
 
 def main() -> int:
@@ -687,20 +505,20 @@ def main() -> int:
     if args.stats:
         return cmd_stats(ledger_dir, use_gh)
     if args.prune:
-        return cmd_prune(ledger_dir, repo, args.dry_run)
+        return cmd_prune(ledger_dir, repo, args.dry_run, LANE)
     if not args.out and not args.dry_run:
         p.error("--out is required (or use --dry-run/--stats/--prune)")
 
     today = parse_day(args.today) or datetime.now(timezone.utc).date()
     tier_rules = load_tiers(Path(args.tiers))
-    ledger = load_ledger(ledger_dir)
+    ledger = load_ledger(ledger_dir, LANE)
 
     all_paths = sorted(
         str(f.relative_to(repo)) for f in (repo / CONTENT_DIR).rglob("*.md")
     )
     known = set(all_paths)
     traffic, traffic_meta = load_traffic(
-        Path(args.traffic_file) if args.traffic_file else None, known
+        Path(args.traffic_file) if args.traffic_file else None, known, content_path_for_url
     )
     have_traffic = bool(traffic)
     visits_known = sorted(traffic.values())
@@ -779,19 +597,19 @@ def main() -> int:
                 print(f"select-articles: --paths entry not found: {path}", file=sys.stderr)
                 return 1
             queue["articles"].append(article(path, lane, None))
-        return finish(queue, args)
+        return finish(queue, args, LANE)
 
     open_branches = open_review_branches(use_gh)
     if open_branches is None:
         # Can't dedup against open PRs -> opening more is unsafe. Halt loudly.
         queue["halted"] = "gh_unavailable"
-        return finish(queue, args)
+        return finish(queue, args, LANE)
     if len(open_branches) >= MAX_OPEN_PRS:
         queue["halted"] = "max_open_prs"
-        return finish(queue, args)
+        return finish(queue, args, LANE)
     open_slugs = {b[len(BRANCH_PREFIX):].removeprefix("retire-") for b in open_branches}
 
-    newest_non_bot, created = git_history_signals(repo)
+    newest_non_bot, created = git_history_signals(repo, CONTENT_DIR)
 
     candidates: list[str] = []
     capped: list[str] = []
@@ -844,7 +662,7 @@ def main() -> int:
     for score, path in scored[: max(args.count, 0)]:
         queue["articles"].append(article(path, "priority", score))
 
-    return finish(queue, args)
+    return finish(queue, args, LANE)
 
 
 def is_draft(file_path: Path) -> bool:
@@ -860,25 +678,6 @@ def is_draft(file_path: Path) -> bool:
     except yaml.YAMLError:
         return False
     return bool(isinstance(fm, dict) and fm.get("draft"))
-
-
-def finish(queue: dict, args) -> int:
-    queue["count"] = len(queue["articles"])
-    body = json.dumps(queue, indent=2)
-    if args.dry_run or not args.out:
-        print(body)
-    else:
-        out = Path(args.out)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(body + "\n")
-        print(
-            f"select-articles: {queue['count']} article(s)"
-            + (f" (halted: {queue['halted']})" if queue["halted"] else "")
-            + f" → {out}",
-            file=sys.stderr,
-        )
-    write_github_output(queue)
-    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/content-review/test_select_articles.py
+++ b/scripts/content-review/test_select_articles.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 SCRIPT = HERE / "select-articles.py"
+COMMON = HERE / "_selector_common.py"
+BLOG_SCRIPT = HERE.parent / "blog-review" / "select-posts.py"
 REPO_TIERS = (
     HERE.parents[1]
     / ".claude/commands/review-existing-content/references/strategic-tiers.yaml"
@@ -41,21 +43,39 @@ _failures: list[str] = []
 _passes = 0
 
 
-def _bot_authors() -> set[str]:
-    """Read BOT_AUTHORS out of select-articles.py without importing it.
+def _module_assign(path: Path, name: str):
+    """Return a module-level literal assignment's value, or None if absent.
 
-    The script's filename is hyphenated (not importable) and it runs argparse
-    at module scope, so the constant is parsed from source instead. Reading it
-    rather than restating it is the point: the test then covers whatever the
-    set actually contains.
+    Parsed from source rather than imported: these filenames are hyphenated
+    (not importable) and run argparse at module scope. Reading the value rather
+    than restating it is the point — the test then covers whatever the constant
+    actually holds.
     """
-    tree = ast.parse(SCRIPT.read_text())
-    for node in tree.body:
+    for node in ast.parse(path.read_text()).body:
         if isinstance(node, ast.Assign) and any(
-            isinstance(t, ast.Name) and t.id == "BOT_AUTHORS" for t in node.targets
+            isinstance(t, ast.Name) and t.id == name for t in node.targets
         ):
-            return set(ast.literal_eval(node.value))
-    raise AssertionError("BOT_AUTHORS not found in select-articles.py")
+            try:
+                return ast.literal_eval(node.value)
+            except ValueError:
+                # A non-literal re-declaration (`BOT_AUTHORS = COMMON | {...}`)
+                # is still a re-declaration. Report it as one rather than
+                # letting literal_eval raise out of the test harness.
+                return f"<non-literal assignment in {path.name}>"
+    return None
+
+
+def _bot_authors() -> set[str]:
+    """Read BOT_AUTHORS out of the shared selector module.
+
+    It lives in _selector_common.py, not in either selector, because the two
+    copies drifted once and cost ~65% of content/docs their staleness clock.
+    _check_bot_authors_single_definition below is the guard that keeps it there.
+    """
+    value = _module_assign(COMMON, "BOT_AUTHORS")
+    if value is None:
+        raise AssertionError(f"BOT_AUTHORS not found in {COMMON.name}")
+    return set(value)
 
 
 def check(cond: bool, msg: str) -> None:
@@ -212,6 +232,14 @@ def main() -> int:
         # constant means the next identity added to the set is covered the day
         # it lands, and one omitted from it fails here.
         print("every BOT_AUTHORS identity suppresses the staleness clock")
+        # The set has exactly one home. It used to have two, and the second one
+        # missed the fix — which is the whole reason _selector_common.py exists.
+        # A selector that re-declares it locally shadows the shared set for its
+        # own lane only, silently recreating the divergence.
+        for script in (SCRIPT, BLOG_SCRIPT):
+            check(_module_assign(script, "BOT_AUTHORS") is None,
+                  f"{script.name} re-declares BOT_AUTHORS instead of importing it "
+                  f"from _selector_common.py; the two copies will drift again")
         bot_names = sorted(_bot_authors())
         # Identities observed authoring commits in pulumi/docs. A name missing
         # here can't be caught by the loop below (the loop only iterates what is


### PR DESCRIPTION
Follow-up to #20811, which listed these three as deliberately out of scope. Each is now closed.

## Vale parity — update lane only

The refresh lane ran Vale but never merged `markdown-syntax-findings.py`, so a refresh dropped the two rules it contributes (`Pulumi.EmptyAltText`, `Pulumi.LinkText`) from a review the initial pass had raised them on.

This is an **advisory-tier** fix. Neither rule is blocker-tier, so the `[style-blocker]` set is byte-identical either way and the provenance check downstream is unaffected.

`claude-triage.yml` runs the same block and is **deliberately not changed**: its findings feed the trivial-PR prose check and `review:prose-flagged`, which the PR-sweep weighs when rubber-stamping, so widening it there would change what gets auto-approved.

## `gh pr diff --range` is not a real flag

The call failed with `unknown flag` on **every** invocation, so the documented fallback was the normal path — the update lane re-read the entire PR diff every time instead of the delta since the last review. Replaced with the compare API, which also survives the lane's `fetch-depth: 1` checkout where a local `git diff` could not.

Two traps the naive replacement walks into, both handled and exercised against live PRs:

- **Branch on `.status`, not the exit code.** GitHub keeps force-pushed-away commits, so comparing against a rewritten SHA returns HTTP 200 with `status: "diverged"` — only a SHA it has never seen 404s. Keyed on the exit code, the force-push fallback would never fire, and the lane would review a merge-base diff while recording in 📜 history that it reviewed the delta.
- **`compare` is three-dot.** On a PR rebased or merged forward between reviews, the range also carries master's own commits. Intersecting against the PR's own file set keeps the model off files the author never touched — without it this would *regress* against the previously-broken command, whose fallback correctly excluded base churn.

Verified across all four branches (`ahead` / `identical` / `diverged` / 404) against real PRs.

## Shared selector helpers

`select-articles.py` and `select-posts.py` shared ~266 byte-identical lines, and that duplication is not theoretical: `BOT_AUTHORS` was fixed in one and never back-ported, costing ~65% of `content/docs` their staleness clock.

Extracted `_selector_common.py` — the constant, the git-history/date/ledger/traffic helpers, and the shared URL normalization. Scoring and selection stay per-lane, because they legitimately differ.

Three genuine differences are preserved as explicit parameters rather than smoothed over: the blog lane falls back to the frontmatter publish date before the git creation date, it resolves only `<p>/index.md`, and each lane uses its own noun in messages. `ATTEMPT_CAP` and the GSC thresholds stay duplicated on purpose — identical today, but per-lane tuning knobs over different corpora, so sharing them would let a docs retune silently move blog behavior.

The blog lane's `count=` job output is removed rather than parameterized: no workflow ever read it, and `review-existing-content.yml` still described a `count=` its own lane had already dropped.

**Selector queues are byte-for-byte identical.** The test now reads `BOT_AUTHORS` from the shared module and asserts neither selector re-declares it — a local re-declaration would shadow the shared set for one lane only, which is exactly how the original bug worked. Verified that guard fires.

## Verification

`make lint`, `actionlint` (no new findings), all 21 suites green, selector queues diffed before/after.