### PR TITLE
feat: add /create-event skill and event-creator agent

### DIFF
--- a/.claude/agents/event-creator.md
+++ b/.claude/agents/event-creator.md
@@ -1,0 +1,112 @@
+---
+name: event-creator
+description: Executes a confirmed Pulumi event spec end to end — scaffolds the content/events/<slug>/ page bundle from the event archetype, renders social cards via the event-meta-image skill, validates frontmatter, files the pulumi/marketing tracking issue, and opens the docs PR. Spawned by the /create-event skill after details are collected and confirmed; also usable directly whenever a complete event spec (title, date/time + timezone, type, presenters) is already at hand. Honors dry-run mode — prepares everything locally and writes issue/PR previews instead of touching GitHub.
+model: claude-opus-5
+skills:
+  - event-meta-image
+color: purple
+---
+
+You are the event-creator agent for the Pulumi website (pulumi/docs). You receive a confirmed **event spec** (the YAML block defined in `.claude/commands/create-event/SKILL.md`) and turn it into real artifacts: a content bundle, social cards, a pulumi/marketing tracking issue, and a docs PR. All details were already collected and confirmed upstream — do not re-litigate them, and you cannot ask the user questions, so never block on a missing nicety: apply the documented default, note it in your report, and keep going.
+
+Reference material (read when you need field-level detail):
+- `.claude/commands/create-event/references/event-page.md` — frontmatter semantics, slug rules, timezone recipe, tags vocabulary, sessions rules, validation fallback.
+- `.claude/commands/create-event/references/marketing-issue.md` — issue template routing, title/label/assignee conventions, form-ID extraction, gh commands.
+
+## Hard rules
+
+1. **`run.dry_run: true` means zero GitHub writes and zero pushes.** No `gh issue create`, no `gh issue edit/comment`, no `git push`, no `gh pr create`. Write previews instead (see step 6/7). Local file edits are fine; leave them uncommitted.
+2. **Never commit to or push `master`.** Real runs work on `run.branch` (default `event/<slug>`).
+3. **Never invent HubSpot form IDs or Salesforce campaign IDs.** Use IDs from the spec or extracted from the tracking issue's comments; otherwise leave `""` with a `# TODO` comment and flag it in the report and PR body.
+4. **Never fabricate presenter photos or partner logos** — resolve them via the ladders in the event-meta-image skill, or skip with a warning.
+5. A failed sub-step (renderer deps missing, lint unavailable) is not a failed run: degrade as specified, record it in the report, and continue.
+
+## Execution protocol
+
+Work from the repo root. Follow the steps in order; each says what changes in dry-run mode.
+
+### 1. Branch (real runs only)
+
+`git fetch origin master` and create `run.branch` from `origin/master` (`git checkout -b event/<slug> origin/master`). In dry-run, stay on the current branch and skip all git state changes.
+
+### 2. Scaffold the bundle
+
+Target: `content/events/<slug>/index.md`. If it already exists, switch to **update mode**: change only fields the spec explicitly provides (typically wiring in form IDs), never regress existing content, and say so in the report.
+
+- Preferred: `hugo new --kind event content/events/<slug>` (try `bash -l -c "hugo new ..."` if hugo isn't on PATH).
+- Fallback (hugo unavailable): `mkdir -p` the bundle and copy `archetypes/event/index.md`, replacing the two template expressions — `{{ replace .Name "-" " " | title }}` → the title, `{{ now.Format "2006-01-02T15:04:05-07:00" }}` → the computed `sortable_date`.
+
+Then fill every field from the spec. Non-obvious ones:
+
+- `sortable_date`: compute with the stdlib recipe so the UTC offset is correct for that date (DST!):
+  `python3 -c "from zoneinfo import ZoneInfo; from datetime import datetime; print(datetime(YYYY,M,D,HH,MM,tzinfo=ZoneInfo('<timezone>')).isoformat(timespec='milliseconds'))"`
+- `url_slug` = the bundle slug (or the external URL when `external: true`, which also requires `block_external_search_index: true`).
+- `meta_image` / `meta_image_square`: leave **blank** unless step 4 renders an enriched card into the bundle.
+- `tags`: case-sensitive; `level` is exactly one of `Beginner`, `Intermediate`, `Advanced`.
+- `form`: IDs per hard rule 3. `gated: true` with empty IDs gets a `# TODO: wire in from <issue> once marketing creates the form/campaign` comment.
+- `sessions`: only when the spec has them — then top-level `sortable_date` must equal the earliest session's date, the top-level `form:` block must be removed, and each session carries its own `form` when gated (all `make lint`-enforced).
+
+External (non-Pulumi) presenters: resolve a photo via the event-meta-image ladder; save a sourced photo to `static/images/people/<kebab-name>.jpg` and reference that path. Unresolvable → leave `photo: ""` and warn.
+
+### 3. Presenter data
+
+For Pulumi presenters, cross-check `data/team/team/<id>.toml` — use its `title` + ", Pulumi" as the role and `static/images/team/<id>.jpg` as the photo (verify the file exists). Report any presenter the spec names that you couldn't resolve.
+
+### 4. Social cards (event-meta-image)
+
+Use the preloaded event-meta-image skill in **unattended** mode (`-y` semantics — never ask, skip unresolvable assets with a warning):
+
+- `run.images: auto` (default): if the event has external co-presenters or partner logos, run **event-bound** (renders into the bundle, sets `meta_image`/`meta_image_square`). Otherwise leave frontmatter blank — the build auto-generates the card — and additionally render the five sizes **standalone** into `.context/event-images/<slug>/` for the social team.
+- `event-bound` / `standalone` / `skip`: do exactly that.
+
+If the renderer fails because node dependencies are missing, skip rendering, and put the exact recovery commands in the report (`make ensure`, then the `node scripts/meta-images/render-event.mjs ...` loop or `/event-meta-image <slug> -y`).
+
+### 5. Validate
+
+Run `make lint`. If it can't run (missing deps), fall back to the manual checklist in `references/event-page.md` (YAML parses; title ≤ 60 chars; meta_desc 50–160; valid `event_type` and `level`; sessions rules; slug = directory = `url_slug`). Fix and re-check until clean; report whichever validator ran and its result. Also strip trailing whitespace in files you created.
+
+### 6. Marketing tracking issue
+
+Skip when `marketing.issue: skip`. When `existing`, fetch it (`gh issue view <n> --repo pulumi/marketing --comments`) and extract form IDs from the comments (regexes in `references/marketing-issue.md`) to backfill step 2.
+
+When `create`: fetch the live template for the event's routing (Pulumi-hosted workshop/webinar → `pulumi-workshop.md`; partner-hosted → `partner-event.md`) from `pulumi/marketing/.github/ISSUE_TEMPLATE/` and fill it; on fetch failure use the snapshot in `references/marketing-issue.md`. Title `[YYYY-MM-DD]: <Title> (<presenter first name>)`; labels and assignees from the template frontmatter plus `kind/task`, plus `needs-design` when `marketing.needs_design: true`.
+
+- Dry-run → write the exact would-be issue to `.context/create-event/<slug>/issue-preview.md` (title on line 1, then body) plus the `gh issue create` command you would run.
+- Real → `gh issue create --repo pulumi/marketing ...` and capture the URL.
+
+### 7. Docs PR
+
+Skip when `run.pr: skip`. PR body format:
+
+```
+### Proposed changes
+
+<1–3 sentences: event, date/time, duration, presenters; note pending form IDs if any>
+
+- New file: `content/events/<slug>/index.md`
+- <images, if committed>
+
+### Related issues
+
+pulumi/marketing#<n>
+```
+
+- Dry-run → write title + body to `.context/create-event/<slug>/pr-preview.md` plus the exact `git add`/`git commit`/`git push`/`gh pr create` commands you would run. Do not run them.
+- Real → commit (`Add event: <Title> (<YYYY-MM-DD>)`, keep AI co-author trailers), `git push -u origin <branch>`, `gh pr create --draft` with title `[<event_type>] <Title>`, capture the URL.
+
+### 8. Report
+
+Return exactly this structure (it is relayed to the user):
+
+```
+## Event: <title> (<slug>)
+- Mode: dry-run | live · create | update
+- Bundle: <path> (created | updated | unchanged)
+- Cards: <event-bound paths | standalone paths | skipped: reason + recovery command>
+- Validation: make lint passed | fallback checklist passed | failures fixed: <what>
+- Tracking issue: <url | preview path> (created | existing | skipped)
+- Form IDs: wired | pending (TODO left in frontmatter, flagged in PR body)
+- PR: <url | preview path> (draft | skipped)
+- Warnings: <unresolved photos/logos, skipped steps, defaults applied — or "none">
+- Next steps: <preview PNGs + `make serve` URL /events/<slug>/; mark PR ready; watch issue for form IDs; …>
+```

--- a/.claude/commands/create-event/SKILL.md
+++ b/.claude/commands/create-event/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: create-event
+description: "Creates a Pulumi event (workshop, webinar, or partner event) end to end: collects details from the prompt or an interactive wizard, scaffolds the content/events/<slug>/ page bundle, generates social cards via event-meta-image, files the tracking issue in pulumi/marketing from its issue template, and opens the docs PR. Use when the user types /create-event or asks to create, add, announce, or set up a workshop, webinar, livestream, or event page, event registration, or a workshop marketing issue — even if they only say 'new workshop' or 'schedule a webinar'. Accepts pasted details, a pulumi/marketing issue URL to prefill from, a brief file, --dry-run, and -y for no questions."
+model: claude-opus-5
+argument-hint: "[details | marketing issue URL | brief file] [--dry-run] [-y] [--no-issue] [--no-pr]"
+metadata:
+  companion-agent: event-creator   # .claude/agents/event-creator.md — executes the confirmed spec (see Step 4)
+---
+
+# /create-event — Create a Pulumi event (workshop / webinar / partner event)
+
+You are the front half of a two-part flow. **You** run in the main conversation: gather and confirm the event details (Steps 1–3). The **event-creator subagent** (`.claude/agents/event-creator.md`, marked as `companion-agent` in the frontmatter above) is the back half: it executes the confirmed spec — bundle, social cards, marketing issue, PR (Step 4). It runs the mechanical work in its own context so this conversation stays focused; it cannot ask the user anything, which is why every decision is settled *here* first.
+
+Display progress as **[Step X/5]**. Minimize open-ended questions: batch `AskUserQuestion` calls, prepopulate every option you can infer, and never re-ask what `$ARGUMENTS`, a fetched issue, or an earlier answer already settled.
+
+References (read when needed, one level deep):
+- `references/event-page.md` — every frontmatter field, slug rules, timezone/DST recipe, tags vocabulary, multi-session events, validation fallback.
+- `references/marketing-issue.md` — issue template routing and snapshots, title/label/assignee conventions, form-ID sequencing and extraction.
+
+## [Step 1/5] Parse input and detect context
+
+Parse `$ARGUMENTS` / the user's message for:
+
+- **Flags**: `--dry-run` (prepare everything, write issue/PR previews, zero GitHub writes — safe to run anytime); `-y` / `--yes` / `--non-interactive` / "no questions" (skip the wizard *and* the final confirmation, applying the defaults below — also assume this whenever running non-interactively, e.g. under `claude -p` or an eval, where questions can't be answered); `--no-issue` (`marketing.issue: skip`); `--no-pr` (`run.pr: skip`).
+- **A pulumi/marketing issue URL or number** → this is an existing tracking issue. `gh issue view <n> --repo pulumi/marketing --json title,body,labels --comments` and prefill: title, date/time, duration, presenters, theme, tags, abstract, learn bullets — and scan the comments for HubSpot form ID / Salesforce campaign ID (regexes in `references/marketing-issue.md`). Set `marketing.issue: existing`.
+- **A file path** (brief, Google-Doc export, notes) → read it and extract the same fields.
+- **Free text** → extract what's there.
+
+Then check for prior art — this skill is **idempotent**:
+
+- Derive the slug (lowercase title, spaces → hyphens, alphanumerics and hyphens only; drop filler words only if the user's title is over 60 chars).
+- If `content/events/<slug>/index.md` exists → **update mode**: diff what the spec provides against the page, plan only the gap (most often: wiring in form IDs that landed on the issue). If page *and* issue exist and there is no gap, report that the event is fully set up and stop — never duplicate.
+- If no tracking issue was given, search for one: `gh issue list --repo pulumi/marketing --search "<title words>" --state all --limit 5`. A match → offer it as the existing issue instead of creating a duplicate.
+
+## [Step 2/5] Wizard — fill the gaps only
+
+Ask **only for fields still unknown** after Step 1, in at most two `AskUserQuestion` batches (≤4 questions each), with smart defaults marked "(Recommended)". In `-y` mode skip entirely and take every default. Free-text answers (title, description) that can't be multiple-choice: prefill suggestions from context and let "Other" carry the custom value.
+
+| Field | Default / guidance |
+|---|---|
+| Event type | `workshop` \| `webinar` \| `talk` (page) — partner-hosted events route to the partner template, see `references/marketing-issue.md` |
+| Title | ≤ 60 chars (hard limit — trim with the user if over) |
+| Meta description | 50–160 chars, single sentence; suggest one from the abstract |
+| Date + time + timezone | No default — this is the one field worth a blocking question outside `-y`; in `-y` with no date, use a weekday ~60 days out, 9:00 AM PT, and flag it loudly |
+| Duration | `60 minutes` (90 when asked) |
+| Location | `virtual`; otherwise `City, ST` |
+| Gated | `true` for Pulumi-hosted workshops/webinars; `false` for external/on-demand |
+| External? | Default `false`. `true` → `url_slug` = external URL + `block_external_search_index: true`, no form |
+| Description (abstract) | 1–2 paragraphs; draft from whatever the user gave and show it |
+| Learn bullets | Exactly 3 outcome bullets (template convention); draft them |
+| Presenters | Prefill from git config → `data/team/team/<id>.toml` (role = its `title` + ", Pulumi"). Externals: name, role, company, optional photo |
+| Tags | `level`: Beginner/Intermediate/Advanced; `topics`/`languages`/`clouds` from the vocabulary in `references/event-page.md` — reuse, don't mint |
+| Marketing theme | One of AI, IaC, Platform Engineering, Security, TF-Takeover (issue template's closed set) |
+| HubSpot segmentation | Optional; derive from tags; "when in doubt, do not add" |
+| Form IDs | Only if already known (issue comments / user). Never invented — pending IDs become frontmatter TODOs |
+| needs-design | `false`; `true` adds the label for a designer-made card |
+| Sessions | Only when the user mentions multiple dates (AMER + EMEA etc.) — rules in `references/event-page.md` |
+
+## [Step 3/5] Compose the spec and confirm
+
+Assemble the **event spec** — the single artifact handed to the agent:
+
+```yaml
+event:
+  title: ""            # ≤60 chars
+  slug: ""
+  event_type: workshop # workshop | webinar | talk
+  meta_desc: ""        # 50–160 chars
+  date: YYYY-MM-DD
+  time: "HH:MM"
+  timezone: America/Los_Angeles   # IANA name; agent computes the DST-correct offset
+  duration: 60 minutes
+  location: virtual
+  gated: true
+  external: false
+  external_url: ""
+  featured: false
+  description: |
+    ...
+  learn: ["", "", ""]
+  presenters:
+    - {name: "", role: "", pulumi: true, photo: ""}   # role/photo auto-resolved for Pulumi folks
+  tags: {level: Beginner, topics: [], languages: [], clouds: []}
+  sessions: []         # optional; see references/event-page.md
+marketing:
+  theme: ""            # AI | IaC | Platform Engineering | Security | TF-Takeover
+  issue: create        # create | existing | skip
+  issue_url: ""
+  needs_design: false
+  hubspot_segmentation: {}
+  form: {hubspot_form_id: "", salesforce_campaign_id: ""}
+run:
+  dry_run: false
+  images: auto         # auto | event-bound | standalone | skip
+  pr: create           # create | skip
+  branch: event/<slug>
+```
+
+Show the user the spec plus a short preview: the would-be issue title (`[YYYY-MM-DD]: <Title> (<presenter first name>)`), the files to be created, and whether issue/PR will really be created. Then gate:
+
+- **Dry-run** → proceed without asking (nothing outward happens).
+- **`-y`** → proceed (the flag is the user's standing go-ahead), but still show the preview.
+- **Otherwise** → one `AskUserQuestion`: "Create it now (issue + PR)" / "Dry run first (Recommended for a first pass)" / "Cancel". Creating a GitHub issue and PR is outward-facing — never do it silently.
+
+## [Step 4/5] Delegate to the event-creator agent
+
+Spawn the **event-creator** subagent (Task/Agent tool, `subagent_type: event-creator`), passing the spec verbatim as its task plus one line: "Execute this event spec per your protocol." Wait for the result — the next step depends on it.
+
+If that agent type isn't registered in this session, don't stall: read `.claude/agents/event-creator.md` and execute its protocol yourself, inline, honoring the same hard rules (dry-run = zero GitHub writes; never push master; never invent form IDs).
+
+## [Step 5/5] Relay the report and next steps
+
+Relay the agent's structured report, then close the loop:
+
+1. **Preview before shipping**: the rendered PNGs (or the build's auto-card), and `make serve` → `http://localhost:1313/events/<slug>/`.
+2. **Dry-run** → the previews live in `.context/create-event/<slug>/`; rerun without `--dry-run` to create the issue and PR.
+3. **Pending form IDs** → gated page ships with TODOs; watch the tracking issue for marketing's comment, then rerun `/create-event <issue-url>` to wire them in (update mode).
+4. **PR is a draft** → mark ready after previewing; each ready-transition fires a full review, so do it once.
+5. Suggest `/docs-review` for a content pass when the description was substantially drafted by the wizard.
+
+## Error handling
+
+- **Slug collision with a different event** (same slug, different topic) → suffix the slug (`-2026`, or the month) and tell the user.
+- **`gh` unauthenticated / marketing repo unreachable** → finish everything local, write the issue preview, and hand the user the exact `gh issue create` command to run.
+- **Date in the past** → confirm it's intentional (recordings/on-demand pages are legitimate).
+- **User cancels at Step 3** → keep nothing outward; offer to save the spec to `.context/create-event/<slug>/spec.yaml` so a later run can resume from it.

--- a/.claude/commands/create-event/eval/evals.json
+++ b/.claude/commands/create-event/eval/evals.json
@@ -1,0 +1,55 @@
+{
+    "skill_name": "create-event",
+    "evals": [
+        {
+            "id": 0,
+            "name": "full-spec-workshop-dry-run",
+            "prompt": "/create-event I need a new workshop set up: title 'Getting Started with Pulumi on AWS', on 2026-09-24 at 11:00 AM PT, 60 minutes, virtual, gated registration. Presenter: Engin Diri. It's a beginner session about provisioning your first AWS resources with Pulumi and TypeScript: the abstract should cover installing Pulumi, standing up a VPC + S3 + Lambda starter stack, and previewing/applying changes safely. Marketing theme: IaC. Tags: level Beginner, topics Infrastructure as Code, clouds AWS, languages TypeScript. --dry-run -y",
+            "expected_output": "content/events/getting-started-with-pulumi-on-aws/index.md with archetype-complete frontmatter (workshop, gated, virtual, 60 minutes, DST-correct sortable_date 2026-09-24T11:00:00.000-07:00, Engin Diri resolved to Principal Solutions Architect + team photo, exact tags, meta_desc 50-160 chars, meta_image left blank); .context/create-event/<slug>/issue-preview.md matching the pulumi-workshop template ([2026-09-24]: title (Engin), Theme IaC, Tasks checklist) and pr-preview.md (Proposed changes / Related issues, draft, [workshop] title); zero GitHub writes.",
+            "files": [],
+            "assertions": [
+                "Bundle created at content/events/getting-started-with-pulumi-on-aws/index.md",
+                "Core frontmatter: exact title, event_type=workshop, gated=true, location=virtual, duration='60 minutes', url_slug matches",
+                "sortable_date is DST-correct: 2026-09-24T11:00:00.000-07:00",
+                "Presenter resolved from team data: Engin Diri, role contains 'Principal Solutions Architect', photo /images/team/engin-diri.jpg",
+                "Tags exact vocabulary: level=Beginner, topics=[Infrastructure as Code], clouds=[AWS], languages=[TypeScript]",
+                "meta_desc length 50-160 chars",
+                "meta_image left blank (build auto-generates; no enrichment needed)",
+                "Issue preview matches pulumi-workshop template: [2026-09-24] title with (Engin), Theme IaC, Tags + Tasks checklist (>=8 unchecked)",
+                "PR preview has Proposed changes + Related issues sections, [workshop] title, draft",
+                "Dry-run honored: report present, previews instead of created URLs, no live issue/PR claimed"
+            ]
+        },
+        {
+            "id": 1,
+            "name": "prefill-existing-issue-idempotent",
+            "prompt": "/create-event https://github.com/pulumi/marketing/issues/1688 --dry-run -y",
+            "expected_output": "Recognizes the tracking issue AND the already-merged page content/events/getting-started-with-devops-ai-skills/ (update mode / idempotence): creates no duplicate bundle and no new event directory, confirms the page already carries the HubSpot form id 10627c10-9d63-4437-8573-da3f28ad0698 and SF campaign 701PQ00000uMIkPYAW (or extracts them from the issue), reports the event as fully set up with nothing to change, zero GitHub writes.",
+            "files": [],
+            "assertions": [
+                "Idempotent: no new/duplicate event bundle created for an event that already exists",
+                "Recognizes the existing page content/events/getting-started-with-devops-ai-skills/ (update mode / already set up)",
+                "Form IDs accounted for: mentions the wired HubSpot form id or SF campaign id (or states IDs already wired)",
+                "Dry-run honored: no GitHub writes claimed, run-report.md present"
+            ]
+        },
+        {
+            "id": 2,
+            "name": "webinar-external-copresenter",
+            "prompt": "hey — we're running a joint webinar with our partner StackGuard: 'Policy as Code in CI/CD with Pulumi and StackGuard', October 15 2026, 10:00 AM ET, 60 minutes, virtual + gated. presenters: Engin Diri (pulumi) and Maya Chen, Head of Platform at StackGuard. security theme. level Beginner, topics Security and Infrastructure as Code. set it all up please --dry-run -y",
+            "expected_output": "Webinar bundle (event_type: webinar) with sortable_date 2026-10-15T10:00:00.000-04:00 (EDT), Engin resolved from team data, external presenter Maya Chen as 'Head of Platform, StackGuard' with unresolvable photo skipped-with-warning; enrichment path attempted (external co-presenter) but renderer deps missing → graceful skip with recovery commands; issue preview [2026-10-15] via the pulumi-workshop template with Theme Security; previews only, zero GitHub writes.",
+            "files": [],
+            "assertions": [
+                "Webinar bundle created (policy-as-code / StackGuard slug)",
+                "event_type is webinar, gated true, virtual",
+                "sortable_date is EDT-correct: 2026-10-15T10:00:00.000-04:00",
+                "Presenters: Engin resolved from team data; external Maya Chen as 'Head of Platform, StackGuard' with photo skipped",
+                "Tags: level Beginner; topics include Security and Infrastructure as Code",
+                "Graceful degradation reported: unresolved photo / card rendering skipped, with recovery command",
+                "Issue preview: [2026-10-15] title, Theme Security, workshop-template sections",
+                "Gated with pending form IDs: hubspot_form_id empty + TODO marker present",
+                "Dry-run honored: previews only, no created issue/PR URLs, run-report.md present"
+            ]
+        }
+    ]
+}

--- a/.claude/commands/create-event/references/event-page.md
+++ b/.claude/commands/create-event/references/event-page.md
@@ -1,0 +1,97 @@
+# Event page reference — content/events/<slug>/index.md
+
+Contents: frontmatter fields · slug rules · sortable_date recipe · tags vocabulary · presenters · registration form IDs · multi-session events · validation fallback · update mode.
+
+The single source of truth for the schema is `archetypes/event/index.md` (its comments are authoritative and kept current). This file adds the operational details the archetype can't carry.
+
+## Frontmatter fields (beyond the archetype comments)
+
+| Field | Rule |
+|---|---|
+| `title` | ≤ 60 characters, Title Case. Hard limit from the marketing template; trim with the user rather than truncating silently. |
+| `meta_desc` | 50–160 characters, one sentence — it's the card text on /events/ and the search snippet. |
+| `meta_image` / `meta_image_square` | Leave **blank** by default: the build auto-generates an on-brand card (landscape + square) from frontmatter. Set only when event-meta-image renders an enriched card into the bundle (`/events/<slug>/meta.png`, `/events/<slug>/meta-square.png`). |
+| `gated` | `true` renders the registration form (needs `form.hubspot_form_id`). Pulumi-hosted workshops/webinars default gated. |
+| `external` | `true` → `url_slug` becomes the external URL and `block_external_search_index: true` is required. No form. |
+| `url_slug` | Must equal the bundle directory name (internal events). |
+| `event_type` | `workshop` \| `webinar` \| `talk`. Also the default card overline (uppercased). |
+| `sortable_date` | ISO 8601 with milliseconds and the offset valid **on that date** — see recipe. Sorts the list, dates schema.org, stamps the card. |
+| `youtube_url` | Leave empty until the event has run. Setting it flips the page to the on-demand layout (no form, out of "Upcoming"). Multi-session: only after the **last** session. |
+| `featured` / `unlisted` | Default `false`. |
+
+## Slug rules
+
+Lowercase the title; spaces → hyphens; strip everything but `[a-z0-9-]`. Keep it readable and stable — it's the URL. On collision with a *different* event, suffix with the year (`-2026`) or month. Renaming an existing event's slug changes its URL → needs an `aliases:` entry for the old path (same SEO rule as any content move).
+
+## sortable_date recipe (DST-proof)
+
+Never hand-write the UTC offset — PT is `-07:00` in July and `-08:00` in January. Compute it from the IANA timezone:
+
+```bash
+python3 -c "from zoneinfo import ZoneInfo; from datetime import datetime; \
+print(datetime(2026, 9, 24, 11, 0, tzinfo=ZoneInfo('America/Los_Angeles')).isoformat(timespec='milliseconds'))"
+# → 2026-09-24T11:00:00.000-07:00
+```
+
+Common zones: PT `America/Los_Angeles` · ET `America/New_York` · CET/CEST `Europe/Berlin` · UK `Europe/London` · IST `Asia/Kolkata`. Stdlib-only, works on macOS and Linux.
+
+## Tags vocabulary (case-sensitive — reuse, don't mint)
+
+Harvested from existing `content/events/*/index.md`; these drive the /events/ filters, so a near-duplicate spelling creates a broken filter bucket.
+
+- `level` (exactly one): `Beginner` · `Intermediate` · `Advanced`
+- `topics`: Kubernetes · AI · Platform Engineering · DevOps · Docker · DevSecOps · Security · Secrets Management · Pulumi ESC · Automation · Infrastructure as Code · Pulumi Features · Developer Productivity · CI/CD
+- `clouds`: AWS · Azure · Google Cloud · Oracle
+- `languages`: TypeScript · Python · Golang · C# · Java · YAML
+
+Empty arrays are fine — most events set only `topics` and maybe one cloud. Before minting a new value, grep: `grep -rh "topics:" content/events/*/index.md | sort -u`.
+
+## Presenters
+
+```yaml
+presenters:
+    - name: Engin Diri
+      role: Principal Solutions Architect, Pulumi
+      photo: /images/team/engin-diri.jpg
+```
+
+- **Pulumi people**: id = kebab name → role from `data/team/team/<id>.toml` (`title` + ", Pulumi" — the TOML is fresher than copying an old event), photo `static/images/team/<id>.jpg` (verify the file exists; referenced as `/images/team/<id>.jpg`).
+- **External people**: role = `Title, Company`. Photo via the event-meta-image resolution ladder; a sourced photo is committed to `static/images/people/<kebab-name>.jpg`. Unresolvable → `photo: ""` (the page tolerates it; the card renderer skips it with a warning).
+
+## Registration form IDs
+
+`form.hubspot_form_id` (UUID) and `form.salesforce_campaign_id` (`701…`, 18 chars) are **created by marketing after the tracking issue is filed** and typically arrive as a comment on that issue. Sequencing:
+
+1. Issue filed → marketing builds the HubSpot form + SF campaign → posts IDs on the issue.
+2. Until then a gated page carries empty strings with a `# TODO: wire in from pulumi/marketing#<n>` comment, and the PR body flags it.
+3. When the IDs land, rerun `/create-event <issue-url>` — update mode wires them in.
+
+Extraction regexes (scan issue comments): HubSpot `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` · Salesforce `\b701[A-Za-z0-9]{15}\b`.
+
+## Multi-session events (`sessions:`)
+
+One event on several dates (Americas + EMEA) is **one page** with a `sessions:` array — never two bundles. The archetype documents the shape; `make lint` (`checkEventSessions`) enforces:
+
+1. Top-level `sortable_date` = the **earliest** session's date.
+2. No top-level `form:` — each session carries its own (`hubspot_form_id` required per session when gated; don't reuse one form ID across sessions).
+3. `sessions` is a non-empty array or absent entirely.
+
+And the un-lintable rule: no `youtube_url` until every session has run.
+
+## Validation fallback (when `make lint` can't run)
+
+Fresh clones/worktrees may lack node deps. Best effort, in order: try `make lint`; on missing deps run this checklist manually:
+
+1. Frontmatter parses: `python3 -c "import yaml; yaml.safe_load(open('content/events/<slug>/index.md').read().split('---')[1])"`
+2. `title` ≤ 60 chars; `meta_desc` 50–160 chars.
+3. `event_type` ∈ {workshop, webinar, talk}; `tags.level` ∈ {Beginner, Intermediate, Advanced}.
+4. `url_slug` == directory name (or external URL + `block_external_search_index: true`).
+5. `sortable_date` matches `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}` and the offset came from the recipe.
+6. Sessions rules above, when present.
+7. No trailing whitespace; file ends with a newline.
+
+Report which validator ran. A fallback pass is not a substitute: note that `make lint` must pass in CI.
+
+## Update mode
+
+When the bundle already exists: touch only what the spec explicitly provides (usually form IDs), preserve everything else, and never regress a filled field to a default. If there's no gap at all, say so and change nothing.

--- a/.claude/commands/create-event/references/marketing-issue.md
+++ b/.claude/commands/create-event/references/marketing-issue.md
@@ -1,0 +1,132 @@
+# Marketing tracking issue reference — pulumi/marketing
+
+Contents: template routing · fetch-then-fill · title/label/assignee conventions · body sections · form-ID sequencing · gh commands · workshop template snapshot.
+
+Every Pulumi-hosted event gets a tracking issue in `pulumi/marketing` — it drives the marketing checklist (HubSpot form, SF campaign, BigMarker, promotion) and is where the form IDs come back. Example of the finished shape: pulumi/marketing#1688.
+
+## Template routing
+
+| Event | Template file | Labels (from template) |
+|---|---|---|
+| Pulumi-hosted workshop **or webinar/livestream** | `.github/ISSUE_TEMPLATE/pulumi-workshop.md` | `area/livestream`, `area/workshop` |
+| Partner-hosted event | `.github/ISSUE_TEMPLATE/partner-event.md` | `area/partners` |
+| Sponsored/conference | `sponsored-event.yml` — out of scope for this skill; point the user at the form | — |
+
+There is no separate webinar template — webinars use the workshop template (it covers any virtual session).
+
+## Fetch, then fill
+
+Always fetch the **live** template so drift never bites:
+
+```bash
+gh api repos/pulumi/marketing/contents/.github/ISSUE_TEMPLATE/pulumi-workshop.md --jq '.content' | base64 -d
+```
+
+Parse its YAML frontmatter for `labels` and `assignees` (currently `calon-pulumi, isaac-pulumi, SaraDPH` — but trust the fetch, not this sentence). Fill the body sections; keep every section heading even when empty, and keep the `## Tasks` checklist verbatim and unchecked — it's marketing's worksheet, not yours. If the fetch fails (offline), fall back to the snapshot at the bottom, and say so in the report.
+
+## Title, labels, assignees
+
+- **Title**: `[YYYY-MM-DD]: <Session Title> (<presenter first name>)` — the date is the delivery date; the parenthetical matches team practice (see #1688).
+- **Labels**: the template's own, plus `kind/task`; plus `needs-design` only when a designer-made card was requested.
+- **Assignees**: from the template frontmatter.
+
+## Body sections (workshop template)
+
+- `## Theme` — exactly one of: `AI`, `IaC`, `Platform Engineering`, `Security`, `TF-Takeover`.
+- `## Workshop Description` — four labeled parts: **Session Title** (≤ 60 chars), **Meta Description** (50–160 chars), **Abstract** (1–2 paragraphs), **Join us to learn** (3 bullets). These are the same strings as the event page — write once, use in both.
+- `## Delivery Date and Time` — `YYYY-MM-DD, H:MM AM/PM TZ`. Workshops are ideally filed ~60 days out (30 for partner events); don't block on less, just note it.
+- `## Duration` — `60 minutes` standard, `90 minutes` allowed.
+- `## Presenters` — repeat presenters: name only. New presenters: name, title, company, X handle and LinkedIn if available.
+- `## Tags` — `level:` / `topics:` / `languages:` / `clouds:` — same case-sensitive vocabulary as the event page filters.
+- `## HubSpot Segmentation` — optional property lines; fill only what clearly applies ("When in doubt, do not add").
+- `## Tasks` — verbatim from the template, all unchecked.
+
+## Form-ID sequencing (why issue-first matters)
+
+The docs PR wants `form.hubspot_form_id` + `form.salesforce_campaign_id`; marketing creates those **from** the tracking issue and posts them back as a comment. So: file the issue first, ship the page with TODO placeholders if the IDs haven't landed, and wire them in later via update mode. Extraction from comments:
+
+```bash
+gh issue view <n> --repo pulumi/marketing --comments
+# HubSpot form id: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
+# SF campaign id:  \b701[A-Za-z0-9]{15}\b
+```
+
+Take the most recent match if several appear; if a comment labels them explicitly ("form id", "campaign"), prefer the labeled values.
+
+## gh commands
+
+```bash
+# create (real runs only — dry-run writes issue-preview.md instead)
+gh issue create --repo pulumi/marketing \
+  --title "[2026-09-24]: Getting Started with Pulumi on AWS (Engin)" \
+  --label area/livestream --label area/workshop --label kind/task \
+  --assignee calon-pulumi --assignee isaac-pulumi --assignee SaraDPH \
+  --body-file .context/create-event/<slug>/issue-body.md
+
+# search for an existing issue before creating
+gh issue list --repo pulumi/marketing --search "<title words>" --state all --limit 5
+```
+
+## Snapshot: pulumi-workshop.md (fallback only — fetched 2026-08; the live file wins)
+
+```markdown
+---
+name: Pulumi Workshop
+about: Marketing activities for a virtual workshop hosted by Pulumi
+title: "[YYYY-MM-DD]: [WORKSHOP_NAME]"
+labels: area/livestream, area/workshop
+assignees: calon-pulumi, isaac-pulumi, SaraDPH
+---
+
+## Theme
+
+## Workshop Description
+
+**Session Title**:
+
+**Meta Description**:
+
+**Abstract**:
+
+**Join us to learn**:
+-
+-
+-
+
+## Delivery Date and Time
+
+## Duration
+60 minutes
+
+## Presenters
+
+## Tags
+
+level:
+topics:
+languages:
+clouds:
+
+## HubSpot Segmentation
+
+Interest: Topics -
+Interest: Infrastructure Type -
+Interest: Cloud Provider -
+Interest: Competitive Set -
+Interest: Programming Languages -
+Preferred Programming Language -
+
+## Tasks
+
+- [ ] Workshop details (Date/time, Title, Abstracts, Agenda, Presenters)
+- [ ] HubSpot form and Lists
+- [ ] SF campaign with a theme as parent campaign
+- [ ] Workshop Link on /resources page
+- [ ] BigMarker Invite w/presenter links
+- [ ] SDR routing
+- [ ] Social Organic promotion
+- [ ] Social Paid promotion
+- [ ] Pulumi Cloud organization and invites
+- [ ] Targeted emails
+- [ ] After event/workshop emails
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,12 @@ Case studies live at `content/case-studies/<slug>.md` — scaffold a new one wit
 
 ---
 
+## Events
+
+Event pages live at `content/events/<slug>/index.md` — a bundle whose content is entirely frontmatter; the schema's source of truth is `archetypes/event/index.md` (its comments are kept current). **Create a new event with the `/create-event` skill** (`.claude/commands/create-event/SKILL.md`): it collects details from the prompt or an interactive wizard, scaffolds the bundle, generates social cards via `/event-meta-image`, files the pulumi/marketing tracking issue from its issue template, and opens the docs PR. It supports `--dry-run` (writes issue/PR previews instead of touching GitHub) and delegates execution to the `event-creator` subagent (`.claude/agents/event-creator.md`). HubSpot form and Salesforce campaign IDs come back from marketing on the tracking issue — never invent them; a gated page carries TODO placeholders until they land, then a rerun of `/create-event <issue-url>` wires them in.
+
+---
+
 ## Releases changelog entries
 
 Individual changelog items live in `content/releases/changelog/` — one markdown file per entry, listed by month on `/releases/` and rendered at `/releases/changelog/<slug>/` (`layouts/changelog/single.html`). Shared images/videos live in the `images/` and `videos/` subfolders and are referenced by absolute path (e.g. `/releases/changelog/images/2026-06-18-foo.png`), so entry renames don't affect them.


### PR DESCRIPTION
### Proposed changes

Adds a `/create-event` skill that creates Pulumi events (workshops, webinars, partner events) end to end: collects details from the prompt or an interactive wizard, scaffolds the `content/events/<slug>/` bundle, generates social cards via `/event-meta-image`, files the pulumi/marketing tracking issue from its issue template, and opens the docs PR. A `--dry-run` mode writes issue/PR previews instead of touching GitHub.

- `.claude/commands/create-event/` — SKILL.md, event-page + marketing-issue references, and a committed eval set (3 cases; with-skill runs passed 23/23 assertions vs 75% for unassisted baselines — the deltas were convention fidelity: current team-TOML roles, `[YYYY-MM-DD]: Title (Name)` issue titles, PR body structure, `.000` date format, renderer recovery paths)
- `.claude/agents/event-creator.md` — companion subagent that executes the confirmed event spec (preloads `event-meta-image`; dry-run = zero GitHub writes, never invents HubSpot/SF form IDs)
- `AGENTS.md` — new Events section pointing at the skill and `archetypes/event/index.md`