### PR TITLE
Restore redirect for /docs/get-started/connect-cloud/

### DIFF
--- a/scripts/redirects/general-broken-links-redirects.txt
+++ b/scripts/redirects/general-broken-links-redirects.txt
@@ -100,3 +100,9 @@ migrate/arm2pulumi/index.html|/docs/iac/guides/migration/migrating-to-pulumi/fro
 # so the social cards that were already shared need these.
 events/neo-in-a-docker-sandbox-eu/meta.png|/events/neo-in-a-docker-sandbox/meta.png
 events/neo-in-a-docker-sandbox-eu/meta-square.png|/events/neo-in-a-docker-sandbox/meta-square.png
+
+# /docs/get-started/connect-cloud/ was live on master from 2026-07-27 to 2026-08-03 and
+# died with the revert of #20428 (#20638), which left no alias or redirect behind. The
+# content question -- where the credential-setup steps ultimately live -- is still open;
+# this just stops the orphaned URL from 404ing in the meantime.
+docs/get-started/connect-cloud/index.html|/docs/get-started/


### PR DESCRIPTION
### Proposed changes

Adds one S3 redirect entry for `/docs/get-started/connect-cloud/`, which has been 404ing since 2026-08-03.

That URL was live on `master` from 2026-07-27 until the revert of #20428 (landed as #20638). The revert removed the page without leaving a Hugo alias or an S3 redirect behind, so anyone who bookmarked or linked it during the week it was up has been hitting a 404 ever since. It points at `/docs/get-started/` as the nearest live equivalent.

```text
docs/get-started/connect-cloud/index.html|/docs/get-started/
```

Placed in `general-broken-links-redirects.txt` alongside the existing `docs/guides/index.html|/docs/iac/guides/` entries, with a comment recording why the URL died.

**Verification**
- Confirmed no existing redirect or alias covers the path (grepped `scripts/redirects/` and `content/docs/get-started/`).
- Confirmed the destination `/docs/get-started/` exists (`content/docs/get-started/_index.md`).
- Re-parsed the file with the same filter `scripts/make-s3-redirects.js` uses: 99 entries, 0 malformed.
- Because the key starts with `docs/` and ends in `.html`, `make-s3-redirects.js` also emits the `.md` variant automatically, so the CLI's markdown content negotiation gets a 301 rather than a 404.

**Deliberately scoped to the URL only.** Where the credential-setup content ultimately belongs is still open -- Chris's counter-proposal was to fix it inside the flow rather than on the landing page -- and that decision is tracked separately. This just stops the orphaned URL bleeding in the meantime.

### Unreleased product version (optional)

N/A

### Related issues (optional)

Follows up the revert in #20638 (which reverted #20428).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8RuW2DPPkTaiLJLDGDEpr)_