### PR TITLE
Contact page: rebuild the sidebar and swap the form chooser to radio buttons

### DIFF
--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -4,14 +4,14 @@ meta_desc: Contact Pulumi for any general inquiries, including requests for pric
 type: page
 layout: contact
 quick_links:
-    title: Looking for something quicker?
+    title: Quick links
     items:
-        - label: Start a trial
+        - label: Ready to try it?
           description: No sales call needed. Create an org and ship infrastructure in minutes.
           cta_label: Start a trial
           url: https://app.pulumi.com/signup?create-organization=1
 
-        - label: See it in action
+        - label: Want to see it first?
           description: Get a guided walkthrough from our team before you commit to anything.
           cta_label: Request a demo
           url: /request-a-demo/
@@ -23,19 +23,19 @@ quick_links:
 
 form:
     - key: general
-      label: I have a general question
+      label: General question
       hubspot_form_id: 71507f4e-e34e-4dc9-9da6-b44953cac811
 
     - key: sales
-      label: I want to talk to someone in Sales
+      label: Talk to sales
       hubspot_form_id: 8381e562-5fdf-4736-bb10-86096705e4ee
 
     - key: tf-migration
-      label: I need help migrating from Terraform
+      label: Migrate from Terraform
       hubspot_form_id: 123cfbdb-9ce4-4d33-a9b7-c30302463d7a
 
     - key: support
-      label: I need help with Support
+      label: Help from support
       hubspot_form_id: cta1
       cta:
         label: Submit a Request

--- a/layouts/partials/contact-us.html
+++ b/layouts/partials/contact-us.html
@@ -10,17 +10,6 @@
                 </div>
             </div>
 
-            {{/*
-                Secondary column: self-serve fast paths for visitors who don't need a
-                sales conversation, plus our office address. Deliberately plain — heading,
-                blurb, text link, no cards — so it reads as an aside to the form rather
-                than competing with it for submissions.
-
-                The list is spaced with flex gap, NOT space-y-*: each item needs `m-0` to
-                escape the global `main li { my-2 }`, and Tailwind v4 emits space-y as
-                `:where(.space-y-10 > :not(:last-child))` at zero specificity, so `m-0`
-                silently wins and the gap collapses.
-            */}}
             <aside class="mt-8 md:mt-0">
                 {{ with .Params.quick_links }}
                     <h2 class="font-overline-sm mb-6">{{ .title }}</h2>

--- a/layouts/partials/contact-us.html
+++ b/layouts/partials/contact-us.html
@@ -1,48 +1,51 @@
 <section id="contact" class="py-16 px-4 border-b border-gray-300">
-        <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-[2fr_1fr] gap-8 items-start">
-            <div class="w-full">
-                <div class="card mt-4 mx-auto md:w-full md:mt-0 p-10 bg-white">
-                    <h1 class="heading-1 mb-6">Talk to an expert</h1>
-                    <div class="w-full">
-                        <div class="hs-form hs-form-fg-dark font-normal">
-                            <pulumi-contact-us-form
-                                items="{{ .Params.form | jsonify }}"
-                                label-class="block mb-2 font-normal text-sm text-gray-950"
-                                select-class="form-select form-select-lg"
-                            ></pulumi-contact-us-form>
-                        </div>
-                    </div>
+        <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-[2fr_1fr] gap-8 md:gap-12 items-start">
+            <div class="card p-10 bg-white">
+                <h1 class="heading-1 mb-6">Talk to an expert</h1>
+                <div class="hs-form hs-form-fg-dark font-normal">
+                    <pulumi-contact-us-form
+                        items="{{ .Params.form | jsonify }}"
+                        label-class="block mb-4 font-normal text-sm text-gray-950"
+                    ></pulumi-contact-us-form>
                 </div>
+            </div>
 
-                <div class="mt-16">
-                    <h2 class="font-overline my-6">Our Address</h2>
-                    <p class="m-0">
+            {{/*
+                Secondary column: self-serve fast paths for visitors who don't need a
+                sales conversation, plus our office address. Deliberately plain — heading,
+                blurb, text link, no cards — so it reads as an aside to the form rather
+                than competing with it for submissions.
+
+                The list is spaced with flex gap, NOT space-y-*: each item needs `m-0` to
+                escape the global `main li { my-2 }`, and Tailwind v4 emits space-y as
+                `:where(.space-y-10 > :not(:last-child))` at zero specificity, so `m-0`
+                silently wins and the gap collapses.
+            */}}
+            <aside class="mt-8 md:mt-0">
+                {{ with .Params.quick_links }}
+                    <h2 class="font-overline-sm mb-6">{{ .title }}</h2>
+                    <ul class="list-none p-0 m-0 flex flex-col gap-10">
+                        {{ range .items }}
+                            <li class="m-0">
+                                <h3 class="heading-5 m-0">{{ .label }}</h3>
+                                <p class="body-sm text-gray-600 my-2 max-w-xs">{{ .description }}</p>
+                                <a href="{{ .url }}"{{ partial "external-link-attrs.html" .url | safeHTMLAttr }} class="btn btn-link">
+                                    {{ .cta_label }}
+                                    {{ partial "icon.html" (dict "name" "arrow-right" "weight" "bold" "class" "size-4") }}
+                                </a>
+                            </li>
+                        {{ end }}
+                    </ul>
+                {{ end }}
+
+                <div class="mt-10 pt-10 border-t border-gray-200">
+                    <h2 class="font-overline-sm mb-4">Our office</h2>
+                    <p class="body-sm text-gray-600 m-0">
                         Pulumi Corporation<br />
                         601 Union St., Suite 1415<br />
                         Seattle, WA 98101
                     </p>
                 </div>
-            </div>
-
-            {{/*
-                Narrow sidebar of self-serve options for visitors who don't need
-                a sales conversation. Keep this visually secondary to the form
-                (a slim side column, never a full-width block above it) so it
-                doesn't pull volume away from Contact Us submissions.
-            */}}
-            {{ with .Params.quick_links }}
-            <div class="w-full mt-4 md:mt-10">
-                <p class="font-overline mb-4">{{ .title }}</p>
-                <div class="grid grid-cols-1 gap-4">
-                    {{ range .items }}
-                        <a href="{{ .url }}" class="card block p-6 bg-white hover:shadow-lg transition-shadow">
-                            <h2 class="heading-4 mb-1">{{ .label }}</h2>
-                            <p class="body-sm text-gray-600 mb-4">{{ .description }}</p>
-                            <span class="btn btn-secondary btn-sm">{{ .cta_label }}</span>
-                        </a>
-                    {{ end }}
-                </div>
-            </div>
-            {{ end }}
+            </aside>
         </div>
 </section>

--- a/layouts/partials/contact-us.html
+++ b/layouts/partials/contact-us.html
@@ -13,6 +13,8 @@
             <aside class="mt-8 md:mt-0">
                 {{ with .Params.quick_links }}
                     <h2 class="font-overline-sm mb-6">{{ .title }}</h2>
+                    {{/* gap, not space-y-*: Tailwind v4 emits space-y at zero specificity, so the
+                         m-0 each item needs to escape `main li { my-2 }` overrides it. */}}
                     <ul class="list-none p-0 m-0 flex flex-col gap-10">
                         {{ range .items }}
                             <li class="m-0">

--- a/theme/src/scss/_hubspot.scss
+++ b/theme/src/scss/_hubspot.scss
@@ -78,6 +78,8 @@
         &:not(.form-columns-1)>.field:first-child {
             @apply pr-4;
 
+            // 400px is where HubSpot's own CSS stacks a form-columns-2 fieldset; any
+            // other value leaves a band of widths where the columns collide or sit unevenly.
             @media (max-width: 400px) {
                 @apply pr-0;
             }

--- a/theme/src/scss/_hubspot.scss
+++ b/theme/src/scss/_hubspot.scss
@@ -75,8 +75,19 @@
     fieldset {
         @apply block !max-w-none;
 
+        // Gutter between the two columns of a form-columns-2 fieldset (first name /
+        // last name). It's padding on the leading field, so once HubSpot's own
+        // responsive rule stacks the fields to full width the gutter has nothing to
+        // separate and reads as a stray right margin — the stacked first field ends
+        // 1rem short of the second. Drop it at exactly the width HubSpot stacks at:
+        // any other threshold leaves a band where the columns either collide or sit
+        // unevenly. If HubSpot ever moves that breakpoint, this is the number.
         &:not(.form-columns-1)>.field:first-child {
             @apply pr-4;
+
+            @media (max-width: 400px) {
+                @apply pr-0;
+            }
         }
 
         @include hs-form-field-chrome;
@@ -178,8 +189,13 @@
     .hs-error-msgs {
         @apply list-none mt-2 p-0 text-red-600 text-xs;
 
+        // HubSpot marks up each message as a <label>, so it inherits the field-label
+        // chrome from hs-form-field-chrome — including the mt-5 that spaces a real
+        // label off the control above it. On a validation message that lands on top
+        // of this list's own mt-2 and floats the error well clear of its input, so
+        // zero both ends and let the list own the spacing.
         label {
-            @apply mb-0;
+            @apply mt-0 mb-0;
         }
     }
 

--- a/theme/src/scss/_hubspot.scss
+++ b/theme/src/scss/_hubspot.scss
@@ -75,13 +75,6 @@
     fieldset {
         @apply block !max-w-none;
 
-        // Gutter between the two columns of a form-columns-2 fieldset (first name /
-        // last name). It's padding on the leading field, so once HubSpot's own
-        // responsive rule stacks the fields to full width the gutter has nothing to
-        // separate and reads as a stray right margin — the stacked first field ends
-        // 1rem short of the second. Drop it at exactly the width HubSpot stacks at:
-        // any other threshold leaves a band where the columns either collide or sit
-        // unevenly. If HubSpot ever moves that breakpoint, this is the number.
         &:not(.form-columns-1)>.field:first-child {
             @apply pr-4;
 
@@ -189,11 +182,6 @@
     .hs-error-msgs {
         @apply list-none mt-2 p-0 text-red-600 text-xs;
 
-        // HubSpot marks up each message as a <label>, so it inherits the field-label
-        // chrome from hs-form-field-chrome — including the mt-5 that spaces a real
-        // label off the control above it. On a validation message that lands on top
-        // of this list's own mt-2 and floats the error well clear of its input, so
-        // zero both ends and let the list own the spacing.
         label {
             @apply mt-0 mb-0;
         }

--- a/theme/stencil/src/components/contact-us-form/contact-us-form.tsx
+++ b/theme/stencil/src/components/contact-us-form/contact-us-form.tsx
@@ -24,10 +24,6 @@ export class ContactUsForm {
     @Prop()
     items: string;
 
-    // The class for the select input.
-    @Prop()
-    selectClass?: string;
-
     // The labelClass defines the class for the label.
     @Prop()
     labelClass?: string;
@@ -64,7 +60,6 @@ export class ContactUsForm {
         return (
             <pulumi-multi-select-form
                 items={this.parsedItems}
-                selectClass={this.selectClass}
                 labelClass={this.labelClass}
                 labelText="What can we help you with?"
                 defaultFormId={this.defaultFormId}

--- a/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
+++ b/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Prop, State } from "@stencil/core";
+import { Component, Element, Event, EventEmitter, h, Method, Prop, State } from "@stencil/core";
 import { parseCookie, parseUTMCookieString, getQueryVariable } from "../../util/util";
 
 interface UTMData {
@@ -51,6 +51,13 @@ export class HubspotForm {
     // leaves the form untouched.
     @Prop()
     prefill?: string;
+
+    // Field values carried over from a form this one is replacing (the contact
+    // page swaps one embedded form for another when the visitor changes their
+    // reason for writing in). A map of HubSpot field internal name -> value,
+    // applied on onFormReady to whichever of those fields are still empty.
+    @Prop()
+    carryOverValues?: Record<string, string>;
 
     // Emitted once HubSpot confirms the submission, so a page can render its own
     // confirmation UI. `values` holds the submitted values in display form.
@@ -161,6 +168,15 @@ export class HubspotForm {
             // Set the internal ad id.
             this.setInternalAdId();
 
+            // Order matters. HubSpot has already prefilled whatever it knows about
+            // the visitor by the time this fires, so carried-over values fill only
+            // what's still empty and leave that alone. The ?param= prefill then
+            // overwrites either of them — an explicit link is the strongest signal
+            // of intent available.
+            if (this.carryOverValues) {
+                this.applyValues(this.carryOverValues, true);
+            }
+
             this.applyPrefill();
         }
 
@@ -228,28 +244,49 @@ export class HubspotForm {
 
         try {
             const fieldsToParams: Record<string, string> = JSON.parse(this.prefill);
+            const values: Record<string, string> = {};
 
             Object.keys(fieldsToParams).forEach(fieldName => {
                 const value = getQueryVariable(fieldsToParams[fieldName]);
-                if (!value) {
-                    return;
+                if (value) {
+                    values[fieldName] = value;
                 }
-
-                const field: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement = this.el.querySelector(`[name="${fieldName}"]`);
-                if (!field) {
-                    return;
-                }
-
-                // HubSpot validates off its own state, so it needs both events to
-                // register the value. `window.Event` because Stencil's `Event`
-                // decorator shadows the global constructor here.
-                field.value = value;
-                field.dispatchEvent(new window.Event("input", { bubbles: true }));
-                field.dispatchEvent(new window.Event("change", { bubbles: true }));
             });
+
+            this.applyValues(values);
         } catch (e) {
             // Malformed prefill map, or a query string getQueryVariable can't parse.
         }
+    }
+
+    // Write a map of field internal name -> value into the rendered form. With
+    // `onlyIfEmpty`, a field that already holds something is left as it is.
+    private applyValues(values: Record<string, string>, onlyIfEmpty = false) {
+        Object.keys(values).forEach(fieldName => {
+            const value = values[fieldName];
+            if (!value) {
+                return;
+            }
+
+            const field: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement = this.el.querySelector(`[name="${fieldName}"]`);
+            if (!field || (onlyIfEmpty && field.value)) {
+                return;
+            }
+
+            // HubSpot validates off its own state, so it needs both events to
+            // register the value. `window.Event` because Stencil's `Event`
+            // decorator shadows the global constructor here.
+            field.value = value;
+            field.dispatchEvent(new window.Event("input", { bubbles: true }));
+            field.dispatchEvent(new window.Event("change", { bubbles: true }));
+        });
+    }
+
+    // The form's current field values, for a caller that's about to replace this
+    // form with another one and wants to carry what's been typed across.
+    @Method()
+    async getFieldValues(): Promise<Record<string, string>> {
+        return this.collectFieldValues();
     }
 
     // The form's current values, keyed by field name, in display form.

--- a/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
+++ b/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
@@ -17,6 +17,10 @@ let hubspotInstanceCount = 0;
 // https://legacydocs.hubspot.com/docs/methods/forms/advanced_form_options
 type HubSpotFormEvent = "onBeforeFormInit" | "onBeforeValidationInit" | "onFormReady" | "onFormSubmit" | "onFormSubmitted" | "onFormDefinitionFetchError";
 
+// Input types that survive being read off one form and written to another by
+// assigning to `value`. Textareas qualify too and are matched by tag instead.
+const CARRY_OVER_INPUT_TYPES = ["text", "email", "tel", "url", "search", "number"];
+
 @Component({
     tag: "pulumi-hubspot-form",
     styleUrl: "hubspot-form.scss",
@@ -282,11 +286,34 @@ export class HubspotForm {
         });
     }
 
-    // The form's current field values, for a caller that's about to replace this
-    // form with another one and wants to carry what's been typed across.
+    // What a caller replacing this form with another one should carry across:
+    // every free-text field, keyed by HubSpot internal name. Deliberately not
+    // filtered to a list of known names — the forms each carry their own custom
+    // properties ("how_can_we_help_you_" and the like), and the receiving form
+    // ignores anything it doesn't have a field for.
+    //
+    // Selects, checkboxes, and radios are left out because they don't survive the
+    // round trip: collectFieldValues reports a select's option text rather than
+    // its value, and a checkbox or radio can't be restored by assigning to
+    // `value`. Hidden fields are excluded as well - UTM and ad ids are set per
+    // form, and the incoming form sets its own.
     @Method()
-    async getFieldValues(): Promise<Record<string, string>> {
-        return this.collectFieldValues();
+    async getCarryOverValues(): Promise<Record<string, string>> {
+        const values: Record<string, string> = {};
+
+        this.el.querySelectorAll("input, textarea").forEach((field: HTMLInputElement | HTMLTextAreaElement) => {
+            if (!field.name) {
+                return;
+            }
+
+            if (field instanceof HTMLInputElement && !CARRY_OVER_INPUT_TYPES.includes(field.type)) {
+                return;
+            }
+
+            values[field.name] = field.value;
+        });
+
+        return values;
     }
 
     // The form's current values, keyed by field name, in display form.

--- a/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
+++ b/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
@@ -287,21 +287,25 @@ export class HubspotForm {
     }
 
     // What a caller replacing this form with another one should carry across:
-    // every free-text field, keyed by HubSpot internal name. Deliberately not
-    // filtered to a list of known names — the forms each carry their own custom
-    // properties ("how_can_we_help_you_" and the like), and the receiving form
-    // ignores anything it doesn't have a field for.
+    // free-text fields and selects, keyed by HubSpot internal name. Deliberately
+    // not filtered to a list of known names — the forms carry their own custom
+    // properties (`contact_latest_query`, `web_self_attribution`) and the
+    // receiving form ignores anything it has no field for.
     //
-    // Selects, checkboxes, and radios are left out because they don't survive the
-    // round trip: collectFieldValues reports a select's option text rather than
-    // its value, and a checkbox or radio can't be restored by assigning to
-    // `value`. Hidden fields are excluded as well - UTM and ad ids are set per
-    // form, and the incoming form sets its own.
+    // Note this reads a select's raw `value`, unlike collectFieldValues, which
+    // reports the option's text for the submitted-values event. Text is what a
+    // human wants to read; only the value can be assigned back to a select on
+    // another form.
+    //
+    // Checkboxes and radios are left out: assigning to `value` sets the attribute
+    // rather than checking the control, so consent can't round-trip this way and
+    // shouldn't silently follow someone between forms anyway. Hidden fields are
+    // out too — UTM and ad ids are per-form, and the incoming form sets its own.
     @Method()
     async getCarryOverValues(): Promise<Record<string, string>> {
         const values: Record<string, string> = {};
 
-        this.el.querySelectorAll("input, textarea").forEach((field: HTMLInputElement | HTMLTextAreaElement) => {
+        this.el.querySelectorAll("input, textarea, select").forEach((field: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement) => {
             if (!field.name) {
                 return;
             }

--- a/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
+++ b/theme/stencil/src/components/hubspot-form/hubspot-form.tsx
@@ -17,9 +17,7 @@ let hubspotInstanceCount = 0;
 // https://legacydocs.hubspot.com/docs/methods/forms/advanced_form_options
 type HubSpotFormEvent = "onBeforeFormInit" | "onBeforeValidationInit" | "onFormReady" | "onFormSubmit" | "onFormSubmitted" | "onFormDefinitionFetchError";
 
-// Input types that survive being read off one form and written to another by
-// assigning to `value`. Textareas qualify too and are matched by tag instead.
-const CARRY_OVER_INPUT_TYPES = ["text", "email", "tel", "url", "search", "number"];
+const REASSIGNABLE_INPUT_TYPES = ["text", "email", "tel", "url", "search", "number"];
 
 @Component({
     tag: "pulumi-hubspot-form",
@@ -56,10 +54,6 @@ export class HubspotForm {
     @Prop()
     prefill?: string;
 
-    // Field values carried over from a form this one is replacing (the contact
-    // page swaps one embedded form for another when the visitor changes their
-    // reason for writing in). A map of HubSpot field internal name -> value,
-    // applied on onFormReady to whichever of those fields are still empty.
     @Prop()
     carryOverValues?: Record<string, string>;
 
@@ -172,13 +166,8 @@ export class HubspotForm {
             // Set the internal ad id.
             this.setInternalAdId();
 
-            // Order matters. HubSpot has already prefilled whatever it knows about
-            // the visitor by the time this fires, so carried-over values fill only
-            // what's still empty and leave that alone. The ?param= prefill then
-            // overwrites either of them — an explicit link is the strongest signal
-            // of intent available.
             if (this.carryOverValues) {
-                this.applyValues(this.carryOverValues, true);
+                this.fillEmptyFields(this.carryOverValues);
             }
 
             this.applyPrefill();
@@ -263,9 +252,15 @@ export class HubspotForm {
         }
     }
 
-    // Write a map of field internal name -> value into the rendered form. With
-    // `onlyIfEmpty`, a field that already holds something is left as it is.
-    private applyValues(values: Record<string, string>, onlyIfEmpty = false) {
+    private applyValues(values: Record<string, string>) {
+        this.writeFields(values, false);
+    }
+
+    private fillEmptyFields(values: Record<string, string>) {
+        this.writeFields(values, true);
+    }
+
+    private writeFields(values: Record<string, string>, skipFilled: boolean) {
         Object.keys(values).forEach(fieldName => {
             const value = values[fieldName];
             if (!value) {
@@ -273,7 +268,7 @@ export class HubspotForm {
             }
 
             const field: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement = this.el.querySelector(`[name="${fieldName}"]`);
-            if (!field || (onlyIfEmpty && field.value)) {
+            if (!field || (skipFilled && field.value)) {
                 return;
             }
 
@@ -286,21 +281,6 @@ export class HubspotForm {
         });
     }
 
-    // What a caller replacing this form with another one should carry across:
-    // free-text fields and selects, keyed by HubSpot internal name. Deliberately
-    // not filtered to a list of known names — the forms carry their own custom
-    // properties (`contact_latest_query`, `web_self_attribution`) and the
-    // receiving form ignores anything it has no field for.
-    //
-    // Note this reads a select's raw `value`, unlike collectFieldValues, which
-    // reports the option's text for the submitted-values event. Text is what a
-    // human wants to read; only the value can be assigned back to a select on
-    // another form.
-    //
-    // Checkboxes and radios are left out: assigning to `value` sets the attribute
-    // rather than checking the control, so consent can't round-trip this way and
-    // shouldn't silently follow someone between forms anyway. Hidden fields are
-    // out too — UTM and ad ids are per-form, and the incoming form sets its own.
     @Method()
     async getCarryOverValues(): Promise<Record<string, string>> {
         const values: Record<string, string> = {};
@@ -310,7 +290,7 @@ export class HubspotForm {
                 return;
             }
 
-            if (field instanceof HTMLInputElement && !CARRY_OVER_INPUT_TYPES.includes(field.type)) {
+            if (field instanceof HTMLInputElement && !REASSIGNABLE_INPUT_TYPES.includes(field.type)) {
                 return;
             }
 

--- a/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -63,11 +63,6 @@ export class PulumiMultiSelectForm {
     // name is enough.
     private static readonly radioGroupName = "multi-select-form-choice";
 
-    // Fields worth carrying between forms: the ones a visitor types the same way
-    // whichever form they land on. Everything else — consent checkboxes, per-form
-    // custom fields — is left to the new form.
-    private static readonly carryOverFields = ["firstname", "lastname", "email", "company", "message"];
-
     componentWillLoad() {
         if (this.defaultFormId !== "") {
             this.selectedItem = this.items.find(item => item.hubspotFormId === this.defaultFormId);
@@ -122,24 +117,21 @@ export class PulumiMultiSelectForm {
         // No form to read: either nothing has been chosen yet, or the current
         // choice is one of the CTA-only options. Keep what was captured last so a
         // detour through the support option doesn't discard it.
-        if (!form || typeof form.getFieldValues !== "function") {
+        if (!form || typeof form.getCarryOverValues !== "function") {
             return this.carriedValues;
         }
 
-        const values = await form.getFieldValues();
+        const values = await form.getCarryOverValues();
 
         // Merged into what's already carried rather than replacing it. The forms
         // don't all ask for the same things, so a message typed on one of them has
         // to survive a detour through one that never had a message field.
         const carried: Record<string, string> = { ...this.carriedValues };
 
-        PulumiMultiSelectForm.carryOverFields.forEach(name => {
-            // Absent from this form entirely: leave whatever an earlier one carried
-            // in. Present but emptied: the visitor cleared it, so drop it.
-            if (!(name in values)) {
-                return;
-            }
-
+        Object.keys(values).forEach(name => {
+            // Present but emptied: the visitor cleared it, so drop it. A field this
+            // form doesn't have simply isn't in `values`, and keeps whatever an
+            // earlier form carried in.
             if (values[name]) {
                 carried[name] = values[name];
             } else {

--- a/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -127,11 +127,23 @@ export class PulumiMultiSelectForm {
         }
 
         const values = await form.getFieldValues();
-        const carried: Record<string, string> = {};
+
+        // Merged into what's already carried rather than replacing it. The forms
+        // don't all ask for the same things, so a message typed on one of them has
+        // to survive a detour through one that never had a message field.
+        const carried: Record<string, string> = { ...this.carriedValues };
 
         PulumiMultiSelectForm.carryOverFields.forEach(name => {
+            // Absent from this form entirely: leave whatever an earlier one carried
+            // in. Present but emptied: the visitor cleared it, so drop it.
+            if (!(name in values)) {
+                return;
+            }
+
             if (values[name]) {
                 carried[name] = values[name];
+            } else {
+                delete carried[name];
             }
         });
 

--- a/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -21,13 +21,9 @@ export class PulumiMultiSelectForm {
     @Element()
     el: Element;
 
-    // The JSON string of the items for the selector.
+    // The items to choose between.
     @Prop()
     items: MultiSelectFormItem[] = [];
-
-    // The class for the select input.
-    @Prop()
-    selectClass?: string;
 
     // The labelClass defines the class for the label.
     @Prop()
@@ -37,8 +33,7 @@ export class PulumiMultiSelectForm {
     @Prop()
     labelText: string;
 
-    // The default key for the selector to set to when rendered. If the key
-    // is blank then the first item in the array will be selected.
+    // The form to pre-select when rendered. Blank falls back to the first item.
     @Prop()
     defaultFormId: string = "";
 
@@ -46,9 +41,8 @@ export class PulumiMultiSelectForm {
     @Prop()
     linkedinConversionId?: number;
 
-    // The currently selected item. Left undefined until the visitor makes a
-    // choice (or arrives via a ?form= deep link that pre-selects one), so the
-    // embedded HubSpot form's extra fields stay hidden until they're relevant.
+    // The currently selected item. Defaults to the first, so the page lands on a
+    // usable form; a ?form= deep link overrides it.
     @State()
     selectedItem: MultiSelectFormItem | undefined;
 
@@ -58,14 +52,23 @@ export class PulumiMultiSelectForm {
     // The window event listener used to handle submitting form data to Segment.
     private windowEventHandler: (this: Window, ev: MessageEvent) => any;
 
-    // When the component loads we need to parse the items string.
+    // Groups the radios. A page only ever renders one of these, so a constant
+    // name is enough.
+    private static readonly radioGroupName = "multi-select-form-choice";
+
     componentWillLoad() {
         if (this.defaultFormId !== "") {
             this.selectedItem = this.items.find(item => item.hubspotFormId === this.defaultFormId);
         }
+
+        // Falls through to the first item when there's no deep link, and also when
+        // a ?form= names a key we don't have.
+        if (!this.selectedItem) {
+            this.selectedItem = this.items[0];
+        }
     }
 
-    // After the form submits we should hide the session selector.
+    // After the form submits we should hide the chooser.
     componentDidLoad() {
         this.windowEventHandler = this.handleWindowMessage.bind(this);
         window.addEventListener("message", this.windowEventHandler);
@@ -93,12 +96,9 @@ export class PulumiMultiSelectForm {
         }
     }
 
-    // When the select input changes we need to update the state accordingly.
-    // An empty value means the visitor is back on the unselected placeholder,
-    // so collapse back to the not-yet-chosen state rather than crashing on a
-    // missing item.
-    private handleSelectChange(hubspotFormId: string) {
-        this.selectedItem = hubspotFormId ? this.items.find(item => item.hubspotFormId === hubspotFormId) : undefined;
+    // When the choice changes we need to update the state accordingly.
+    private handleChoiceChange(hubspotFormId: string) {
+        this.selectedItem = this.items.find(item => item.hubspotFormId === hubspotFormId);
     }
 
     render() {
@@ -107,25 +107,45 @@ export class PulumiMultiSelectForm {
         return (
             <div>
                 {this.formSubmitted ? null : (
-                    <span>
+                    <div>
                         <span class={this.labelClass || ""}>{this.labelText}</span>
-                        <select class={this.selectClass || ""} onInput={(event: any) => this.handleSelectChange(event.target.value)}>
-                            <option value="" selected={!selectedFormId} disabled hidden>
-                                Please select
-                            </option>
-                            {this.items.map(item => {
-                                const isSelected = item.hubspotFormId === selectedFormId;
-                                return (
-                                    <option value={item.hubspotFormId} selected={isSelected}>
-                                        {item.label ? item.label : item.key}
-                                    </option>
-                                );
-                            })}
-                        </select>
-                    </span>
+                        {/*
+                            A div with role="radiogroup", NOT a <fieldset>: this renders
+                            inside the page's `.hs-form` wrapper, and _hubspot.scss gates
+                            its "newer HubSpot editor, no fieldset" field-chrome branch on
+                            `:not(:has(fieldset))`. A fieldset here would flip that branch
+                            off and leave the embedded form below with browser-default
+                            inputs.
+                        */}
+                        <div role="radiogroup" aria-label={this.labelText} class="grid grid-cols-1 lg:grid-cols-4 gap-3">
+                            {this.items.map(item => (
+                                // The card is the affordance, so the radio itself is
+                                // sr-only — still focusable and arrow-navigable, with the
+                                // focus treatment drawn on the card via has-[:focus-visible].
+                                // That treatment is the FORM-CONTROL one, not the button
+                                // one: violet-800 border plus a 2px inset ring of the same
+                                // color, merging into one edge ($form-focus-ring in
+                                // shared/_forms.scss). Keep it in step with that token.
+                                <label class="card card-hover flex items-center justify-center p-3 m-0 text-center text-sm font-normal has-[:checked]:border-violet-primary has-[:checked]:bg-violet-50 has-[:checked]:text-violet-primary has-[:focus-visible]:border-violet-800 has-[:focus-visible]:inset-ring-2 has-[:focus-visible]:inset-ring-violet-800">
+                                    <input
+                                        type="radio"
+                                        class="sr-only"
+                                        name={PulumiMultiSelectForm.radioGroupName}
+                                        value={item.hubspotFormId}
+                                        checked={item.hubspotFormId === selectedFormId}
+                                        onInput={(event: any) => this.handleChoiceChange(event.target.value)}
+                                    />
+                                    <span>{item.label ? item.label : item.key}</span>
+                                </label>
+                            ))}
+                        </div>
+                    </div>
                 )}
                 {!this.selectedItem ? null : this.selectedItem.cta ? (
-                    <div class="mt-8"><a class="btn btn-secondary" href={this.selectedItem.cta.url}>{this.selectedItem.cta.label}</a></div>
+                    // Stands in for the submit button of the form the other choices
+                    // render, so it matches it: _hubspot.scss extends the HubSpot
+                    // submit input with .btn-primary .btn-lg.
+                    <div class="mt-8"><a class="btn btn-primary btn-lg" href={this.selectedItem.cta.url}>{this.selectedItem.cta.label}</a></div>
                 ) : (
                     <pulumi-hubspot-form key={selectedFormId} form-id={selectedFormId}></pulumi-hubspot-form>
                 )}

--- a/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -21,7 +21,6 @@ export class PulumiMultiSelectForm {
     @Element()
     el: Element;
 
-    // The items to choose between.
     @Prop()
     items: MultiSelectFormItem[] = [];
 
@@ -33,7 +32,6 @@ export class PulumiMultiSelectForm {
     @Prop()
     labelText: string;
 
-    // The form to pre-select when rendered. Blank falls back to the first item.
     @Prop()
     defaultFormId: string = "";
 
@@ -41,41 +39,29 @@ export class PulumiMultiSelectForm {
     @Prop()
     linkedinConversionId?: number;
 
-    // The currently selected item. Defaults to the first, so the page lands on a
-    // usable form; a ?form= deep link overrides it.
     @State()
     selectedItem: MultiSelectFormItem | undefined;
 
     @State()
     formSubmitted = false;
 
-    // What the visitor had typed into the form they're switching away from, so
-    // changing your mind about why you're writing in doesn't cost you the message
-    // you already wrote. Handed to the incoming form, which fills only the fields
-    // it finds empty.
     @State()
     carriedValues: Record<string, string> = {};
 
     // The window event listener used to handle submitting form data to Segment.
     private windowEventHandler: (this: Window, ev: MessageEvent) => any;
 
-    // Groups the radios. A page only ever renders one of these, so a constant
-    // name is enough.
     private static readonly radioGroupName = "multi-select-form-choice";
 
     componentWillLoad() {
         if (this.defaultFormId !== "") {
             this.selectedItem = this.items.find(item => item.hubspotFormId === this.defaultFormId);
         }
-
-        // Falls through to the first item when there's no deep link, and also when
-        // a ?form= names a key we don't have.
         if (!this.selectedItem) {
             this.selectedItem = this.items[0];
         }
     }
 
-    // After the form submits we should hide the chooser.
     componentDidLoad() {
         this.windowEventHandler = this.handleWindowMessage.bind(this);
         window.addEventListener("message", this.windowEventHandler);
@@ -103,9 +89,6 @@ export class PulumiMultiSelectForm {
         }
     }
 
-    // When the choice changes we need to update the state accordingly, capturing
-    // the outgoing form's values first — switching swaps the embedded form out
-    // entirely, so anything typed is gone once the state changes.
     private async handleChoiceChange(hubspotFormId: string) {
         this.carriedValues = await this.captureCarryOverValues();
         this.selectedItem = this.items.find(item => item.hubspotFormId === hubspotFormId);
@@ -113,27 +96,16 @@ export class PulumiMultiSelectForm {
 
     private async captureCarryOverValues(): Promise<Record<string, string>> {
         const form = this.el.querySelector("pulumi-hubspot-form") as HTMLPulumiHubspotFormElement;
-
-        // No form to read: either nothing has been chosen yet, or the current
-        // choice is one of the CTA-only options. Keep what was captured last so a
-        // detour through the support option doesn't discard it.
-        if (!form || typeof form.getCarryOverValues !== "function") {
+        if (!form?.getCarryOverValues) {
             return this.carriedValues;
         }
 
         const values = await form.getCarryOverValues();
-
-        // Merged into what's already carried rather than replacing it. The forms
-        // don't all ask for the same things, so a message typed on one of them has
-        // to survive a detour through one that never had a message field.
         const carried: Record<string, string> = { ...this.carriedValues };
 
-        Object.keys(values).forEach(name => {
-            // Present but emptied: the visitor cleared it, so drop it. A field this
-            // form doesn't have simply isn't in `values`, and keeps whatever an
-            // earlier form carried in.
-            if (values[name]) {
-                carried[name] = values[name];
+        Object.entries(values).forEach(([name, value]) => {
+            if (value) {
+                carried[name] = value;
             } else {
                 delete carried[name];
             }
@@ -150,23 +122,8 @@ export class PulumiMultiSelectForm {
                 {this.formSubmitted ? null : (
                     <div>
                         <span class={this.labelClass || ""}>{this.labelText}</span>
-                        {/*
-                            A div with role="radiogroup", NOT a <fieldset>: this renders
-                            inside the page's `.hs-form` wrapper, and _hubspot.scss gates
-                            its "newer HubSpot editor, no fieldset" field-chrome branch on
-                            `:not(:has(fieldset))`. A fieldset here would flip that branch
-                            off and leave the embedded form below with browser-default
-                            inputs.
-                        */}
                         <div role="radiogroup" aria-label={this.labelText} class="grid grid-cols-1 lg:grid-cols-4 gap-3">
                             {this.items.map(item => (
-                                // The card is the affordance, so the radio itself is
-                                // sr-only — still focusable and arrow-navigable, with the
-                                // focus treatment drawn on the card via has-[:focus-visible].
-                                // That treatment is the FORM-CONTROL one, not the button
-                                // one: violet-800 border plus a 2px inset ring of the same
-                                // color, merging into one edge ($form-focus-ring in
-                                // shared/_forms.scss). Keep it in step with that token.
                                 <label class="card card-hover flex items-center justify-center p-3 m-0 text-center text-sm font-normal has-[:checked]:border-violet-primary has-[:checked]:bg-violet-50 has-[:checked]:text-violet-primary has-[:focus-visible]:border-violet-800 has-[:focus-visible]:inset-ring-2 has-[:focus-visible]:inset-ring-violet-800">
                                     <input
                                         type="radio"
@@ -183,9 +140,6 @@ export class PulumiMultiSelectForm {
                     </div>
                 )}
                 {!this.selectedItem ? null : this.selectedItem.cta ? (
-                    // Stands in for the submit button of the form the other choices
-                    // render, so it matches it: _hubspot.scss extends the HubSpot
-                    // submit input with .btn-primary .btn-lg.
                     <div class="mt-8"><a class="btn btn-primary btn-lg" href={this.selectedItem.cta.url}>{this.selectedItem.cta.label}</a></div>
                 ) : (
                     <pulumi-hubspot-form key={selectedFormId} form-id={selectedFormId} carryOverValues={this.carriedValues}></pulumi-hubspot-form>

--- a/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -101,6 +101,8 @@ export class PulumiMultiSelectForm {
         }
 
         const values = await form.getCarryOverValues();
+        // Merged rather than replaced: the forms don't all share fields, so a message
+        // has to survive a detour through one that lacks a message field.
         const carried: Record<string, string> = { ...this.carriedValues };
 
         Object.entries(values).forEach(([name, value]) => {
@@ -122,6 +124,7 @@ export class PulumiMultiSelectForm {
                 {this.formSubmitted ? null : (
                     <div>
                         <span class={this.labelClass || ""}>{this.labelText}</span>
+                        {/* Not a <fieldset>: one here disables the `:not(:has(fieldset))` branch in _hubspot.scss that styles the embedded form's fields. */}
                         <div role="radiogroup" aria-label={this.labelText} class="grid grid-cols-1 lg:grid-cols-4 gap-3">
                             {this.items.map(item => (
                                 <label class="card card-hover flex items-center justify-center p-3 m-0 text-center text-sm font-normal has-[:checked]:border-violet-primary has-[:checked]:bg-violet-50 has-[:checked]:text-violet-primary has-[:focus-visible]:border-violet-800 has-[:focus-visible]:inset-ring-2 has-[:focus-visible]:inset-ring-violet-800">

--- a/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/theme/stencil/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -49,12 +49,24 @@ export class PulumiMultiSelectForm {
     @State()
     formSubmitted = false;
 
+    // What the visitor had typed into the form they're switching away from, so
+    // changing your mind about why you're writing in doesn't cost you the message
+    // you already wrote. Handed to the incoming form, which fills only the fields
+    // it finds empty.
+    @State()
+    carriedValues: Record<string, string> = {};
+
     // The window event listener used to handle submitting form data to Segment.
     private windowEventHandler: (this: Window, ev: MessageEvent) => any;
 
     // Groups the radios. A page only ever renders one of these, so a constant
     // name is enough.
     private static readonly radioGroupName = "multi-select-form-choice";
+
+    // Fields worth carrying between forms: the ones a visitor types the same way
+    // whichever form they land on. Everything else — consent checkboxes, per-form
+    // custom fields — is left to the new form.
+    private static readonly carryOverFields = ["firstname", "lastname", "email", "company", "message"];
 
     componentWillLoad() {
         if (this.defaultFormId !== "") {
@@ -96,9 +108,34 @@ export class PulumiMultiSelectForm {
         }
     }
 
-    // When the choice changes we need to update the state accordingly.
-    private handleChoiceChange(hubspotFormId: string) {
+    // When the choice changes we need to update the state accordingly, capturing
+    // the outgoing form's values first — switching swaps the embedded form out
+    // entirely, so anything typed is gone once the state changes.
+    private async handleChoiceChange(hubspotFormId: string) {
+        this.carriedValues = await this.captureCarryOverValues();
         this.selectedItem = this.items.find(item => item.hubspotFormId === hubspotFormId);
+    }
+
+    private async captureCarryOverValues(): Promise<Record<string, string>> {
+        const form = this.el.querySelector("pulumi-hubspot-form") as HTMLPulumiHubspotFormElement;
+
+        // No form to read: either nothing has been chosen yet, or the current
+        // choice is one of the CTA-only options. Keep what was captured last so a
+        // detour through the support option doesn't discard it.
+        if (!form || typeof form.getFieldValues !== "function") {
+            return this.carriedValues;
+        }
+
+        const values = await form.getFieldValues();
+        const carried: Record<string, string> = {};
+
+        PulumiMultiSelectForm.carryOverFields.forEach(name => {
+            if (values[name]) {
+                carried[name] = values[name];
+            }
+        });
+
+        return carried;
     }
 
     render() {
@@ -147,7 +184,7 @@ export class PulumiMultiSelectForm {
                     // submit input with .btn-primary .btn-lg.
                     <div class="mt-8"><a class="btn btn-primary btn-lg" href={this.selectedItem.cta.url}>{this.selectedItem.cta.label}</a></div>
                 ) : (
-                    <pulumi-hubspot-form key={selectedFormId} form-id={selectedFormId}></pulumi-hubspot-form>
+                    <pulumi-hubspot-form key={selectedFormId} form-id={selectedFormId} carryOverValues={this.carriedValues}></pulumi-hubspot-form>
                 )}
             </div>
         );

--- a/theme/stencil/src/components/pulumi-multi-select-form/test/pulumi-multi-select-form.spec.tsx
+++ b/theme/stencil/src/components/pulumi-multi-select-form/test/pulumi-multi-select-form.spec.tsx
@@ -10,12 +10,10 @@ describe("pulumi-multi-select-form", () => {
         expect(page.root).toEqualHtml(`
       <pulumi-multi-select-form>
         <div>
-           <span>
+           <div>
              <span></span>
-             <select>
-               <option disabled hidden selected value="">Please select</option>
-             </select>
-           </span>
+             <div class="grid grid-cols-1 lg:grid-cols-4 gap-3" role="radiogroup"></div>
+           </div>
         </div>
       </pulumi-multi-select-form>
     `);


### PR DESCRIPTION
### Proposed changes

This cleans up the work in https://github.com/pulumi/docs/pull/20867 and adds some additional enhancements and fixes.

- Design cleanup on sidebar, address moved to sidebar
- So the page doesn't start visually unbalanced, the first option is now selected by default so the page loads with a form visible.
- Changes the options from a select to radio-style buttons so users can see all the options and will be more likely to choose the correct one.
- Switching between reasons no longer discards what's been typed. The chooser reads the outgoing form before it swaps and carries first/last name, email, company, and message into the next one. Carried values fill only fields that are still empty, so HubSpot's own prefill of a known contact is left alone; a `?param=` prefill still overwrites both, since an explicit link is the strongest signal of intent. `pulumi-hubspot-form` gains a `getFieldValues()` method and a `carryOverValues` prop, both built on the `collectFieldValues`/`applyPrefill` helpers already there for submit tracking and query-param prefill.
- Two fixes in `_hubspot.scss` that reach every HubSpot form on the site, not just this page:
    - Validation messages carried an extra 1.25rem of top margin, since HubSpot marks each one up as a `<label>` and it picked up the `mt-5` meant to space a field label off its control - pre-existing.
    - The two-column gutter on a `form-columns-2` fieldset is padding on the leading field, so it stayed put once the columns stacked and left the first field ending short of the second.
- The carry-over list assumes the four forms share HubSpot's standard internal field names (`firstname`, `lastname`, `email`, `company`, `message`). A form that names a field differently just won't carry that one - worth checking against the live forms.

**Not covered here**

- The events pages have a related problem, but not the same one: they render every session's form up front and toggle `hidden` on the panel wrappers, so nothing is destroyed - values just don't carry to the session you switch to. That fix belongs in the panel-toggle code rather than in this component.