### PR TITLE
Keep the statuspage badge clear of the Intercom launcher

### DIFF
--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -1,7 +1,13 @@
 {{ $f := .Site.Data.footer }}
 {{ partial "footer/cta.html" . }}
 
-<footer class="relative bg-service-black text-white overflow-clip px-6 lg:px-8 pt-12 pb-8 ">
+{{/* The bottom padding and the bottom row's right margin below both keep the
+     statuspage badge clear of the Intercom launcher, which floats over the
+     page bottom-right at right: 100px / bottom: 25px in a 48px circle (padding
+     set in the Intercom workspace, shared with app.pulumi.com). Small screens
+     center the badge, so there it has to clear the launcher vertically; lg+
+     right-aligns it, so there it clears horizontally instead. */}}
+<footer class="relative bg-service-black text-white overflow-clip px-6 lg:px-8 pt-12 pb-24 lg:pb-8 ">
     <div class="absolute top-0 right-0 pointer-events-none max-w-[50%] opacity-90" aria-hidden="true">
         {{ if (resources.Get "fingerprinted/images/footer/bg-lines.svg") }}
             {{ partial "fingerprinted-img.html" (dict "src" "images/footer/bg-lines.svg" "alt" "" "ariaHidden" "true" "loading" "lazy" "width" "421" "height" "474") }}
@@ -64,7 +70,7 @@
         </div>
     </div>
 
-    <div class="mt-24 pt-6 flex flex-col lg:flex-row gap-4 lg:gap-6 items-center justify-between lg:mr-12">
+    <div class="mt-24 pt-6 flex flex-col lg:flex-row gap-4 lg:gap-6 items-center justify-between lg:mr-32">
         <ul class="text-xs flex flex-wrap gap-x-4 gap-y-2 justify-center lg:justify-start items-center">
             <li>
                 <a class="text-white opacity-70 hover:opacity-100 hover:underline cursor-pointer"


### PR DESCRIPTION
### Proposed changes

Intercom's launcher now floats at `right: 100px` (horizontal padding set in the Intercom workspace, which app.pulumi.com shares), so it sits on top of the "All Systems Operational" badge at the bottom of the footer.

* `lg:mr-12` -> `lg:mr-32` on the footer's bottom row, which puts the badge's right edge 160px in, 12px clear of the launcher
* `pb-8` -> `pb-24 lg:pb-8` on the footer - below `lg` the badge is centered and can't dodge sideways, so it clears the launcher vertically instead (~30px)
* Both offsets are pinned to the launcher's box (right 100px, bottom 25px, 48px circle) - if that padding gets changed in the Intercom workspace again these have to move with it
* 96px of footer padding on small screens is a noticeable gap at the bottom of every page 
* Not touched: on mobile the consent banner still goes full width under the launcher, same as before this change

### Unreleased product version (optional)

### Related issues (optional)