### PR TITLE
Make "type tokens" more findable

### DIFF
--- a/content/docs/iac/concepts/resources/names.md
+++ b/content/docs/iac/concepts/resources/names.md
@@ -393,9 +393,9 @@ config:
 
 Changing the autonaming setting on an existing stack doesn't cause any immediate changes. It will only affect any newly created resources on this stack, including resources being replaced for unrelated reasons. To re-create resources with new names, e.g. on a dev stack, you would need to destroy the stack and update it again.
 
-## Resource Types and type tokens {#types}
+## Resource Types and Type Tokens {#types}
 
-Each resource is an instance of a specific Pulumi resource type.  This type is specified by a _type token_ in the format `<package>:<module>:<typename>`.  Concrete examples of this format are:
+Each resource is an instance of a specific Pulumi resource type. This type is specified by a _type token_ in the format `<package>:<module>:<typename>`. Concrete examples of this format are:
 
 - `aws:s3/bucket:Bucket`
 - `azure-native:compute:VirtualMachine`

--- a/content/docs/iac/concepts/resources/names.md
+++ b/content/docs/iac/concepts/resources/names.md
@@ -393,9 +393,9 @@ config:
 
 Changing the autonaming setting on an existing stack doesn't cause any immediate changes. It will only affect any newly created resources on this stack, including resources being replaced for unrelated reasons. To re-create resources with new names, e.g. on a dev stack, you would need to destroy the stack and update it again.
 
-## Resource Types {#types}
+## Resource Types and type tokens {#types}
 
-Each resource is an instance of a specific Pulumi resource type.  This type is specified by a type token in the format `<package>:<module>:<typename>`.  Concrete examples of this format are:
+Each resource is an instance of a specific Pulumi resource type.  This type is specified by a _type token_ in the format `<package>:<module>:<typename>`.  Concrete examples of this format are:
 
 - `aws:s3/bucket:Bucket`
 - `azure-native:compute:VirtualMachine`


### PR DESCRIPTION
We're referring to type tokens a lot more often these days, particularly with the addition of `pulumi do`, but neither Algolia nor the Googles seem to surface them all that well. This should help.