### PR TITLE
Fix double URL-encoding in blog share links

### DIFF
--- a/layouts/partials/blog/share.html
+++ b/layouts/partials/blog/share.html
@@ -4,16 +4,20 @@
     page context. Only renders for pages backed by a file.
 */ -}}
 {{- with .File -}}
-{{- $title := $.Title -}}
-{{- $url := $.Permalink -}}
-{{- $t := $title | urlquery -}}
-{{- $u := $url | urlquery -}}
-{{- $tu := (printf "%s %s" $title $url) | urlquery -}}
+{{- /*
+    Interpolate the title and URL raw. Hugo percent-encodes a value emitted
+    inside an href's query string automatically, so piping through urlquery
+    first double-encodes it (the comma in a title arrives at X/Reddit/HN as
+    "%2C"), and urlquery's "+" for a space arrives there as a literal "+".
+*/ -}}
+{{- $t := $.Title -}}
+{{- $u := $.Permalink -}}
+{{- $tu := printf "%s %s" $.Title $.Permalink -}}
 <div>
     <p class="font-overline-sm mb-4 text-service-black">Share</p>
     <ul class="m-0 flex list-none items-center gap-3 p-0">
         <li class="m-0">
-            <button type="button" data-copy-link data-url="{{ $url }}" aria-label="Copy link" data-track="blog-share-copy-link" class="block cursor-pointer text-gray-500 transition-colors hover:text-violet-primary">
+            <button type="button" data-copy-link data-url="{{ $u }}" aria-label="Copy link" data-track="blog-share-copy-link" class="block cursor-pointer text-gray-500 transition-colors hover:text-violet-primary">
                 <span data-copy-link-idle>{{ partial "icon.html" (dict "name" "link" "class" "text-lg") }}</span>
                 <span data-copy-link-done hidden class="text-green-500">{{ partial "icon.html" (dict "name" "check" "class" "text-lg") }}</span>
             </button>


### PR DESCRIPTION
Fixes pulumi/marketing#1828 — share links from a blog post arrive at X, Reddit, and Hacker News with the title and URL encoded twice.

### The bug

`layouts/partials/blog/share.html` pre-encoded the title and permalink with `urlquery` into `$t` / `$u`, then emitted those variables inside an `href` query string. Hugo percent-encodes a value in that position automatically, so the encoding ran twice. Live output today:

```
https://x.com/intent/post?text=A%2bguided%2btour%2bof%2bTerraform%2bstate%252C%2b…&url=https%253A%252F%252Fwww.pulumi.com%252Fblog%252F…
```

The receiving site decodes once and is left with `A+guided+tour+of+Terraform+state%2C+…`, which is what the screenshots in the issue show. LinkedIn looked fine only because it decodes twice.

Note this is specifically about *pre-escaping into a variable*: Hugo recognizes a pipeline ending in `urlquery` and skips its own escaper, but `{{ $t }}` is an opaque variable, so it adds one. `layouts/shortcodes/neo-card.html` also uses `urlquery`, but builds the whole attribute value, which gets the idempotent URL normalizer — it is not affected.

### The fix

Interpolate the raw title and permalink and let Hugo encode once. That also drops `urlquery`'s `+`-for-space, which those sites render as a literal `+` because they decode with `decodeURIComponent` semantics; Hugo's escaper emits `%20`.

### Verification

Rendered the patched partial through Hugo (the pre-fix template reproduces the production bytes exactly):

```
https://x.com/intent/post?text=A%20guided%20tour%20of%20Terraform%20state%2c%20hosted%20modules%2c%20%26%20HCL%20in%20Pulumi&url=https%3a%2f%2fwww.pulumi.com%2f…
```

All four links single-encoded; a `&` in a title encodes to `%26`, so it can't leak into the query string. Worth a click-through on a deploy preview for each of the four networks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)