### PR TITLE
Add HCL to the AWS Get Started guide

### DIFF
--- a/content/docs/iac/get-started/aws/_index.md
+++ b/content/docs/iac/get-started/aws/_index.md
@@ -27,7 +27,7 @@ Complete this step-by-step tutorial to deploy an AWS S3 bucket-based website usi
 
 First, choose your language and ensure you've performed any prerequisites:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" / >}}
 
 {{% choosable language "typescript" %}}
 
@@ -67,6 +67,12 @@ First, choose your language and ensure you've performed any prerequisites:
 {{% choosable language "yaml" %}}
 
 * <a href="https://aws.amazon.com/free" target="_blank">An AWS account</a>
+
+{{% /choosable %}}
+
+{{% choosable language "hcl" %}}
+
+* An <a href="https://aws.amazon.com/free" target="_blank">AWS account</a>
 
 {{% /choosable %}}
 

--- a/content/docs/iac/get-started/aws/create-component.md
+++ b/content/docs/iac/get-started/aws/create-component.md
@@ -84,16 +84,44 @@ Unfortunately, YAML lacks the language facilities to author components. Feel fre
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```hcl
+resource "website_aws_s3_website" "my-website" {
+  files = [abspath("index.html")]
+}
+```
+
+{{% /choosable %}}
+
 Using components here also has the benefit that, as the requirements for S3 websites changes, you can
 update the one component definition and have all uses of it benefit.
 
 ### Define a new component
+
+{{% choosable language "typescript,python,go,csharp,java,yaml" %}}
 
 To define a new component, create a class called `AwsS3Website` that derives from `ComponentResource`. It'll have a mostly-empty
 constructor to start with but you will add the AWS S3 resources to it in the next step. You'll also define the inputs for the
 component -- the `files` to add to the website -- and outputs -- a single property with the website `url`.
 
 To get going, create a new file {{< compfile >}} alongside {{< langfile >}} and add the following:
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+In HCL, a component is a module: a directory of `.tf` files with a `PulumiPlugin.yaml` naming the `hcl` runtime. The module's `variable` blocks become the component's inputs -- the `files` to add to the website -- and its `output` blocks become the component's outputs -- a single `url` value.
+
+To get going, create a new directory called `website` alongside `main.tf` and add two files to it. First, `website/PulumiPlugin.yaml`:
+
+```yaml
+name: website
+runtime: hcl
+```
+
+Then a mostly-empty `website/main.tf` that declares the component and its inputs; you will add the AWS S3 resources to it in the next step:
+
+{{% /choosable %}}
 
 {{% choosable language typescript %}}
 
@@ -247,19 +275,63 @@ Unfortunately, YAML lacks the language facilities to author components. Feel fre
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```hcl
+terraform {
+  component {
+    name = "AwsS3Website"
+  }
+  package {
+    name    = "website"
+    version = "1.0.0"
+  }
+  required_providers {
+    aws = {
+      source = "pulumi/aws"
+    }
+  }
+}
+
+# The files to serve from the website.
+variable "files" {
+  type = list(string)
+}
+```
+
+The `component` and `package` blocks set the component's name and its package identity; everything else is an ordinary Pulumi HCL program. See the [HCL component reference](/docs/iac/languages-sdks/hcl/hcl-component-reference/) for the full details.
+
+{{% /choosable %}}
+
 This defines a component but it doesn't do much yet.
 
 ### Refactor your code into the component
 
+{{% choosable language "typescript,python,go,csharp,java,yaml" %}}
+
 Next, make four changes:
 
-1. Move all resources from {{< langfile >}} ino the component's constructor
-2. Change each resource to use the component [as the `parent`](/docs/iac/concepts/resources/options/parent/)
-3. Generalize the creation of bucket objects by looping over the list of `files`
-4. Assign the resulting website URL to the `url` property of the component
+1. Move all resources from {{< langfile >}} into the component's constructor
+1. Change each resource to use the component [as the `parent`](/docs/iac/concepts/resources/options/parent/)
+1. Generalize the creation of bucket objects by looping over the list of `files`
+1. Assign the resulting website URL to the `url` property of the component
 
 The resulting {{< compfile >}} file will look like this; you can make each edit one at a time if preferred
 to get a feel for things, or paste the contents of this into {{< compfile >}}:
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+Next, make three changes:
+
+1. Move all resources from `main.tf` into `website/main.tf`
+1. Generalize the creation of bucket objects by looping over the list of `files` with `for_each`
+1. Assign the resulting website URL to a `url` output of the module
+
+The resulting `website/main.tf` will look like this; you can make each edit one at a time if preferred
+to get a feel for things, or paste the contents of this into `website/main.tf`:
+
+{{% /choosable %}}
 
 {{% choosable language typescript %}}
 
@@ -677,6 +749,82 @@ Unfortunately, YAML lacks the language facilities to author components. Feel fre
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```hcl
+terraform {
+  component {
+    name = "AwsS3Website"
+  }
+  package {
+    name    = "website"
+    version = "1.0.0"
+  }
+  required_providers {
+    aws = {
+      source = "pulumi/aws"
+    }
+  }
+}
+
+# The files to serve from the website.
+variable "files" {
+  type = list(string)
+}
+
+# Create an S3 bucket for the website:
+resource "aws_s3_bucket" "bucket" {}
+
+# Turn the bucket into a website:
+resource "aws_s3_bucket_website_configuration" "website" {
+  bucket = aws_s3_bucket.bucket.id
+
+  index_document = {
+    suffix = "index.html"
+  }
+}
+
+# Permit access control configuration:
+resource "aws_s3_bucket_ownership_controls" "ownership-controls" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule = {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+# Enable public access to the website:
+resource "aws_s3_bucket_public_access_block" "public-access-block" {
+  bucket            = aws_s3_bucket.bucket.id
+  block_public_acls = false
+}
+
+# Upload each file to the bucket:
+resource "aws_s3_bucket_object" "files" {
+  for_each = toset(var.files)
+
+  bucket       = aws_s3_bucket.bucket.id
+  key          = basename(each.value)
+  source       = fileasset(each.value)
+  content_type = "text/html"
+  acl          = "public-read"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.ownership-controls,
+    aws_s3_bucket_public_access_block.public-access-block,
+  ]
+}
+
+# The website's URL:
+output "url" {
+  value = "http://${aws_s3_bucket_website_configuration.website.website_endpoint}"
+}
+```
+
+Two things are specific to running inside a component module. Nested properties such as `index_document` and `rule` are written as attribute maps (with `=`) rather than Terraform's nested block syntax. And `fileasset` resolves relative paths against the module's own directory, so the component takes absolute paths as input and derives each object's key from the file name with `basename`. There is no `parent` to set: resources in the module are parented to the component instance automatically.
+
+{{% /choosable %}}
+
 ### Instantiate the component
 
 Now go back to your original file {{< langfile >}}. Now that you have moved all of the resources, you can start over with a clean slate.
@@ -802,6 +950,32 @@ public class App {
 Unfortunately, YAML lacks the language facilities to author components. Feel free to [skip ahead](/docs/iac/get-started/aws/destroy-stack/).
 
 {{% /notes %}}
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+First register the component with your project. The `pulumi package add` command records the module in `Pulumi.yaml` and generates a local SDK for it:
+
+```bash
+$ pulumi package add ./website
+```
+
+Then add this to `main.tf`:
+
+```hcl
+# Create an instance of our component with the same files as before:
+resource "website_aws_s3_website" "my-website" {
+  files = [abspath("index.html")]
+}
+
+# And export its autoassigned URL:
+output "url" {
+  value = website_aws_s3_website.my-website.url
+}
+```
+
+The resource type `website_aws_s3_website` combines the package name and the component name. Passing the file through `abspath` hands the module an absolute path it can resolve from its own directory.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/get-started/aws/create-project.md
+++ b/content/docs/iac/get-started/aws/create-project.md
@@ -169,6 +169,24 @@ $ pulumi new aws-yaml
 {{% /choosable %}}
 
 {{% /choosable %}}
+{{% choosable language hcl %}}
+
+{{% choosable os "linux,macos" %}}
+
+```bash
+$ pulumi new aws-hcl
+```
+
+{{% /choosable %}}
+{{% choosable os "windows" %}}
+
+```powershell
+> pulumi new aws-hcl
+```
+
+{{% /choosable %}}
+
+{{% /choosable %}}
 
 The `pulumi new` command interactively walks through initializing a new project, as well as creating a
 [**stack**](/docs/iac/concepts/stacks) and [**configuring**](/docs/iac/concepts/config) it. A stack is an instance of your
@@ -217,7 +235,7 @@ If you list the contents of your directory, you'll see some key files:
 
 {{% /choosable %}}
 
-{{% choosable language "typescript,python,go,csharp,java" %}}
+{{% choosable language "typescript,python,go,csharp,java,hcl" %}}
 
 - <span>{{< langfile >}}</span> contains your project's main code that declares a new S3 bucket
 
@@ -353,6 +371,30 @@ outputs:
   # Export the name of the bucket
   bucketName: ${my-bucket.id}
 ```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source = "pulumi/aws"
+    }
+  }
+}
+
+# Create an AWS resource (S3 Bucket)
+resource "aws_s3_bucket" "my-bucket" {}
+
+# Export the name of the bucket
+output "bucket_name" {
+  value = aws_s3_bucket.my-bucket.id
+}
+```
+
+The `pulumi/` prefix in the provider source selects the [Pulumi AWS provider](/registry/packages/aws/); an unprefixed source such as `hashicorp/aws` would resolve from the OpenTofu registry instead. See [Pulumi HCL](/docs/iac/languages-sdks/hcl/) for how provider resolution works.
 
 {{% /choosable %}}
 

--- a/content/docs/iac/get-started/aws/deploy-stack.md
+++ b/content/docs/iac/get-started/aws/deploy-stack.md
@@ -98,7 +98,7 @@ $ aws s3 ls s3://$(pulumi stack output bucketName)
 
 {{% /choosable %}}
 
-{{% choosable language python %}}
+{{% choosable language "python,hcl" %}}
 
 ```bash
 $ aws s3 ls s3://$(pulumi stack output bucket_name)
@@ -118,7 +118,7 @@ $ aws s3 ls ("s3://" + (pulumi stack output bucketName))
 
 {{% /choosable %}}
 
-{{% choosable language python %}}
+{{% choosable language "python,hcl" %}}
 
 ```powershell
 $ aws s3 ls ("s3://" + (pulumi stack output bucket_name))

--- a/content/docs/iac/get-started/aws/modify-program.md
+++ b/content/docs/iac/get-started/aws/modify-program.md
@@ -255,6 +255,38 @@ resources:
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```hcl
+# Bucket ...
+
+# Turn the bucket into a website:
+resource "aws_s3_bucket_website_configuration" "website" {
+  bucket = aws_s3_bucket.my-bucket.id
+
+  index_document {
+    suffix = "index.html"
+  }
+}
+
+# Permit access control configuration:
+resource "aws_s3_bucket_ownership_controls" "ownership-controls" {
+  bucket = aws_s3_bucket.my-bucket.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+# Enable public access to the website:
+resource "aws_s3_bucket_public_access_block" "public-access-block" {
+  bucket            = aws_s3_bucket.my-bucket.id
+  block_public_acls = false
+}
+```
+
+{{% /choosable %}}
+
 Notice that resources can reference each other, which forms automatic dependencies between them.
 Pulumi uses this information to parallelize deployments safely.
 
@@ -393,6 +425,30 @@ resources:
 
 {{% /choosable %}}
 
+{{% choosable language hcl %}}
+
+```hcl
+# Other resources ...
+
+# Create an S3 Bucket object
+resource "aws_s3_bucket_object" "index-html" {
+  bucket       = aws_s3_bucket.my-bucket.id
+  key          = "index.html"
+  source       = fileasset("index.html")
+  content_type = "text/html"
+  acl          = "public-read"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.ownership-controls,
+    aws_s3_bucket_public_access_block.public-access-block,
+  ]
+}
+```
+
+In HCL, explicit dependencies use the standard Terraform `depends_on` meta-argument rather than a `pulumi` option, and `fileasset` is a [Pulumi-specific function](/docs/iac/languages-sdks/hcl/hcl-language-reference/#pulumi-specific-functions) that turns a local file into an asset. Resource labels can't contain dots, so the resource is labeled `index-html` and the `key` attribute names the object in the bucket.
+
+{{% /choosable %}}
+
 This uploads the `index.html` file to your bucket using a Pulumi concept called an [asset](/docs/iac/concepts/assets-archives/#assets).
 
 The bucket object also declares that it [`dependsOn`](/docs/iac/concepts/resources/options/dependson/) the other resources. That is because
@@ -462,6 +518,17 @@ ctx.export("url", website.websiteEndpoint().applyValue(
 outputs:
   # ...
   url: http://${website.websiteEndpoint}
+```
+
+{{% /choosable %}}
+
+{{% choosable language hcl %}}
+
+```hcl
+# Export the bucket's autoassigned URL:
+output "url" {
+  value = "http://${aws_s3_bucket_website_configuration.website.website_endpoint}"
+}
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
### Proposed changes

Adds an HCL tab to every page of the AWS Get Started guide that offers language tabs, closing the gap where a reader who chooses Pulumi for its HCL support has no path through the main quickstart.

- **`_index.md`** — HCL in the language chooser, with prerequisites (an AWS account; like YAML, no local runtime is needed).
- **`create-project.md`** — `pulumi new aws-hcl`, the generated `main.tf`, and a note on `pulumi/` provider sources.
- **`deploy-stack.md`** — HCL joins the snake_case `bucket_name` output group alongside Python.
- **`modify-program.md`** — the three website resources, the `BucketObject` with `fileasset()` and native `depends_on`, and the `url` output.
- **`create-component.md`** — a full HCL narrative: components are authored as multi-language components (a `website/` module with `PulumiPlugin.yaml`), registered with `pulumi package add ./website`, and instantiated as `website_aws_s3_website`.

Every command and snippet was verified against a live AWS deployment end to end (`pulumi new` → `up` → website modify → `curl` → component refactor → `curl` → `destroy`), including the module-context details: attribute-map syntax for nested properties, `fileasset` path resolution relative to the module directory (hence `abspath`/`basename`), and automatic parenting.

### Notes for review

- Selecting HCL does not yet persist across stepper pages — the theme store deliberately never persists it. A follow-up PR removes that guard once all four cloud guides have HCL tabs; until then the tab behaves like the existing HCL tab on the Terraform onramp's first-look page.
- #20360 rewrites this guide and does not add HCL; whichever lands second pays for the collision. Happy to rebase this onto it if it lands first.