### PR TITLE
claims-reverify: actually upload the report artifact (dotfile excluded by upload-artifact)

### DIFF
--- a/.github/workflows/claims-reverify.yml
+++ b/.github/workflows/claims-reverify.yml
@@ -198,6 +198,15 @@ jobs:
         with:
           name: claims-reverify-report
           path: .claims-reverify-report.json
+          # Dotfile: upload-artifact excludes hidden files unless told
+          # otherwise, and hashFiles() has no such exclusion — so without this
+          # the step runs and uploads nothing, with only a warning annotation.
+          # That's exactly what happened on every run before 2026-08. The
+          # hashFiles guard above covers the legitimately-absent report (job
+          # died before the write), so a no-files result here can only be a
+          # regression of the hidden-file kind: fail loudly.
+          include-hidden-files: true
+          if-no-files-found: error
           retention-days: 90
 
       # Counts only + a run link — the evidence lives in the report artifact


### PR DESCRIPTION
### Proposed changes

**This touches `.github/workflows/` (a deployable path), so the automated review sweep will punt it to a human by design. Written accordingly — exact before/after below.**

The nightly claims re-verify workflow writes its report to a **dot-prefixed** file, `.claims-reverify-report.json`, and `actions/upload-artifact` v4.4+ **excludes hidden files by default** (`include-hidden-files: false`). The "Upload re-verify report" step has therefore been silently no-op'ing on every run:

- The step's gate `if: always() && hashFiles('.claims-reverify-report.json') != ''` **does** match dotfiles, so the step ran.
- The uploader's own glob then excluded the file, producing only a warning annotation. From run [31780468227](https://github.com/pulumi/docs/actions/runs/31780468227) (2026-08-14):
  > No files were found with the provided path: .claims-reverify-report.json. No artifacts will be uploaded.
- Meanwhile the same file was demonstrably present in that run — it was `cat`-ed to stdout, read by `jq` for the Slack summary, and read by `signal-health.py` — so the only durable copy of the report is a log dump that masks the org name and ages out with the run.

**What changed** (one step, two settings + a comment):

1. `include-hidden-files: true` — opts the dotfile back in. This is the same setting every other dot-path upload in this repo already carries (`content-review-article.yml` ×2, `blog-review-index.yml` ×2, `claude-code-review.yml`); `claims-reverify.yml` was the only one missing it.
1. `if-no-files-found: error` — the previous default (`warn`) is what let this fail silently for the lane's entire life. With the `hashFiles()` guard still in place, the legitimately-absent case (job died before the report was written) skips the step entirely, so an empty upload here can only mean the present-but-excluded regression class — that should fail the job loudly, not emit an annotation nobody reads. No reason was found for it to stay a warning.

**Why not rename the file instead:** dropping the leading dot would also work but touches ~11 references (workflow ×6, `reverify-claims.py` argparse default + docstrings, `signal-health.py` docstring, `.gitignore`) for no added safety, and the dot-prefix is the established convention for this pipeline's working files.

**Sweep for the same latent bug:** every `upload-artifact` step in `.github/workflows/` was checked; this was the only dot-prefixed path without `include-hidden-files: true`. The other dot-files in this workflow (`.health-state.json`) round-trip via S3, not artifacts, and are unaffected.

**Validation:** YAML parses; `.github/` is outside both `make lint` lanes (prettier ignores it via `.prettierignore`, lint-markdown only covers content), so runtime behavior is reasoned above rather than tested — the next scheduled run is the real test: it should produce a `claims-reverify-report` artifact with 90-day retention.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Follow-up to the claims-reverify lane turned on 2026-08-11 (#20851 context). Observed on run 31780468227, job 94705045145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp4LqiP4u81uT48MS8Hea4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp4LqiP4u81uT48MS8Hea4)_