### PR TITLE
Add HCL to the language lists it was missing from

### DIFF
--- a/content/docs/iac/_index.md
+++ b/content/docs/iac/_index.md
@@ -10,7 +10,7 @@ menu:
         weight: 1
 meta_desc: Learn how to create, deploy, and manage infrastructure on any cloud using Pulumi's open source infrastructure as code SDK.
 h1: Infrastructure as Code
-description: <p>Define and manage cloud infrastructure using familiar programming languages. Pulumi's <a href="https://github.com/pulumi/pulumi" target="_blank">open source</a> infrastructure as code SDK supports TypeScript, Python, Go, .NET, Java, and YAML.</p>
+description: <p>Define and manage cloud infrastructure using familiar programming languages. Pulumi's <a href="https://github.com/pulumi/pulumi" target="_blank">open source</a> infrastructure as code SDK supports TypeScript, Python, Go, .NET, Java, YAML, and HCL.</p>
 link_buttons:
   primary:
     label: Get Started
@@ -55,6 +55,9 @@ sections:
   - label: YAML
     icon: icon-32-32 yaml-color-32-32
     link: /docs/iac/languages-sdks/yaml/
+  - label: HCL
+    icon: icon-32-32 hcl-color-32-32
+    link: /docs/iac/languages-sdks/hcl/
 - type: button-cards
   heading: Resources
   cards:

--- a/content/docs/iac/comparisons/cdktf.md
+++ b/content/docs/iac/comparisons/cdktf.md
@@ -41,7 +41,7 @@ CDK for Terraform (CDKTF) was a HashiCorp project, released in 2020 and [depreca
 | Feature | Pulumi | CDKTF |
 | --- | --- | --- |
 | Language support | {{< pulumi-languages >}} | TypeScript, Python, Go, C#, Java |
-| Cloud and service support | [Pulumi Registry](/registry/) of packages, including [bridged, native, parameterized, and dynamic providers](/docs/iac/concepts/providers/#types-of-providers); first-party native providers for [Kubernetes](/registry/packages/kubernetes/) and [Azure Native](/registry/packages/azure-native/); [any Terraform provider](/docs/iac/concepts/providers/any-terraform-provider/) can be adapted into a Pulumi provider, and [Terraform modules](/docs/iac/using-pulumi/extending-pulumi/use-terraform-module/) can be consumed directly | Terraform providers only, accessed through project-specific SDKs generated on demand by `cdktf get` |
+| Cloud and service support | [Pulumi Registry](/registry/) of packages, including [bridged, native, parameterized, and dynamic providers](/docs/iac/concepts/providers/#types-of-providers); first-party native providers for [Kubernetes](/registry/packages/kubernetes/) and [Azure Native](/registry/packages/azure-native/); [any Terraform provider](/docs/iac/concepts/providers/any-terraform-provider/) can be adapted into a Pulumi provider, and [Terraform modules](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) can be consumed directly | Terraform providers only, accessed through project-specific SDKs generated on demand by `cdktf get` |
 | Transpiled to another format? | No — programs run directly in their host language | Yes — programs are synthesized into Terraform JSON and deployed by the Terraform CLI |
 | State management | [Managed by Pulumi Cloud by default](/docs/iac/concepts/state-and-backends/); self-managed backends include Amazon S3, Azure Blob Storage, Google Cloud Storage, local files, and others | Local, remote, or cloud-hosted (the Terraform state model) |
 | Secrets management | [Encrypted in transit and at rest](/docs/iac/concepts/secrets/) in the state file by default, with per-stack encryption keys; pluggable KMS providers (AWS KMS, Azure Key Vault, Google Cloud KMS, HashiCorp Vault) | No built-in secrets primitive |
@@ -62,7 +62,7 @@ Pulumi and CDKTF both let you author infrastructure in general-purpose languages
 
 ### Cloud and service coverage
 
-CDKTF supported Terraform providers through project-specific SDKs generated on demand by `cdktf get`. Pulumi supports the [Pulumi Registry](/registry/) of pre-built providers — including native providers for [Kubernetes](/registry/packages/kubernetes/) and [Azure Native](/registry/packages/azure-native/) generated directly from each platform's API schema for same-day coverage of new resources — and can additionally [generate typed SDKs on demand](/docs/iac/get-started/terraform/terraform-providers/) for any Terraform provider. Pulumi also supports referencing [Terraform modules directly](/docs/iac/using-pulumi/extending-pulumi/use-terraform-module/) without rewriting them, so existing module investment is preserved during migration.
+CDKTF supported Terraform providers through project-specific SDKs generated on demand by `cdktf get`. Pulumi supports the [Pulumi Registry](/registry/) of pre-built providers — including native providers for [Kubernetes](/registry/packages/kubernetes/) and [Azure Native](/registry/packages/azure-native/) generated directly from each platform's API schema for same-day coverage of new resources — and can additionally [generate typed SDKs on demand](/docs/iac/get-started/terraform/terraform-providers/) for any Terraform provider. Pulumi also supports referencing [Terraform modules directly](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) without rewriting them, so existing module investment is preserved during migration.
 
 ### Execution and rollbacks
 
@@ -103,7 +103,7 @@ The [Automation API](/docs/iac/concepts/automation-api/) lets a host application
 There are several common paths for migrating from CDKTF to Pulumi, and they can be combined:
 
 1. **Use Terraform/CDKTF state alongside Pulumi.** Pulumi can [reference local or remote Terraform state](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/) — including the state produced by a CDKTF deployment — from a Pulumi program. This lets you continue managing a subset of your infrastructure with CDKTF (or Terraform) while incrementally moving the rest to Pulumi.
-1. **Consume Terraform modules directly.** Pulumi can [reference Terraform modules directly](/docs/iac/using-pulumi/extending-pulumi/use-terraform-module/) by generating language-specific SDKs on demand, so existing module investment is preserved.
+1. **Consume Terraform modules directly.** Pulumi can [reference Terraform modules directly](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) by generating language-specific SDKs on demand, so existing module investment is preserved.
 1. **Convert with `pulumi convert --from terraform`.** Run `cdktf synth` to produce Terraform JSON, then convert that JSON to Pulumi with `pulumi convert --from terraform`. For state, [`pulumi-terraform-migrate`](https://github.com/pulumi/pulumi-tool-terraform-migrate) translates Terraform state into Pulumi state.
 1. **Import existing resources.** [`pulumi import`](/docs/iac/guides/migration/import/) and the [`import` resource option](/docs/iac/concepts/resources/options/import/) bring already-provisioned resources under Pulumi management and generate the corresponding code in your chosen language.
 1. **Automated migration with Pulumi Neo (recommended).** [Pulumi Neo](/product/neo/) automates code conversion and state migration, then runs `pulumi preview` to verify zero changes before you commit. See [Migrating from Terraform/CDKTF to Pulumi](/docs/iac/guides/migration/migrating-to-pulumi/from-terraform/).
@@ -130,7 +130,7 @@ Yes. [`pulumi-terraform-migrate`](https://github.com/pulumi/pulumi-tool-terrafor
 
 ### Does Pulumi support Terraform modules and providers?
 
-Yes. Pulumi can [adapt any Terraform provider](/docs/iac/concepts/providers/any-terraform-provider/) and can [reference Terraform modules directly](/docs/iac/using-pulumi/extending-pulumi/use-terraform-module/) by generating language-specific SDKs on demand. Many of Pulumi's most popular registry providers are also derived from upstream Terraform provider schemas, so resource models often map one-to-one with CDKTF code.
+Yes. Pulumi can [adapt any Terraform provider](/docs/iac/concepts/providers/any-terraform-provider/) and can [reference Terraform modules directly](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) by generating language-specific SDKs on demand. Many of Pulumi's most popular registry providers are also derived from upstream Terraform provider schemas, so resource models often map one-to-one with CDKTF code.
 
 ### Can Pulumi coexist with existing Terraform or CDKTF deployments?
 

--- a/content/docs/iac/concepts/plugins.md
+++ b/content/docs/iac/concepts/plugins.md
@@ -111,7 +111,7 @@ Use this configuration file when developing custom components or providers to di
 
 | Name | Required | Description | Options |
 | - | - | - | - |
-| `runtime` | required | Installed language runtime used to run the plugin: `nodejs`, `python`, `go`, `dotnet`, `java`, `yaml`, or `bun`. | [runtime options](#plugin-runtime-options) |
+| `runtime` | required | Installed language runtime used to run the plugin: `nodejs`, `python`, `go`, `dotnet`, `java`, `yaml`, `hcl`, or `bun`. | [runtime options](#plugin-runtime-options) |
 | `packages` | optional | Additional packages to be used in the plugin. | Same as [`Pulumi.yaml` packages](/docs/iac/concepts/projects/project-file/#packages-options) |
 | `requiredPulumiVersion` | optional | The version range of the Pulumi CLI this plugin requires. | Same as [`Pulumi.yaml` requiredPulumiVersion](/docs/iac/concepts/projects/project-file/#requiredpulumiversion-options) |
 

--- a/content/docs/iac/concepts/projects/_index.md
+++ b/content/docs/iac/concepts/projects/_index.md
@@ -25,13 +25,13 @@ A Pulumi project is any folder that contains a `Pulumi.yaml` project file. At ru
 
 ## The project file (Pulumi.yaml) {#pulumi-yaml}
 
-The project file specifies which runtime to use and determines where to look for the program that should be executed during deployments. Supported runtimes are `nodejs`, `python`, `dotnet`, `go`, `java`, and `yaml`.
+The project file specifies which runtime to use and determines where to look for the program that should be executed during deployments. Supported runtimes are `nodejs`, `python`, `dotnet`, `go`, `java`, `yaml`, and `hcl`.
 
 Project files also contain metadata about your project. The project file must begin with a capital `P`, although either `.yml` or `.yaml` extension will work.
 
 A typical `Pulumi.yaml` file looks like the following. The `runtime` value depends on the language you choose:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
 
 {{% choosable language typescript %}}
 
@@ -87,10 +87,19 @@ description: A minimal Pulumi program.
 ```
 
 {{% /choosable %}}
+{{% choosable language hcl %}}
+
+```yaml
+name: webserver
+runtime: hcl
+description: A minimal Pulumi program.
+```
+
+{{% /choosable %}}
 
 {{< /chooser >}}
 
-Each language has its own conventions for locating the program's entrypoint. For TypeScript, the working directory should contain a `package.json` file that points to an entrypoint such as `index.ts`. For Python, the presence of a `__main__.py` or `setup.py` file defines the entrypoint. Go, .NET, and Java follow the conventions of their respective build tools.
+Each language has its own conventions for locating the program's entrypoint. For TypeScript, the working directory should contain a `package.json` file that points to an entrypoint such as `index.ts`. For Python, the presence of a `__main__.py` or `setup.py` file defines the entrypoint. Go, .NET, and Java follow the conventions of their respective build tools. For HCL, the working directory should contain one or more `.tf` files.
 
 The following are other examples of `Pulumi.yaml` files that define project configurations for other use cases.
 

--- a/content/docs/iac/concepts/projects/project-file.md
+++ b/content/docs/iac/concepts/projects/project-file.md
@@ -29,7 +29,7 @@ For Pulumi programs specifically written in Pulumi YAML, the project file not on
 | Name | Required | Description | Options |
 | - | - | - | - |
 | `name` | required | Name of the project containing alphanumeric characters, hyphens, underscores, and periods. | None |
-| `runtime` | required | Installed language runtime of the project: `nodejs`, `python`, `go`, `dotnet`, `java`, `yaml`, or `bun`. | [runtime options](#runtime-options)
+| `runtime` | required | Installed language runtime of the project: `nodejs`, `python`, `go`, `dotnet`, `java`, `yaml`, `hcl`, or `bun`. | [runtime options](#runtime-options)
 | `description` | optional | A brief description of the project. | None |
 | `author` | optional | The author of the project. | None |
 | `website` | optional | A URL for the project's website or repository. | None |

--- a/content/docs/integrations/clouds/aws/_index.md
+++ b/content/docs/integrations/clouds/aws/_index.md
@@ -21,7 +21,7 @@ To start from scratch, follow the [AWS get-started guide](/docs/iac/get-started/
 
 ## Infrastructure as Code
 
-[Pulumi IaC](/docs/iac/) lets you define cloud infrastructure using TypeScript, Python, Go, C#, Java, or YAML — with deterministic deployments, a state backend, and a rich ecosystem of packages.
+[Pulumi IaC](/docs/iac/) lets you define cloud infrastructure using TypeScript, Python, Go, C#, Java, YAML, or HCL — with deterministic deployments, a state backend, and a rich ecosystem of packages.
 
 Pulumi provides several packages for working with AWS. Most projects combine more than one. For a deeper comparison, see [Choosing a Pulumi AWS provider](/docs/iac/guides/clouds/aws/providers/).
 

--- a/content/docs/integrations/clouds/azure/_index.md
+++ b/content/docs/integrations/clouds/azure/_index.md
@@ -21,7 +21,7 @@ To start from scratch, follow the [Azure get-started guide](/docs/iac/get-starte
 
 ## Infrastructure as Code
 
-[Pulumi IaC](/docs/iac/) lets you define cloud infrastructure using TypeScript, Python, Go, C#, Java, or YAML — with deterministic deployments, a state backend, and a rich ecosystem of packages.
+[Pulumi IaC](/docs/iac/) lets you define cloud infrastructure using TypeScript, Python, Go, C#, Java, YAML, or HCL — with deterministic deployments, a state backend, and a rich ecosystem of packages.
 
 Pulumi provides several packages for Azure. For core infrastructure, Azure Native is the recommended choice; Azure Classic is the older alternative. Additional packages cover identity (azuread), Azure DevOps, and static websites. For a deeper comparison, see [Choosing a Pulumi Azure provider](/docs/iac/guides/clouds/azure/).
 

--- a/content/docs/integrations/clouds/gcp/_index.md
+++ b/content/docs/integrations/clouds/gcp/_index.md
@@ -25,7 +25,7 @@ To start from scratch, follow the [Google Cloud get-started guide](/docs/iac/get
 
 ## Infrastructure as Code
 
-[Pulumi IaC](/docs/iac/) lets you define cloud infrastructure using TypeScript, Python, Go, C#, Java, or YAML — with deterministic deployments, a state backend, and a rich ecosystem of packages.
+[Pulumi IaC](/docs/iac/) lets you define cloud infrastructure using TypeScript, Python, Go, C#, Java, YAML, or HCL — with deterministic deployments, a state backend, and a rich ecosystem of packages.
 
 - [Google Cloud provider](/registry/packages/gcp/) — the default Google Cloud provider. Manages a broad set of Google Cloud resources.
 - [Docker](/registry/packages/docker/) — build and push Docker images to Artifact Registry, Container Registry, or other registries.

--- a/content/docs/integrations/clouds/kubernetes/_index.md
+++ b/content/docs/integrations/clouds/kubernetes/_index.md
@@ -21,7 +21,7 @@ To start from scratch, follow the [Kubernetes get-started guide](/docs/iac/get-s
 
 ## Infrastructure as Code
 
-[Pulumi IaC](/docs/iac/) lets you define cloud infrastructure using TypeScript, Python, Go, C#, Java, or YAML — with deterministic deployments, a state backend, and a rich ecosystem of packages.
+[Pulumi IaC](/docs/iac/) lets you define cloud infrastructure using TypeScript, Python, Go, C#, Java, YAML, or HCL — with deterministic deployments, a state backend, and a rich ecosystem of packages.
 
 - [Kubernetes provider](/registry/packages/kubernetes/) — provision any resource available in the Kubernetes API.
 - [Helm charts](/registry/packages/kubernetes/api-docs/helm/v4/chart/) — deploy Helm charts via the Kubernetes provider, with full lifecycle management and value inputs as typed Pulumi resources.

--- a/theme/src/scss/docs/_docs-home.scss
+++ b/theme/src/scss/docs/_docs-home.scss
@@ -136,10 +136,20 @@ section.docs-home {
         }
 
         &.languages a {
-            flex-basis: 32%;
+            // Don't grow. The language count doesn't divide evenly into every
+            // row, and a growing flex item would stretch the leftover card to
+            // the full width of its row. A fixed basis keeps every card the
+            // same size and lets a short final row sit left-aligned instead.
+            // Each basis is sized so a full row still fills the container.
+            flex-basis: 48%;
+            flex-grow: 0;
+
+            @media (min-width: 768px) {
+                flex-basis: 32%;
+            }
 
             @media (min-width: 1240px) {
-                flex-basis: 15%;
+                flex-basis: 13%;
             }
 
             div.card-icon {


### PR DESCRIPTION
> [!WARNING]
> I've turned on auto-merge for this! 

### Proposed changes

HCL shipped as a supported language with its own section under Languages & SDKs, but a number of pages that enumerate the supported languages were never updated. Three of them are now **incorrect** rather than merely incomplete: the project, project-file, and plugin runtime tables omit `hcl`, which is a valid `runtime` value in both `Pulumi.yaml` and `PulumiPlugin.yaml`.

**Language lists**

- `iac/_index.md` — add HCL to the section description and the Languages card grid, so the IaC landing page matches its own child hub. Uses the existing `hcl-color-32-32` icon.
- `concepts/projects/_index.md` — add `hcl` to the supported-runtime list, add an HCL tab to the `Pulumi.yaml` example chooser, and note the `.tf` entrypoint convention alongside the other languages'.
- `concepts/projects/project-file.md` — add `hcl` to the `runtime` row.
- `concepts/plugins.md` — add `hcl` to the `PulumiPlugin.yaml` `runtime` row. A directory of `.tf` files with a `PulumiPlugin.yaml` declaring `runtime: hcl` is precisely how an HCL multi-language component is defined — see the [HCL component reference](https://www.pulumi.com/docs/iac/languages-sdks/hcl/hcl-component-reference/).
- `integrations/clouds/{aws,azure,gcp,kubernetes}/_index.md` — add HCL to the shared "Pulumi IaC lets you define cloud infrastructure using…" sentence. Left as prose rather than swapped for `{{< pulumi-languages >}}`, because these are *or*-lists in a different order and the shortcode emits a fixed *and*-list that doesn't read correctly in this sentence.

**Card grid fix (second commit)**

Adding the seventh language card exposed a latent layout bug: the `.languages` grid was sized for six cards, so the seventh wrapped and `flex: 1` stretched it across the full container width. The cards now take a fixed basis at each breakpoint, sized so a full row still fills the container — two per row on mobile, three at tablet, seven on one row at desktop — and a short final row sits left-aligned with every card the same size. `.languages` is used only by `content/docs/iac/_index.md`, so the blast radius is this one page.

**Adjacent fix on the same pages**

- `comparisons/cdktf.md` — point four `use-terraform-module` links at the canonical path rather than the pre-move alias, per the internal-link rule in `AGENTS.md`. The canonical path is already used in 21 other places.

**Not included**

An earlier revision added three bullets to the "What you'll learn" list on `get-started/terraform/_index.md`, on the theory that the list covered five of the section's eight pages. That was wrong and has been reverted: those five bullets are a one-to-one mirror of the five numbered items in the "Overview of examples" section below them, describing the progressive ECS/web-app example arc. The first-look, state-backend, and remote-execution pages are standalone and aren't taught through that arc. Those three pages genuinely aren't mentioned anywhere in the section intro, but fixing that means restructuring the intro — a content decision rather than a mechanical one.

This is the mechanical, verifiable slice of a larger gap. HCL is still absent from the four cloud getting-started guides, most of the core concepts pages, and `static/programs/`. Those need example programs and a product decision first, and aren't in scope here.

### Test plan

- `make lint`: 1850 files parsed, 0 errors; Prettier clean.
- Built and rendered locally with Hugo. Verified the new card, the description, the HCL chooser tab, and both runtime tables render as intended.
- Card grid checked in **both light and dark mode** at 390, 1024, and 1440 px — seven across at desktop, no full-width orphan at any width, no horizontal overflow at mobile.
- Canonical link target verified to exist on `master`; the old path confirmed to be an alias on the destination page.
- `runtime: hcl` on plugins confirmed against `pulumi/pulumi` master and our own HCL component reference.

### Related issues (optional)

None — no open issue tracks the HCL docs surface-area gap.

---
_Generated by [Claude Code](https://claude.ai/code)_
