### PR TITLE
Add GA update notice to journaling opt-in blog post

### DIFF
--- a/content/blog/journaling/index.md
+++ b/content/blog/journaling/index.md
@@ -56,6 +56,10 @@ social:
 
 Today we're introducing an improvement that can speed up operations by up to 20x. At every operation, and at every step within an operation, `pulumi` saves a snapshot of your cloud infrastructure. This gives `pulumi` a current view of state even if something fails mid-operation, but it comes with a performance penalty for large stacks. Here's how we fixed it.
 
+{{% notes type="info" %}}
+Update: Journaling reached general availability in March 2026 and is now enabled by default for all Pulumi Cloud organizations on CLI v3.225.0+, no opt-in required. See [Now GA: Up to 20x Faster Pulumi Operations for Everyone](/blog/journaling-ga/) for details, including how to opt out with `PULUMI_DISABLE_JOURNALING`.
+{{% /notes %}}
+
 <!--more-->
 
 ## Benchmarks

--- a/content/blog/journaling/index.md
+++ b/content/blog/journaling/index.md
@@ -3,6 +3,8 @@ title: "Speeding up Pulumi Operations by up to 20x"
 
 date: 2026-01-12T18:57:55+02:00
 
+updated: 2026-08-14
+
 draft: false
 
 meta_desc: Pulumi operations get up to 20x faster with journaling, a new snapshotting approach that speeds up large stacks while keeping full data integrity.


### PR DESCRIPTION
## Summary
- Journaling reached GA in March 2026 and is now on by default on CLI v3.225.0+; the January opt-in post ([Speeding up Pulumi Operations by up to 20x](https://www.pulumi.com/blog/journaling/)) still tells readers to set `PULUMI_ENABLE_JOURNALING=true` and reach out to Support to opt in.
- Adds an info notice near the top of the post linking to the [GA post](https://www.pulumi.com/blog/journaling-ga/) and noting `PULUMI_DISABLE_JOURNALING` for opting back out.
- Prompted by a support ticket where a customer asked to be opted into journaling, unaware it's now automatic.

## Test plan
- [x] Verify the notice renders correctly in the PR preview build (local Hugo preview was blocked by unrelated theme toolchain issues - stencil subpackage / tslib resolution - not evaluated locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)