### PR TITLE
Clear Segment's stale user identity on www when signed out of Pulumi Cloud

### DIFF
--- a/theme/src/ts/intercom-identity.ts
+++ b/theme/src/ts/intercom-identity.ts
@@ -2,8 +2,8 @@
 // backend-signed Messenger Security JWT fetched from app.pulumi.com. Rides the
 // consent-managed Segment lifecycle (analytics.ready, same as the head
 // partial's ad pixel): anonymous or non-consented visitors cost zero requests.
-// Segment boots the widget as usual — this only attaches (or clears) verified
-// identity.
+// Segment boots the widget as usual — this attaches (or clears) verified
+// identity and drops Segment's stale persisted user.
 
 // Local docs dev (make serve) pairs with a local console (devtool.py start);
 // everywhere else the console lives at app.pulumi.com.
@@ -15,8 +15,19 @@ const HINT_COOKIE = "pulumi_web_user_info";
 const JWT_CACHE_KEY = "pulumi_intercom_jwt";
 const IDENTIFIED_KEY = "pulumi_intercom_identified";
 const REFRESH_HEADROOM_MS = 5 * 60 * 1000;
+// Segment's persisted user outlives the console session, and its device-mode
+// Intercom destination pushes the stale id into the Messenger unsigned,
+// colliding with JWT-verified identities ("User ID mismatch" errors).
+const SEGMENT_USER_ID_KEY = "ajs_user_id";
+// ajs_anonymous_id is deliberately absent: pre-signup tracking depends on it.
+const SEGMENT_USER_KEYS = [SEGMENT_USER_ID_KEY, "ajs_user_traits"];
 
 type IntercomFn = (command: string, arg?: unknown) => void;
+
+// The analytics.js global is untyped; cross the `any` boundary in one place.
+function segmentAnalytics(): { ready?(cb: () => void): void; user?(): { id(value: string | null): void } } | undefined {
+    return (window as any).analytics;
+}
 
 // The JWT is opaque to this module; freshness comes from the endpoint's
 // expiresAt (unix seconds). Both the cache and the "already identified"
@@ -34,27 +45,33 @@ interface IdentifiedUser {
     userId: string;
 }
 
-// Mirrors theme/stencil/src/store/reducers/user.ts's getUserInfoCookie —
-// keep the parsing logic in sync.
-function hintUserId(): string | null {
+function cookieValue(name: string): string | null {
     for (const entry of document.cookie.split(";")) {
         const idx = entry.indexOf("=");
-        if (idx === -1) {
-            continue;
-        }
-        if (entry.slice(0, idx).trim() !== HINT_COOKIE) {
-            continue;
-        }
-        try {
-            const parsed = JSON.parse(decodeURIComponent(entry.slice(idx + 1).trim()).replace(/^j:/, "")) as {
-                userId?: string;
-            };
-            return typeof parsed.userId === "string" && parsed.userId ? parsed.userId : null;
-        } catch (e) {
-            return null;
+        if (idx !== -1 && entry.slice(0, idx).trim() === name) {
+            try {
+                return decodeURIComponent(entry.slice(idx + 1).trim());
+            } catch (e) {
+                return null;
+            }
         }
     }
     return null;
+}
+
+// Mirrors theme/stencil/src/store/reducers/user.ts's getUserInfoCookie —
+// keep the parsing logic in sync.
+function hintUserId(): string | null {
+    const raw = cookieValue(HINT_COOKIE);
+    if (raw === null) {
+        return null;
+    }
+    try {
+        const parsed = JSON.parse(raw.replace(/^j:/, "")) as { userId?: string };
+        return typeof parsed.userId === "string" && parsed.userId ? parsed.userId : null;
+    } catch (e) {
+        return null;
+    }
 }
 
 function identifiedUser(): IdentifiedUser | null {
@@ -97,9 +114,90 @@ function clearCaches(): void {
     }
 }
 
+// analytics.js persists each value in localStorage with an apex-domain cookie
+// mirror, and reads localStorage first; mirror that read order here.
+function segmentValue(key: string): string | null {
+    let raw: string | null = null;
+    try {
+        raw = localStorage.getItem(key);
+    } catch (e) {
+        // Storage unavailable: the cookie fallback below still applies.
+    }
+    return raw !== null ? raw : cookieValue(key);
+}
+
+// Gate on the id key only: a traits-only identify (the consent manager's
+// destinationTrackingPreferences) persists ajs_user_traits for visitors who
+// never signed in, and there's no id to collide without ajs_user_id.
+function hasSegmentUser(): boolean {
+    return segmentValue(SEGMENT_USER_ID_KEY) !== null;
+}
+
+// analytics.js persists values JSON-encoded; tolerate bare strings too.
+function decodeSegmentValue(raw: string): string | null {
+    try {
+        const parsed = JSON.parse(raw) as unknown;
+        return typeof parsed === "string" && parsed ? parsed : null;
+    } catch (e) {
+        return raw ? raw : null;
+    }
+}
+
+function segmentUserId(): string | null {
+    const raw = segmentValue(SEGMENT_USER_ID_KEY);
+    return raw === null ? null : decodeSegmentValue(raw);
+}
+
+function segmentUserIsStale(): boolean {
+    const sessionUserId = hintUserId();
+    if (!sessionUserId) {
+        return hasSegmentUser();
+    }
+    // An account switch rewrites the apex cookie but not this origin's
+    // localStorage copy, which analytics.js reads first.
+    const segmentId = segmentUserId();
+    return segmentId !== null && segmentId !== sessionUserId;
+}
+
+// Deletion only takes with a matching domain attribute, so expire both the
+// host-only and the apex-domain variant (Segment writes the latter).
+function expireCookie(name: string): void {
+    const expired = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+    document.cookie = expired;
+    const labels = location.hostname.split(".");
+    if (labels.length > 1) {
+        document.cookie = expired + "; domain=." + labels.slice(-2).join(".");
+    }
+}
+
+function clearSegmentUser(): void {
+    for (const key of SEGMENT_USER_KEYS) {
+        try {
+            localStorage.removeItem(key);
+        } catch (e) {
+            // Storage unavailable: the cookie expiry below still applies.
+        }
+        expireCookie(key);
+    }
+    // An already-loaded analytics.js (the 401 path) holds the user in memory
+    // and would re-persist it on the next event.
+    try {
+        const analytics = segmentAnalytics();
+        if (analytics && typeof analytics.user === "function") {
+            analytics.user().id(null);
+        }
+    } catch (e) {
+        // Best effort: storage is already cleared.
+    }
+}
+
 function signedOutCleanup(intercom: IntercomFn): void {
     const wasIdentified = identifiedUser() !== null;
     clearCaches();
+    // The 401 is the staleness proof here; the hint cookie may still match.
+    if (hasSegmentUser()) {
+        clearSegmentUser();
+    }
     if (wasIdentified) {
         intercom("shutdown");
     }
@@ -182,6 +280,12 @@ function run(intercom: IntercomFn): void {
         });
 }
 
+// Runs at module evaluation, before the consent manager loads analytics.js —
+// the stale user is gone before Segment's Intercom destination can push it.
+if (segmentUserIsStale()) {
+    clearSegmentUser();
+}
+
 // analytics.ready fires only after the consent-managed Segment load completes
 // (see conditionallyLoadAnalytics), which is already deferred to browser idle —
 // same fail-closed rendezvous the head partial's ad pixel uses. But ready()
@@ -209,7 +313,7 @@ function tryRun(): void {
     run((cmd, arg) => (window as unknown as { Intercom: IntercomFn }).Intercom(cmd, arg));
 }
 
-const analytics = (window as any).analytics;
+const analytics = segmentAnalytics();
 if (analytics && typeof analytics.ready === "function") {
     analytics.ready(tryRun);
 }

--- a/theme/src/ts/intercom-identity.ts
+++ b/theme/src/ts/intercom-identity.ts
@@ -171,6 +171,17 @@ function expireCookie(name: string): void {
 }
 
 function clearSegmentUser(): void {
+    // An already-loaded analytics.js (the 401 path) holds the user in memory,
+    // and its stores persist id(null) as a literal "null" — reset first so the
+    // storage clear below removes that write too.
+    try {
+        const analytics = segmentAnalytics();
+        if (analytics && typeof analytics.user === "function") {
+            analytics.user().id(null);
+        }
+    } catch (e) {
+        // Best effort: the storage clear below is the real cleanup.
+    }
     for (const key of SEGMENT_USER_KEYS) {
         try {
             localStorage.removeItem(key);
@@ -178,16 +189,6 @@ function clearSegmentUser(): void {
             // Storage unavailable: the cookie expiry below still applies.
         }
         expireCookie(key);
-    }
-    // An already-loaded analytics.js (the 401 path) holds the user in memory
-    // and would re-persist it on the next event.
-    try {
-        const analytics = segmentAnalytics();
-        if (analytics && typeof analytics.user === "function") {
-            analytics.user().id(null);
-        }
-    } catch (e) {
-        // Best effort: storage is already cleared.
     }
 }
 


### PR DESCRIPTION
### Proposed changes

Fixes the five **"User ID mismatch"** Intercom installation errors on www.pulumi.com — the blocker for enabling **Enforce Messenger Security**, which the Intercom customer portal requires.

Segment persists its signed-in identity in apex-domain (`.pulumi.com`) cookies plus a www-origin localStorage mirror, and its device-mode Intercom destination pushes that id into the Messenger unsigned on every page view. When the id is stale — the visitor signed out of the console, or switched accounts — it collides with the JWT-verified identity attached by `intercom-identity.ts` (#20547).

One file, `theme/src/ts/intercom-identity.ts`, clears Segment's user keys (`ajs_user_id`, `ajs_user_traits`; cookies and localStorage) at module evaluation, which runs before the consent manager loads analytics.js:

- **No console session** (hint cookie absent): clear any persisted Segment user.
- **Account switch** (persisted Segment id differs from the session's user id — the console rewrites the apex cookie on sign-in, but analytics.js reads the www-origin localStorage copy first): clear it; the current user re-attaches on their next console-driven identify. Both ids are `apitype.User.id`, so the comparison is sound.
- **Dead session** (hint cookie present, settings fetch 401s): the same cleanup runs in `signedOutCleanup`, additionally clearing analytics.js's in-memory user id.

Deliberately untouched: `ajs_anonymous_id` (pre-signup tracking), signed-in event attribution, and Segment configuration. Disabling the legacy device-mode Intercom destination in Segment is deferred to a follow-up with the Segment owners.

Rollout: stale browsers self-heal on their next www visit. When the install-error log (7-day window) drains to zero, enforcement can be enabled.

