### PR TITLE
fix(ci): don't fail the PR build when a GitHub API call returns an error object

### DIFF
--- a/scripts/run-lighthouse-pr.sh
+++ b/scripts/run-lighthouse-pr.sh
@@ -117,7 +117,7 @@ if [[ -n "$GITHUB_EVENT_PATH" ]]; then
         existing_comment_id=$(curl -s \
             -H "Authorization: token ${PULUMI_BOT_TOKEN}" \
             "$pr_comment_api_url" \
-            | jq -r '[.[] | select(.user.login == "pulumi-bot" and (.body | contains("<!-- lighthouse-report -->")))] | last | .id // empty')
+            | jq -r '[if type == "array" then .[] else empty end | select(.user.login == "pulumi-bot" and (.body | contains("<!-- lighthouse-report -->")))] | last | .id // empty')
 
         if [[ -n "$existing_comment_id" ]]; then
             echo "Updating Lighthouse comment (${existing_comment_id})..."

--- a/scripts/sync-and-test-bucket.sh
+++ b/scripts/sync-and-test-bucket.sh
@@ -147,7 +147,7 @@ if [[ "$1" == "preview" ]]; then
             if [[ -f "${build_dir}${url}index.html" ]]; then
                 changed_pages+=("- [${url}](${s3_website_url}${url})")
             fi
-        done < <(echo "$files_json" | jq -r '.[] | select(.status != "removed") | select(.filename | startswith("content/") and endswith(".md")) | .filename')
+        done < <(echo "$files_json" | jq -r 'if type == "array" then .[] else empty end | select(.status != "removed") | select(.filename | startswith("content/") and endswith(".md")) | .filename')
 
         # Stop once we hit a short (final) page, or if the response wasn't an
         # array (e.g. a transient API error), which yields 0 and breaks cleanly.
@@ -171,7 +171,7 @@ if [[ "$1" == "preview" ]]; then
     existing_comment_id=$(curl -s \
         -H "Authorization: token ${PULUMI_BOT_TOKEN}" \
         "$pr_comment_api_url" \
-        | jq -r '[.[] | select(.user.login == "pulumi-bot" and (.body | contains("<!-- preview-link -->")))] | last | .id // empty')
+        | jq -r '[if type == "array" then .[] else empty end | select(.user.login == "pulumi-bot" and (.body | contains("<!-- preview-link -->")))] | last | .id // empty')
 
     if [[ -n "$existing_comment_id" ]]; then
         curl -s \


### PR DESCRIPTION
### Proposed changes

Fixes a CI failure mode where a fully successful build gets marked red by a transient GitHub API blip. Found while diagnosing #20926, whose build failed four times in a row with:

```
jq: error (at <stdin>:5): Cannot index string with string "status"
jq: error (at <stdin>:5): Cannot index string with string "user"
make: *** [Makefile:117: ci_pull_request] Error 5
```

**Root cause.** Three jq filters assume the GitHub REST response is an array:

| File | Line | Filter |
| --- | --- | --- |
| `scripts/sync-and-test-bucket.sh` | 150 | `.[] \| select(.status != "removed") ...` |
| `scripts/sync-and-test-bucket.sh` | 174 | `[.[] \| select(.user.login == "pulumi-bot" ...)]` |
| `scripts/run-lighthouse-pr.sh` | 120 | `[.[] \| select(.user.login == "pulumi-bot" ...)]` |

When the API returns an error object instead of an array -- rate limit, 403, 5xx -- `.[]` iterates that object's *values*, which are strings, and indexing a string with `.status` or `.user` is a hard jq error (exit 5), not a soft empty. `sync-and-test-bucket.sh` runs under `set -o errexit -o pipefail` and each filter is the last command in its pipeline, so the script dies and takes the build with it.

The failure lands *after* Hugo, the link check, Cypress, and the S3 sync have all succeeded, which is why the red build looks unrelated to anything in the diff. In #20926's case the actual page content was fine every time; only the preview-link comment step blew up.

The intent was already documented -- the comment above the `page_count` line says a non-array response "yields 0 and breaks cleanly" -- but that guard sits *after* the filter that crashes, so it never got the chance to run.

**Fix.** Guard all three with `if type == "array" then .[] else empty end`. The happy path is unchanged; an error response now yields an empty result instead of aborting. A blip costs a missing preview-link (or Lighthouse) comment for that run instead of a red build.

**Validation.** Reproduced both jq errors verbatim, including exit code 5, against a representative GitHub error object (`{"message": "API rate limit exceeded", "documentation_url": "...", "status": "403"}`). Re-ran both filters after the change against that object (empty output, exit 0) and against representative valid array payloads, confirming identical results to the originals: the changed-files filter still drops `status: "removed"` and non-`content/**.md` entries, and the comment filter still selects the last matching `pulumi-bot` comment. `bash -n` clean on both scripts.

### Related issues (optional)

Surfaced while diagnosing the build failures on #20926.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iN1LyQsU2rUov6AQrbozA

---
_Generated by [Claude Code](https://claude.ai/code/session_013iN1LyQsU2rUov6AQrbozA)_