### PR TITLE
Replace Zendesk support portal links with support@pulumi.com

### DIFF
--- a/content/docs/administration/onboarding-guide/choose-edition.md
+++ b/content/docs/administration/onboarding-guide/choose-edition.md
@@ -38,7 +38,7 @@ Designed for larger organizations with mission-critical workloads. These edition
 - **Priority access**: Prioritized bugs and feature requests, plus product roadmap reviews
 - **Custom training**: Tailored onboarding and ongoing training for your team
 
-Access your support through the [support portal](https://support.pulumi.com/hc/en-us) if you're on the Enterprise or Business Critical edition.
+Contact Pulumi support at [support@pulumi.com](mailto:support@pulumi.com) if you're on the Enterprise or Business Critical edition.
 
 {{% notes type="info" %}}
 Learn more about the differences between [the editions](/pricing/).

--- a/content/docs/support/getting-support.md
+++ b/content/docs/support/getting-support.md
@@ -28,7 +28,7 @@ Pulumi staff are active in both the community Slack and on GitHub, but response 
 Customers on a paid support plan have access to direct support channels with response-time commitments:
 
 - **Private chat channel** — A dedicated chat channel with Pulumi support staff for your organization.
-- **Direct email support** — Contact Pulumi support directly via the [Pulumi support portal](https://support.pulumi.com/).
+- **Direct email support** — Contact Pulumi support directly via [support@pulumi.com](mailto:support@pulumi.com).
 
 If you are on a paid plan and aren't sure how to reach your support channel, contact your Pulumi account team.
 

--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -13,7 +13,7 @@ For more details, see our [security whitepaper](/security/pulumi-cloud-security-
 
 ## Vulnerability Reporting
 
-If you believe you’ve discovered a potential vulnerability in Pulumi’s security, please contact us at [security@pulumi.com](mailto:security@pulumi.com). For non-critical matters please file an issue with [Pulumi support](https://support.pulumi.com/).
+If you believe you’ve discovered a potential vulnerability in Pulumi’s security, please contact us at [security@pulumi.com](mailto:security@pulumi.com). For non-critical matters please contact Pulumi support at [support@pulumi.com](mailto:support@pulumi.com).
 
 When reporting a potential vulnerability, please include as much of the following information as possible.
 


### PR DESCRIPTION
### Proposed changes

Pulumi support is moving away from the Zendesk portal, so the places that promise email support but route the reader to the portal now link the address directly.

**`/docs/support/getting-support/`** — the "Direct email support" bullet under *With a paid support plan*:

> - **Direct email support** — Contact Pulumi support directly via ~~the [Pulumi support portal](https://support.pulumi.com/)~~ [support@pulumi.com](mailto:support@pulumi.com).

**`/security/`** — vulnerability reporting:

> For non-critical matters please ~~file an issue with [Pulumi support](https://support.pulumi.com/)~~ contact Pulumi support at [support@pulumi.com](mailto:support@pulumi.com).

("file an issue with" became "contact ... at", since emailing support isn't filing an issue.)

**`/docs/administration/onboarding-guide/choose-edition/`** — Enterprise / Business Critical support:

> ~~Access your support through the [support portal](https://support.pulumi.com/hc/en-us)~~ Contact Pulumi support at [support@pulumi.com](mailto:support@pulumi.com) if you're on the Enterprise or Business Critical edition.

### Scope

The site links `support.pulumi.com` in 17 other spots — the footer, `/support/`, `/contact/`, `/extend-trial/`, the six SAML pages, the SCIM FAQ, publishing packages, Terraform next steps, and the "Submit support ticket" buttons on the community/topics/migrate pages. Kelsey reviewed that list and confirmed these three are the Zendesk ones; the rest route through HubSpot and stay as they are.

Worth a second look at some point: `/support/` is a bare `redirect_to` the portal, so `pulumi.com/support` drops you straight into Zendesk. Out of scope here.

### Related issues (optional)

Requested in Slack: https://pulumi.slack.com/archives/C85BS3LJZ/p1786642291773499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDQeJJLhc82j37nGks7Mcs