### PR TITLE
Make the nightly claims re-verify check facts, not itself

### DIFF
--- a/.claude/commands/docs-review/scripts/entity_key.py
+++ b/.claude/commands/docs-review/scripts/entity_key.py
@@ -70,6 +70,13 @@ PRICING_LIMIT_RE = re.compile(
 # except the page it came from (which is what makes those checks circular —
 # see reverify-claims.py's own-corpus demotion). Excluded from `volatile`;
 # still keyed, still indexed, still re-checked whenever the page is reviewed.
+#
+# PRICING_LIMIT_RE vetoes the exclusion, because the two overlap on the one
+# phrasing where this rule would otherwise do damage: "the example stack costs
+# $12/month" is self-describing in form but the figure is an outside-world
+# price that drifts on its own. Keeping a stray example count in the nightly
+# pool costs one verifier call and a demoted verdict; dropping a real price
+# means never checking it again.
 SELF_DESCRIBING_RE = re.compile(
     r"\b(?:examples?|samples?|tutorials?|walkthroughs?|screenshots?|"
     r"meta[- ]description|"
@@ -165,7 +172,8 @@ def derive(claim: dict) -> tuple[str | None, bool]:
     volatile = ctype in ALWAYS_VOLATILE_TYPES or (
         ctype == "entity-spec" and bool(PRICING_LIMIT_RE.search(text))
     )
-    if ctype == "numerical" and SELF_DESCRIBING_RE.search(text):
+    if (ctype == "numerical" and SELF_DESCRIBING_RE.search(text)
+            and not PRICING_LIMIT_RE.search(text)):
         volatile = False
 
     if ctype not in KEYED_TYPES:
@@ -284,6 +292,15 @@ def self_test() -> int:
     k, v = derive({"type": "numerical",
                    "text": "An operation is retried a maximum of 100 times."})
     check("external limit stays volatile", v is True)
+
+    # A price or limit inside self-describing phrasing keeps the claim in the
+    # nightly pool: the two regexes disagree here, and the figure still drifts
+    # on its own even though the sentence is about the page's own example.
+    for text in ("The example stack costs about $12 per month.",
+                 "The tutorial's cluster stays within the 5-node free limit.",
+                 "The example uses 2 of the 10 seats on the Team plan."):
+        k, v = derive({"type": "numerical", "text": text})
+        check(f"pricing vetoes the exclusion: {text[:34]}...", v is True)
 
     # is_volatile() re-derives from a persisted record, ignoring its stored flag.
     check("is_volatile re-derives from type/text",

--- a/.claude/commands/docs-review/scripts/entity_key.py
+++ b/.claude/commands/docs-review/scripts/entity_key.py
@@ -30,7 +30,8 @@ the index), a wrong key is not.
 `volatile` marks the claim types worth cheap nightly re-verification straight
 from the index — assertions whose truth drifts with the outside world even
 when the page doesn't change: version pins, prices/rates/limits, and
-pricing/limit-flavored entity specs.
+pricing/limit-flavored entity specs. A `numerical` claim about the page's own
+example or tutorial output is excluded: see SELF_DESCRIBING_RE.
 
 No LLM involvement: derivation is pure text normalization, so keys are
 reproducible from the claim record alone. Run the smoke checks with
@@ -58,6 +59,23 @@ PRICING_LIMIT_RE = re.compile(
     r"tier|tiers|plan|plans|edition|editions|subscription|"
     r"limit|limits|limited|quota|quotas|cap|capped|maximum|minimum|"
     r"free|paid|enterprise|business[- ]critical)\b",
+    re.IGNORECASE,
+)
+
+# A `numerical` claim counting something the page itself produced — "the
+# example update creates 3 resources", "this tutorial takes 15 minutes", "the
+# preview output shows 2 changes". The figure is a property of the prose, not
+# of the world: it can only change when the page changes, so the nightly lane
+# can never find drift in it, and the verifier has nothing to check it against
+# except the page it came from (which is what makes those checks circular —
+# see reverify-claims.py's own-corpus demotion). Excluded from `volatile`;
+# still keyed, still indexed, still re-checked whenever the page is reviewed.
+SELF_DESCRIBING_RE = re.compile(
+    r"\b(?:examples?|samples?|tutorials?|walkthroughs?|screenshots?|"
+    r"meta[- ]description|"
+    r"(?:preview|update|command|terminal|console)\s+output|"
+    r"output\s+(?:shows|displays|lists|reports|contains|includes)|"
+    r"shown\s+(?:above|below))\b",
     re.IGNORECASE,
 )
 
@@ -147,6 +165,8 @@ def derive(claim: dict) -> tuple[str | None, bool]:
     volatile = ctype in ALWAYS_VOLATILE_TYPES or (
         ctype == "entity-spec" and bool(PRICING_LIMIT_RE.search(text))
     )
+    if ctype == "numerical" and SELF_DESCRIBING_RE.search(text):
+        volatile = False
 
     if ctype not in KEYED_TYPES:
         return None, volatile
@@ -168,6 +188,17 @@ def derive(claim: dict) -> tuple[str | None, bool]:
     if not tokens:
         return None, volatile
     return f"{ctype}/{'-'.join(tokens)}", volatile
+
+
+def is_volatile(claim: dict) -> bool:
+    """Volatility of one claim record, re-derived from `type`/`text`.
+
+    Both inputs are persisted in the claims index, so `reverify-claims.py`
+    calls this to apply the current policy to snapshots that were stamped
+    under an older one — a narrowed rule takes effect on the whole index that
+    night rather than page by page as each is re-reviewed.
+    """
+    return derive(claim)[1]
 
 
 def stamp(claim: dict) -> dict:
@@ -233,6 +264,31 @@ def self_test() -> int:
     _, v = derive({"type": "entity-spec",
                    "text": "Pulumi-hosted deployment runners run in AWS us-west-2."})
     check("hosting entity-spec is not volatile", v is False)
+
+    # Self-describing numerical claims: still keyed, never volatile. Each of
+    # these was in the nightly lane's first two live sweeps.
+    for text in ("This tutorial takes about 15 minutes to complete.",
+                 "The example update creates 3 resources.",
+                 "The preview output shows 2 changes.",
+                 "The page meta description characterizes the list as complete.",
+                 "The command output lists 4 stacks."):
+        k, v = derive({"type": "numerical", "text": text})
+        check(f"self-describing not volatile: {text[:34]}...", v is False)
+        check(f"self-describing still keyed: {text[:34]}...", k is not None)
+
+    # ...but a count of something the outside world owns still is, including
+    # the policy-pack row counts that share the "lists/complete" vocabulary.
+    k, v = derive({"type": "numerical",
+                   "text": "This page lists all 139 policies in the NIST SP 800-53 pack."})
+    check("policy-pack count stays volatile", v is True)
+    k, v = derive({"type": "numerical",
+                   "text": "An operation is retried a maximum of 100 times."})
+    check("external limit stays volatile", v is True)
+
+    # is_volatile() re-derives from a persisted record, ignoring its stored flag.
+    check("is_volatile re-derives from type/text",
+          is_volatile({"type": "numerical", "volatile": True,
+                       "text": "The example update creates 3 resources."}) is False)
 
     # Non-keyed types: no key, not volatile.
     k, v = derive({"type": "behavior",

--- a/.github/workflows/claims-reverify.yml
+++ b/.github/workflows/claims-reverify.yml
@@ -29,11 +29,20 @@ name: "Scheduled jobs: Re-verify volatile claims"
 # TURNED ON 2026-08-11 with `CLAIMS_REVERIFY_COUNT` set explicitly to '25' in
 # pulumi/docs, so the first live run is a recorded decision rather than an
 # implicit default. At the time there were 63 volatile entities across 86
-# claim snapshots — a full sweep every 3 nights. Because the lane had never
-# executed, watch the first few reports for false-positive churn: most entities
-# are typed `numerical`, and some keys read like prose fragments rather than
-# version pins or limits, which would point at the volatile classifier rather
-# than at genuinely rotted facts.
+# claim snapshots — a full sweep every 3 nights.
+#
+# The first two live sweeps (Aug 11-12, 50 entities, 0 stale) confirmed both
+# of the things that warning called for; pulumi/docs#20851 fixed them:
+#   * 48 of 50 entities were typed `numerical`, and many were counts of the
+#     page's own example output ("the example update creates 3 resources")
+#     rather than version pins or limits. entity_key.py now excludes
+#     self-describing numerical claims from `volatile`, and this lane
+#     re-derives the flag rather than trusting what the snapshot stored.
+#   * 22 of 35 `verified` verdicts cited only Pulumi's own published docs —
+#     16 of them the published copy of the very page making the claim. Those
+#     are demoted to `unverifiable` now: the site is this repo rendered, so
+#     such a check can never detect drift. Expect `fresh` to read far lower
+#     than it did on those two nights; the difference was never real.
 #
 # DEGRADATION HEALTH: this lane only Slacks when it finds STALE entities, so a
 # dead lane (claims index gone, API key missing, every check inconclusive)
@@ -178,6 +187,18 @@ jobs:
           python3 scripts/content-review/reverify-claims.py "${ARGS[@]}"
           echo "--- report ---"
           cat .claims-reverify-report.json
+
+      # The report is the lane's only durable evidence: the run log masks every
+      # occurrence of the org name (so source URLs read as `www.***.com`) and
+      # ages out with the run. Uploaded unconditionally — a run worth debugging
+      # is usually one where the verify step failed.
+      - name: Upload re-verify report
+        if: always() && hashFiles('.claims-reverify-report.json') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: claims-reverify-report
+          path: .claims-reverify-report.json
+          retention-days: 90
 
       # Counts only + a run link — the evidence lives in the report artifact
       # and the ledger markers; the fix arrives as a normal content-review PR.

--- a/scripts/content-review/reverify-claims.py
+++ b/scripts/content-review/reverify-claims.py
@@ -329,9 +329,11 @@ def run(args) -> int:
 
     # The meta block doubles as the health observation consumed by
     # signal-health.py's reverify signal: `skipped` distinguishes "couldn't
-    # run" (degraded) from the quiet-night n_due=0 (healthy), and an
-    # all-inconclusive n_checked is the broken-verifier tell. Keep those
-    # semantics intact when touching the early-exit paths below.
+    # run" (degraded) from the quiet-night n_due=0 (healthy), an
+    # all-inconclusive n_checked is the no-drift-detected tell, and n_demoted
+    # says how much of that was own-corpus evidence rather than broken
+    # plumbing — the two want opposite fixes. Keep those semantics intact when
+    # touching the early-exit paths below.
     snapshots = load_snapshots(Path(args.claims_dir))
     report["meta"]["n_snapshots"] = len(snapshots)
     if not snapshots:

--- a/scripts/content-review/reverify-claims.py
+++ b/scripts/content-review/reverify-claims.py
@@ -34,6 +34,12 @@ the input. `contradicted`/`mismatch` → stale; `verified`/`matches` → fresh;
 anything else (`unverifiable`, errors) → inconclusive, reported but never
 marked — a flaky check must not burn review-queue slots.
 
+Evidence independence: a verdict whose only cited source is Pulumi's own
+published docs — a www.pulumi.com URL, or a `content/` source file — is
+demoted to `unverifiable` before that mapping (see `source_is_own_corpus`).
+The site is this repo rendered, so such a check has confirmed the page
+against itself and cannot detect drift in either direction.
+
 Writes `.claims-reverify-report.json` (plus `n_checked`/`n_stale`/`has_stale`
 to $GITHUB_OUTPUT) and, when CONTENT_REVIEW_LEDGER_URI is set, uploads each
 marked ledger object. Degrades gracefully: no API key, no claims dir, or no
@@ -53,6 +59,7 @@ import argparse
 import importlib.util
 import json
 import os
+import re
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timezone
@@ -60,12 +67,16 @@ from pathlib import Path
 
 HERE = Path(__file__).resolve().parents[2]
 VERIFY_CLAIMS = HERE / ".claude/commands/docs-review/scripts/verify-claims.py"
+ENTITY_KEY = HERE / ".claude/commands/docs-review/scripts/entity_key.py"
 
 SCHEMA_VERSION = 1
 DEFAULT_COUNT = 25
 MAX_CONCURRENCY = 8
 STALE_VERDICTS = {"contradicted", "mismatch", "framing-drift"}
 FRESH_VERDICTS = {"verified", "matches"}
+# Verdicts that assert something either way, and so have to rest on evidence
+# from outside the docs corpus to mean anything.
+DECIDED_VERDICTS = STALE_VERDICTS | FRESH_VERDICTS
 
 
 def log(msg: str) -> None:
@@ -84,6 +95,55 @@ def _load_verify_claims():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _load_is_volatile():
+    """entity_key.is_volatile, or None if the module can't be loaded.
+
+    Re-deriving beats trusting the snapshot's stored `volatile` flag: the flag
+    was stamped whenever the page was last reviewed, so a narrowing of the
+    policy would otherwise only reach the index page by page over months. None
+    falls the caller back to the stored flag — a stale policy is a much smaller
+    problem than a lane that stops selecting anything."""
+    try:
+        spec = importlib.util.spec_from_file_location("entity_key", ENTITY_KEY)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.is_volatile
+    except Exception as e:  # noqa: BLE001 - never break the lane over this
+        warn(f"entity_key module unavailable ({e}); using stored volatile flags")
+        return None
+
+
+# ---- evidence independence ---------------------------------------------------
+
+# www.pulumi.com is this repo rendered and `content/` is its source, so a
+# verdict citing only those has checked the page against itself: it can never
+# go stale, and a `contradicted` from the same place is equally meaningless.
+# Demoted to `unverifiable` — reported, never counted fresh, never marked.
+_URL_RE = re.compile(r"https?://[^\s,;)\]]+", re.IGNORECASE)
+_OWN_HOST_RE = re.compile(r"^https?://(?:[\w-]+\.)*pulumi\.com(?:[/:?#]|$)", re.IGNORECASE)
+_PATH_RE = re.compile(
+    r"(?<![\w/-])[\w][\w./-]*\.(?:json|ya?ml|md|mdx|go|ts|tsx|js|py|cs|java|tf|toml)\b"
+)
+
+
+def source_is_own_corpus(source: str) -> bool:
+    """True when every source the verifier cited is our own published docs.
+
+    Positive evidence only: a source naming nothing identifiable (no URL, no
+    file path) is left alone rather than demoted — unrecognized is not the
+    same as circular.
+    """
+    src = source or ""
+    urls = _URL_RE.findall(src)
+    if any(not _OWN_HOST_RE.match(u) for u in urls):
+        return False
+    paths = _PATH_RE.findall(_URL_RE.sub(" ", src))
+    own_paths = [p for p in paths if p.startswith("content/") or "/content/" in p]
+    if len(paths) > len(own_paths):
+        return False
+    return bool(urls) or bool(own_paths)
 
 
 # ---- index loading -----------------------------------------------------------
@@ -105,16 +165,20 @@ def load_snapshots(claims_dir: Path) -> list[dict]:
     return out
 
 
-def volatile_entities(snapshots: list[dict]) -> dict[str, list[dict]]:
+def volatile_entities(snapshots: list[dict], is_volatile=None) -> dict[str, list[dict]]:
     """{entity_key: [assertion, ...]} over every volatile keyed claim.
 
     Each assertion carries the claim record plus its page provenance
     (path/slug/reviewed_at), so a stale verdict can fan back out to every
-    page asserting the entity."""
+    page asserting the entity.
+
+    `is_volatile` re-derives the flag under today's policy (see
+    `_load_is_volatile`); omitting it reads the snapshot's stored flag."""
+    decide = is_volatile or (lambda c: bool(c.get("volatile")))
     entities: dict[str, list[dict]] = {}
     for snap in snapshots:
         for c in snap.get("claims") or []:
-            if not isinstance(c, dict) or not c.get("entity_key") or not c.get("volatile"):
+            if not isinstance(c, dict) or not c.get("entity_key") or not decide(c):
                 continue
             entities.setdefault(c["entity_key"], []).append({
                 "claim": c,
@@ -239,7 +303,8 @@ def finish(report: dict, out_path: Path) -> int:
     out_path.write_text(json.dumps(report, indent=2) + "\n")
     m = report["meta"]
     log(f"checked={m['n_checked']} stale={m['n_stale']} fresh={m['n_fresh']} "
-        f"inconclusive={m['n_inconclusive']} (volatile entities={m['n_entities']}) -> {out_path}")
+        f"inconclusive={m['n_inconclusive']} (of which {m['n_demoted']} demoted for "
+        f"own-corpus evidence) (volatile entities={m['n_entities']}) -> {out_path}")
     write_outputs(report)
     return 0
 
@@ -258,7 +323,7 @@ def run(args) -> int:
         "checked_at": today.isoformat(),
         "entities": [],
         "meta": {"n_snapshots": 0, "n_entities": 0, "n_due": 0, "n_checked": 0,
-                 "n_stale": 0, "n_fresh": 0, "n_inconclusive": 0},
+                 "n_stale": 0, "n_fresh": 0, "n_inconclusive": 0, "n_demoted": 0},
     }
     out_path = Path(args.out)
 
@@ -275,7 +340,7 @@ def run(args) -> int:
         return finish(report, out_path)
 
     ledger = load_ledger(Path(args.ledger_dir))
-    entities = volatile_entities(snapshots)
+    entities = volatile_entities(snapshots, _load_is_volatile())
     report["meta"]["n_entities"] = len(entities)
 
     unmarked = sorted(k for k, v in entities.items() if not already_marked(k, v, ledger))
@@ -299,9 +364,14 @@ def run(args) -> int:
         claim["__id"] = key
         claim["__route"] = vc.route_claim(claim, {})
         rec, err = vc.process_claim(api_key, claim, {}, args.model, repo_root, args.dry_run)
+        verdict = rec.get("verdict")
+        demoted_from = None
+        if verdict in DECIDED_VERDICTS and source_is_own_corpus(rec.get("source") or ""):
+            demoted_from, verdict = verdict, "unverifiable"
         return {
             "entity_key": key,
-            "verdict": rec.get("verdict"),
+            "verdict": verdict,
+            "demoted_from": demoted_from,
             "confidence": rec.get("confidence"),
             "evidence": rec.get("evidence"),
             "source": rec.get("source"),
@@ -320,6 +390,7 @@ def run(args) -> int:
     report["meta"]["n_stale"] = len(stale)
     report["meta"]["n_fresh"] = len(fresh)
     report["meta"]["n_inconclusive"] = len(results) - len(stale) - len(fresh)
+    report["meta"]["n_demoted"] = sum(1 for r in results if r["demoted_from"])
 
     if stale:
         changed = apply_markers(ledger, stale, today)
@@ -371,9 +442,42 @@ def self_test() -> int:
     ents = volatile_entities(snaps)
     check("volatile keyed entities only",
           set(ents) == {"version/pulumi-gcp", "numerical/team-plan-price"})
+
     check("entity fans out across pages", len(ents["version/pulumi-gcp"]) == 2)
     check("representative is the freshest assertion",
           representative(ents["version/pulumi-gcp"])["text"] == "pulumi-gcp v8.3.0")
+
+    # Re-derived volatility overrides the snapshot's stored flag, so a
+    # narrowed policy reaches the whole index the night it ships.
+    stale_flag = {"entity_key": "numerical/example-resources-created", "volatile": True,
+                  "type": "numerical", "line_range": "L3", "verdict": "verified",
+                  "text": "The example update creates 3 resources."}
+    rederived = volatile_entities(
+        snaps + [snap("c", "2026-07-06", stale_flag)], _load_is_volatile())
+    check("re-derive drops a self-describing claim stamped volatile",
+          "numerical/example-resources-created" not in rederived)
+    check("re-derive keeps genuinely volatile entities",
+          set(rederived) == {"version/pulumi-gcp", "numerical/team-plan-price"})
+    check("no re-derive falls back to the stored flag",
+          "numerical/example-resources-created"
+          in volatile_entities(snaps + [snap("c", "2026-07-06", stale_flag)]))
+
+    # Evidence independence: only own-corpus-sourced verdicts are demoted, and
+    # an unrecognizable source is never treated as circular.
+    own = ["https://www.pulumi.com/docs/iac/get-started/aws/modify-program/",
+           "https://www.pulumi.com/docs/a/ and https://www.pulumi.com/docs/b/",
+           "repo:content/docs/iac/concepts/providers/_index.md"]
+    independent = ["https://docs.aws.amazon.com/config/latest/developerguide/x.html",
+                   "gh api repos/pulumi/pulumi/contents/pkg/resource/deploy/retries.go",
+                   "repo:data/policy_pack_policies/cis-aws.json (line 2872)",
+                   "https://github.com/pulumi/pulumi/blob/master/.goreleaser.yml",
+                   "https://www.pulumi.com/docs/a/ and https://docs.aws.amazon.com/x.html",
+                   "N/A - author's own estimate of their tutorial content",
+                   ""]
+    for s in own:
+        check(f"own-corpus source: {s[:44]}", source_is_own_corpus(s) is True)
+    for s in independent:
+        check(f"independent source: {s[:44] or '(empty)'}", source_is_own_corpus(s) is False)
 
     # Chunk rotation: deterministic, complete coverage across consecutive days.
     keys = [f"k{i}" for i in range(5)]

--- a/scripts/content-review/signal-health.py
+++ b/scripts/content-review/signal-health.py
@@ -18,8 +18,9 @@ workflow; all share one state object:
   reverify        the nightly volatile-claims re-verification only Slacks when
                   it finds STALE entities, so a dead lane (claims index gone,
                   API key missing, every check inconclusive because the
-                  verifier's gh/API plumbing broke) looks identical to a
-                  healthy quiet one
+                  verifier's gh/API plumbing broke — or because every verdict
+                  was demoted for citing only our own docs) looks identical to
+                  a healthy quiet one
 
 Graceful degradation is the right behavior; this script adds the missing
 observability. The dispatcher runs it once per scheduled run with that run's
@@ -109,8 +110,10 @@ CONSEQUENCES = {
     "reverify": (
         "nightly claims re-verify: no conclusive results for {days} day(s) "
         "({detail}) — volatile-claim drift (version pins, prices, limits) is "
-        "going undetected. Check the claims-index S3 sync, ANTHROPIC_API_KEY, "
-        "and the verifier's gh lane on claims-reverify.yml."
+        "going undetected. A demotion count above means the verifier is only "
+        "citing our own docs: that's its source routing, not the plumbing. "
+        "Otherwise check the claims-index S3 sync, ANTHROPIC_API_KEY, and the "
+        "verifier's gh lane on claims-reverify.yml."
     ),
 }
 
@@ -192,6 +195,13 @@ def observe_reverify(report_path: Path | None) -> tuple[str, str] | None:
     `meta.n_due` on every run, so a quiet night (nothing due) is distinguishable
     from a dead lane. A missing/unreadable report is NOT evidence of
     degradation (the job may not have run at all) — return None.
+
+    An all-inconclusive night still degrades when the cause is demotion (the
+    verifier only cited our own docs, so nothing it returned could be trusted
+    either way): no drift was detected, which is the thing this signal exists
+    to notice. But the count is carried into the detail so the alert points at
+    the verifier's source routing rather than at S3 and API keys — the
+    remediation for a demoted night is nothing like the one for a dead lane.
     """
     if report_path is None or not report_path.is_file():
         return None
@@ -204,12 +214,16 @@ def observe_reverify(report_path: Path | None) -> tuple[str, str] | None:
     n_due = int(meta.get("n_due") or 0)
     n_checked = int(meta.get("n_checked") or 0)
     n_inconclusive = int(meta.get("n_inconclusive") or 0)
+    n_demoted = int(meta.get("n_demoted") or 0)
     if skipped == "no_snapshots":
         return "degraded", "claims index empty or unfetchable"
     if skipped:
         return "degraded", f"{n_due} entities due but run skipped ({skipped})"
     if n_checked and n_inconclusive == n_checked:
-        return "degraded", f"all {n_checked} checks inconclusive"
+        detail = f"all {n_checked} checks inconclusive"
+        if n_demoted:
+            detail += f", {n_demoted} demoted for citing only our own docs"
+        return "degraded", detail
     if n_checked:
         return "ok", f"checked={n_checked} inconclusive={n_inconclusive}"
     return "ok", "nothing due tonight"
@@ -507,6 +521,9 @@ def self_test() -> int:
                          "n_checked": 0, "n_stale": 0, "n_fresh": 0, "n_inconclusive": 0}}
     rv_dead = {"meta": {"n_snapshots": 40, "n_entities": 90, "n_due": 25,
                         "n_checked": 25, "n_stale": 0, "n_fresh": 0, "n_inconclusive": 25}}
+    rv_demoted = {"meta": {"n_snapshots": 40, "n_entities": 90, "n_due": 25,
+                           "n_checked": 25, "n_stale": 0, "n_fresh": 0,
+                           "n_inconclusive": 25, "n_demoted": 22}}
     rv_nokey = {"meta": {"n_snapshots": 40, "n_entities": 90, "n_due": 25,
                          "n_checked": 0, "n_stale": 0, "n_fresh": 0, "n_inconclusive": 0,
                          "skipped": "no_api_key"}}
@@ -535,6 +552,15 @@ def self_test() -> int:
         check("skipped run stays degraded with skip detail",
               st["signals"]["reverify"]["status"] == "degraded"
               and "no_api_key" in st["signals"]["reverify"]["detail"])
+
+        # An all-demoted night is still no drift detection, so it still
+        # degrades — but the detail has to name demotion, or the alert sends
+        # the on-call after S3 and API keys for a routing problem.
+        st, alert = run_once(d, "2026-09-07", reverify=rv_demoted)
+        check("all-demoted night still degrades",
+              st["signals"]["reverify"]["status"] == "degraded")
+        check("all-demoted detail names the cause",
+              "22 demoted" in st["signals"]["reverify"]["detail"])
         st, alert = run_once(d, "2026-09-10", reverify=rv_dead)
         check("reverify alert fires at threshold and names the consequence",
               alert is not None and "volatile-claim drift" in alert)


### PR DESCRIPTION
The claims re-validator went live on Aug 11. Its first two sweeps checked 50 volatile entities and found 0 stale — and both halves of that result were misleading, in the two ways `claims-reverify.yml`'s own header had flagged as worth watching. This fixes both.

## 22 of 35 `verified` verdicts were sourced from our own docs

16 of them cited the published copy of the very page making the claim:

```
content/docs/iac/get-started/aws/modify-program.md
  verified high ← https://www.pulumi.com/docs/iac/get-started/aws/modify-program/
```

`www.pulumi.com` is this repo rendered, so that check confirmed the page against itself. It can never go stale, and a `contradicted` from the same place would be equally meaningless. The worst case restated a marketing figure — "5-10X improvements" in the onboarding guide — as `verified high` by quoting itself.

`source_is_own_corpus` now demotes any decided verdict whose every cited source is a `www.pulumi.com` URL or a `content/` file to `unverifiable`: reported, never counted fresh, never written as a stale marker. Positive evidence only — a source naming nothing identifiable (no URL, no path) is left alone, because unrecognized is not the same as circular.

Replayed over both nights' reports, this demotes 22 of 35 and leaves 13 real verifications — against AWS documentation, `pulumi/pulumi` source, `.goreleaser.yml`, and the `data/policy_pack_policies/*.json` files that generate the tables being checked.

| | Aug 11 | Aug 12 |
|---|---|---|
| `fresh` as reported | 16 | 19 |
| demoted (own-corpus evidence) | 11 | 11 |
| `fresh` under this change | 5 | 8 |

## 48 of the 50 entities were typed `numerical` — and many were never volatile

`ALWAYS_VOLATILE_TYPES` made every `numerical` claim volatile unconditionally, so counts of a page's own example output rode along: *"this tutorial takes 15 minutes"*, *"the example update creates 3 resources"*, *"the preview output shows 2 changes"*. Those figures are properties of the prose — they can only change when the page changes, so a nightly check can never find drift in them. Eight came back `not-a-claim` from the verifier saying exactly that.

`SELF_DESCRIBING_RE` excludes them from `volatile`. They stay keyed and indexed, and are still re-checked whenever the page itself is reviewed. The policy-pack row counts share some of that vocabulary ("this page lists all 139 policies…") and deliberately stay volatile — those do drift, and a test pins the distinction.

`reverify-claims.py` re-derives the flag through `entity_key.is_volatile` rather than trusting what each snapshot stored, so the narrower rule reaches the whole index the night it ships instead of page by page as each page is re-reviewed. It falls back to the stored flag if the module can't load.

## The report artifact

The Slack summary has always said "the evidence lives in the report artifact"; no step ever uploaded one. That matters more than it sounds — Actions masks every occurrence of the org name, so source URLs in the run log read `www.***.com`, which is precisely the field this PR turns on.

## Deliberately partial

Neither fix stops the verifier from reaching for the site in the first place; they stop it from being *recorded as confirmed* on that basis. Prompting it toward independent sources means editing `verify-claims.py`, which the pre-merge review lane shares, so that wants its own change rather than a ride-along here.

Not addressed either: near-duplicate keys burning one verifier call each (three separate entities for one ELB SSL policy fact, four for one policy-table count). Real waste, but it's a key-normalization change with a different blast radius.

## Verification

`make lint` and `make test-review-pipeline` (21 suites) green. The new assertions in both suites were negative-tested — they go red against the pre-fix code and name the specific behavior that regressed. The demotion counts above come from replaying the two live reports through the new code, not from an estimate.

Nothing here changes the pre-merge review lane: `volatile` is read only by the nightly job.
