### PR TITLE
Fix stale verifier concurrency in claim-verification workflow comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -775,7 +775,7 @@ jobs:
       # verify-claims.py routes every entry in .candidate-claims.json to one of
       # three lanes — Pass 1 (pulumi-internal: `gh` + local reads), Pass 2
       # (external w/ a fetched URL: consult .fetched-urls.json), Pass 3
-      # (external w/o a fetched URL: server-side web_search) — fires ≤8 parallel
+      # (external w/o a fetched URL: server-side web_search) — fires ≤16 parallel
       # Sonnet 5 verifiers via direct /v1/messages with a forced `verify_claim`
       # tool, and emits .verified-claims.json. The main review reads that file as
       # the verdict *source* (it does NOT re-verify); validate-pinned.py's


### PR DESCRIPTION
### Proposed changes

Comment-only fix in `.github/workflows/claude-code-review.yml`: the claim-verification step's comment said verify-claims.py "fires ≤8 parallel Sonnet 5 verifiers", but the script's `MAX_CONCURRENCY` is 16 (`.claude/commands/docs-review/scripts/verify-claims.py`, line 129). Updated the comment to say "≤16 parallel". No behavior change.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxzVgS1seUK7G3Sxp2kZSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxzVgS1seUK7G3Sxp2kZSv)_