### PR TITLE
Document the SCIM feature surface and fix the stale 40-char team-name limit

### DIFF
--- a/content/docs/administration/access-identity/scim/_index.md
+++ b/content/docs/administration/access-identity/scim/_index.md
@@ -36,7 +36,7 @@ Pulumi implements a single SCIM 2.0 endpoint. Every identity provider uses the s
 | Group-to-team synchronization | Yes (create, read, update, delete, and membership changes) |
 | `PATCH` | Yes, for both users and groups |
 | Filtering | `userName eq` for users and `displayName eq` for groups, and nothing else. Any other attribute or operator, such as `sw` or `co`, fails with a `400 invalidFilter` response |
-| Pagination | Users only, at a maximum of 100 per page. A request for a larger `count` fails with a `400` response. A group search is unpaginated and returns every match in one response |
+| Pagination | Users only, at most 100 per page. A request for a larger `count` fails with a `400` response. A group search is unpaginated and returns every match in one response |
 
 ## Supported attributes
 

--- a/content/docs/administration/access-identity/scim/_index.md
+++ b/content/docs/administration/access-identity/scim/_index.md
@@ -16,17 +16,89 @@ pulumi_cloud_feature: scim
 
 The [Pulumi Cloud](https://app.pulumi.com/signin) supports System for Cross-domain Identity Management (SCIM) 2.0 integration with different identity providers. SCIM enables you to manage your users and groups centrally in your Identity Provider (IdP) and then synchronize those users and groups to the Pulumi Cloud.
 
-    {{% notes type="info" %}}
-If desired, in addition to the SCIM-managed teams, one can also configure and manage Pulumi-local teams in the Pulumi Cloud. See [Teams](/docs/administration/organizations-teams/teams/) for how to configure teams in the Pulumi Cloud.
-    {{% /notes %}}
+SCIM provisions two things in Pulumi Cloud:
+
+- **Users** become [members of your Pulumi organization](/docs/administration/organizations-teams/organizations/), able to sign in through your identity provider.
+- **Groups** become [teams](/docs/administration/access-identity/rbac/teams/), and group membership becomes team membership. Grant those teams access to stacks, environments, and other entities with [RBAC](/docs/administration/access-identity/rbac/).
+
+Pulumi implements a single SCIM 2.0 endpoint. Every identity provider uses the same routes, schemas, and attributes, so only the IdP-side setup differs from one provider to the next. The guides at the end of this page cover popular providers, and everything documented on this page applies to each of them.
 
 {{% notes type="info" %}}
 {{< sso-scim-limits-info idp="your Identity Provider" >}}
 {{% /notes %}}
+
+## Capabilities
+
+| Capability | Support |
+|---|---|
+| User provisioning | Yes (create, read, update, and search) |
+| User deprovisioning | Yes, but soft only (see [Deprovisioning never deletes a user](#deprovisioning-never-deletes-a-user)) |
+| Group-to-team synchronization | Yes (create, read, update, delete, and membership changes) |
+| `PATCH` | Yes, for both users and groups |
+| Filtering | `userName eq` for users and `displayName eq` for groups. `eq` is the only supported operator |
+| Pagination | Users only, up to 100 results per page. A group search returns every match in a single response |
+
+## Supported attributes
+
+The lists below are complete. Pulumi implements the core SCIM 2.0 schemas only, so a request that adds or updates any attribute not listed here fails with a `400 invalidPath` response. See [Unknown path](/docs/support/faq/scim/#unknown-path) in the SCIM FAQ.
+
+For users:
+
+- `userName` (immutable after creation, see [Usernames cannot change](#usernames-cannot-change))
+- `displayName`
+- `name.givenName`
+- `name.familyName`
+- `emails[type eq "work"].value`
+- `active`
+
+For groups:
+
+- `displayName`
+- `members`
+
+## What SCIM does not manage
+
+| Feature | Notes |
+|---|---|
+| Roles and administrator status | Pulumi does not implement the `roles` or `entitlements` attributes. A user provisioned through SCIM is always created as an organization member, and a group member is always added to the team as a plain member. Promote users to admin in the Pulumi Cloud console |
+| `externalId` | Accepted on users but never stored, and not part of the group schema at all. Remove any `externalId` mapping for groups in your IdP |
+| Bulk operations | Not supported. Provision resources one request at a time |
+| Sorting | Not supported |
+| ETags | Not supported |
+| Password synchronization | Not supported. Credentials stay in your IdP |
+| Enterprise User extension | Not supported. Only the core SCIM 2.0 user and group schemas are implemented |
+| Secondary emails | Not supported. Only the primary work email is used |
+
+## Behavior to plan for
+
+These apply to every identity provider, regardless of which guide you follow.
+
+### Deprovisioning never deletes a user
+
+Pulumi has no endpoint for deleting a user through SCIM. Deprovisioning sets `active` to `false`, which removes the user's access to the organization while preserving their account and its history. Configure your IdP to suspend or deactivate users rather than delete them.
+
+Teams are different: a group deleted in your IdP does delete the corresponding Pulumi team.
+
+### Usernames cannot change
+
+A Pulumi username is immutable once the account exists, because it identifies the user across every organization they belong to. If your IdP pushes a changed `userName` on an update, the request fails with a `400 immutability` response. Map `userName` so that it applies only when the account is created, not on later updates. Each provider guide covers where to set this.
+
+### Group members must already be provisioned
+
+Pulumi validates every member of a group before creating or updating the corresponding team. If any member has not yet been provisioned into your organization, or has been deactivated, the entire request fails with a `400` response and no membership changes are applied. Provision users before pushing the groups that contain them.
+
+Member validation reads up to 3000 identities per request, which is a practical ceiling on the size of a SCIM-managed team.
+
+{{% notes type="warning" %}}
+A group search returns every team in your organization whose display name matches the filter, not only the teams that SCIM created. Pulumi-local teams and teams backed by a GitHub organization appear in the results alongside SCIM-provisioned ones. If your IdP reconciles group state, it may see teams it does not own.
+{{% /notes %}}
+
+## Next steps
 
 To set up synchronization between Pulumi and your SAML 2.0 identity provider, refer to one of our example guides:
 
 - [Microsoft Entra ID (formerly Azure Active Directory)](/docs/administration/access-identity/scim/entra/)
 - [Okta](/docs/administration/access-identity/scim/okta/)
 - [OneLogin](/docs/administration/access-identity/scim/onelogin/)
-- [FAQ](/docs/support/faq/scim/)
+
+For the provisioning errors you are most likely to hit and how to resolve them, see the [SCIM FAQ](/docs/support/faq/scim/).

--- a/content/docs/administration/access-identity/scim/_index.md
+++ b/content/docs/administration/access-identity/scim/_index.md
@@ -35,8 +35,8 @@ Pulumi implements a single SCIM 2.0 endpoint. Every identity provider uses the s
 | User deprovisioning | Yes, but soft only (see [Deprovisioning never deletes a user](#deprovisioning-never-deletes-a-user)) |
 | Group-to-team synchronization | Yes (create, read, update, delete, and membership changes) |
 | `PATCH` | Yes, for both users and groups |
-| Filtering | `userName eq` for users and `displayName eq` for groups. `eq` is the only supported operator |
-| Pagination | Users only, up to 100 results per page. A group search returns every match in a single response |
+| Filtering | `userName eq` for users and `displayName eq` for groups, and nothing else. Any other attribute or operator, such as `sw` or `co`, fails with a `400 invalidFilter` response |
+| Pagination | Users only, at a maximum of 100 per page. A request for a larger `count` fails with a `400` response. A group search is unpaginated and returns every match in one response |
 
 ## Supported attributes
 
@@ -60,7 +60,7 @@ For groups:
 
 | Feature | Notes |
 |---|---|
-| Roles and administrator status | Pulumi does not implement the `roles` or `entitlements` attributes. A user provisioned through SCIM is always created as an organization member, and a group member is always added to the team as a plain member. Promote users to admin in the Pulumi Cloud console |
+| Roles and administrator status | Pulumi does not implement the `roles` or `entitlements` attributes, so no SCIM request can set one. A user is always created as an organization member, and a group member is always added to the team as a plain member. Change either afterwards in the Pulumi Cloud console; SCIM does not overwrite a role you set there |
 | `externalId` | Accepted on users but never stored, and not part of the group schema at all. Remove any `externalId` mapping for groups in your IdP |
 | Bulk operations | Not supported. Provision resources one request at a time |
 | Sorting | Not supported |
@@ -75,9 +75,20 @@ These apply to every identity provider, regardless of which guide you follow.
 
 ### Deprovisioning never deletes a user
 
-Pulumi has no endpoint for deleting a user through SCIM. Deprovisioning sets `active` to `false`, which removes the user's access to the organization while preserving their account and its history. Configure your IdP to suspend or deactivate users rather than delete them.
+Pulumi has no endpoint for deleting a user through SCIM. Deprovisioning sets `active` to `false`, which removes the user's access to the organization while preserving their account and its history, so the change is reversible by reactivating the user in your IdP. Configure your IdP to suspend or deactivate users rather than delete them.
 
-Teams are different: a group deleted in your IdP does delete the corresponding Pulumi team.
+Teams do not work this way. See [Deleting a group deletes the team](#deleting-a-group-deletes-the-team).
+
+### Deleting a group deletes the team
+
+Unlike users, teams are deleted outright. Deleting a group in your identity provider deletes the corresponding Pulumi team, and the access you granted that team goes with it: the team's roles, and its permissions on stacks and environments. Members themselves are not deleted and remain in your organization.
+
+Two things to plan for:
+
+- The deletion is not recorded in your organization's audit log, because a SCIM request has no acting user to attribute it to.
+- A delete request identifies the team by id, and Pulumi does not check that the id belongs to a SCIM-provisioned team. Any team in the organization can be deleted this way, including one created in the Pulumi Cloud console.
+
+To keep a team while removing its members, empty the group rather than deleting it.
 
 ### Usernames cannot change
 
@@ -87,10 +98,12 @@ A Pulumi username is immutable once the account exists, because it identifies th
 
 Pulumi validates every member of a group before creating or updating the corresponding team. If any member has not yet been provisioned into your organization, or has been deactivated, the entire request fails with a `400` response and no membership changes are applied. Provision users before pushing the groups that contain them.
 
-Member validation reads up to 3000 identities per request, which is a practical ceiling on the size of a SCIM-managed team.
+Member validation reads up to 3000 identities per request. In an organization larger than that, members outside the window are not silently dropped: they fail validation, and the request is rejected with the same `400` response. This is a practical ceiling on the size of a SCIM-managed team.
 
 {{% notes type="warning" %}}
-A group search returns every team in your organization whose display name matches the filter, not only the teams that SCIM created. Pulumi-local teams and teams backed by a GitHub organization appear in the results alongside SCIM-provisioned ones. If your IdP reconciles group state, it may see teams it does not own.
+A group search returns every team in your organization whose display name matches the filter, not only the teams that SCIM created. Teams created in the Pulumi Cloud console and teams backed by a GitHub organization appear alongside SCIM-provisioned ones.
+
+This matters because an identity provider that reconciles group state may treat a team it does not own as one to remove, and a delete request succeeds against any team in the organization. Scope reconciliation to the groups your identity provider provisions, or give SCIM-managed teams a distinct naming convention so the others are easy to exclude.
 {{% /notes %}}
 
 ## Next steps

--- a/content/docs/administration/access-identity/scim/entra.md
+++ b/content/docs/administration/access-identity/scim/entra.md
@@ -58,7 +58,7 @@ If you are not yet ready to enable provisioning for Groups, disable that.
 
 ### Adjust User Attribute Mappings
 
-Update the mapping for **userName** so that it applies **Only during object creation**. In the **Mappings** expansion panel, select **Provision Microsoft Entra ID _Users_** and then select the corresponding attribute mapping as shown below.
+Update the mapping for **userName** so that it applies **Only during object creation**. In the **Mappings** expansion panel, select **Provision Microsoft Entra ID _Users_** and then select the corresponding attribute mapping.
 
 In the configuration window, change the value of the **Apply this mapping** drop-down to **Only during object creation**.
 

--- a/content/docs/administration/access-identity/scim/entra.md
+++ b/content/docs/administration/access-identity/scim/entra.md
@@ -17,9 +17,9 @@ aliases:
 pulumi_cloud_feature: scim
 ---
 
-This document outlines the steps required to configure automatic provisioning/deprovisioning of your users in Pulumi using SCIM 2.0.
+This document outlines the steps required to configure automatic provisioning/deprovisioning of your users and groups in Pulumi using SCIM 2.0.
 
-Please note that some advanced SCIM features aren't supported yet. For more information, see [Known Limitations](#known-limitations).
+For the capabilities and attributes Pulumi's SCIM implementation supports, see [Pulumi Cloud & SCIM](/docs/administration/access-identity/scim/#capabilities).
 
 ## Prerequisites
 
@@ -28,10 +28,6 @@ Please note that some advanced SCIM features aren't supported yet. For more info
 * (Optional, but highly recommended) You should have more than one admin for your Pulumi organization.
 
 ## Enabling Automatic Provisioning
-
-     {{% notes type="warning" %}}
- **Team name character limit**: Pulumi team names created via SCIM must not exceed 40 characters. If your Entra group name is longer than this limit, you’ll need to rename the group before pushing it to Pulumi. Otherwise, the provisioning will fail.
-     {{% /notes %}}
 
 1. Navigate to the Microsoft Entra ID application where you have configured Single Sign On using SAML with Pulumi.
 2. Select **Enterprise Applications** and select the app in which you configured Single Sign On with Pulumi earlier.
@@ -44,9 +40,9 @@ Under the **Admin Credentials** section of the **Provisioning** feature, fill ou
 * **Tenant URL**: `https://api.pulumi.com/scim/v2/{orgName}`, where `{orgName}` must be replaced with your organization’s login name (not display name). If you do not know this, navigate to your SAML settings and look at the SSO URL. It will have your organization’s login name in the URL.
 * **Secret Token**: You will use a token from the [Pulumi Cloud](https://app.pulumi.com/signin) as the authorization bearer token. To generate a token, navigate to your org in the Pulumi Cloud, select **Settings**, then **Access Management**, and then in the **SCIM** section, generate a new token if you have never generated one for your org or regenerate it if you have already done so in the past.
 
-    {{% notes type="info" %}}
+{{% notes type="info" %}}
 Once you generate the token, save it securely. Neither the Pulumi Cloud nor Pulumi support can retrieve a token once it's been initially generated. If you lose and need the SCIM token again, you'll have to generate a new token, invalidating any previous tokens for your Pulumi organization.
-    {{% /notes %}}
+{{% /notes %}}
 
 Select **Test Connection**. You should get a success notification once the connection is successful.
 
@@ -54,15 +50,15 @@ Select **Test Connection**. You should get a success notification once the conne
 
 Make sure the **Provision Microsoft Entra ID _Users_** mapping is enabled.
 
-    {{% notes type="info" %}}
+{{% notes type="info" %}}
 If you are not yet ready to enable provisioning for Groups, disable that.
-    {{% /notes %}}
+{{% /notes %}}
 
 ![mappings](/images/docs/reference/service/scim/azuread/mappings.png)
 
 ### Adjust User Attribute Mappings
 
-Update the mapping for **userName** so that is applied **Only during object creation**. In the **Mappings** expansion panel, click **Provision Microsoft Entra ID _Users_** and then click on the corresponding attribute mapping as shown below.
+Update the mapping for **userName** so that it applies **Only during object creation**. In the **Mappings** expansion panel, click **Provision Microsoft Entra ID _Users_** and then click on the corresponding attribute mapping as shown below.
 
 In the configuration window, change the value of the **Apply this mapping** drop-down to **Only during object creation**.
 
@@ -97,6 +93,10 @@ You are now done with the Mappings configuration. Click **Save** and close the c
 
 ## Enable Group Provisioning
 
+{{% notes type="warning" %}}
+**Team name character limit**: Pulumi team names created via SCIM must be 100 characters or fewer. If your Entra group name is longer than that, rename the group before pushing it to Pulumi. Otherwise, provisioning fails.
+{{% /notes %}}
+
 To enable the provisioning of Entra ID groups to Pulumi Cloud, select **Edit Provisioning** and then select the **Provision Microsoft Entra ID Groups** setting under the **Mappings**
 expansion panel and switch the **Enabled** setting to **Yes**.
 
@@ -117,16 +117,8 @@ Set the **Provisioning Status** to **On** and then click **Save**.
 
 You must assign users to the Entra ID enterprise application to have them provisioned with an account in Pulumi. Click on the **Users and groups** feature in the left nav, and assign users and/or groups to the application by searching for them.
 
-    {{% notes type="info" %}}
+{{% notes type="info" %}}
 If you did not enable group provisioning while you were editing the provisioning setup, click on **Edit Provisioning** and enable the **Provision Microsoft Entra ID Groups** setting as well under the **Mappings** expansion panel.
-    {{% /notes %}}
+{{% /notes %}}
 
 Review the **Provisioning logs** to ensure there were no errors while provisioning the users. It may take a few minutes for logs to appear. If there were validation errors, you can correct them and try again, or contact Pulumi for support.
-
-## Known Limitations
-
-Some SCIM features are currently not supported:
-
-* Secondary emails
-* Password sync
-* Bulk importing

--- a/content/docs/administration/access-identity/scim/entra.md
+++ b/content/docs/administration/access-identity/scim/entra.md
@@ -58,7 +58,7 @@ If you are not yet ready to enable provisioning for Groups, disable that.
 
 ### Adjust User Attribute Mappings
 
-Update the mapping for **userName** so that it applies **Only during object creation**. In the **Mappings** expansion panel, click **Provision Microsoft Entra ID _Users_** and then click on the corresponding attribute mapping as shown below.
+Update the mapping for **userName** so that it applies **Only during object creation**. In the **Mappings** expansion panel, select **Provision Microsoft Entra ID _Users_** and then select the corresponding attribute mapping as shown below.
 
 In the configuration window, change the value of the **Apply this mapping** drop-down to **Only during object creation**.
 

--- a/content/docs/administration/access-identity/scim/okta.md
+++ b/content/docs/administration/access-identity/scim/okta.md
@@ -17,7 +17,7 @@ pulumi_cloud_feature: scim
 
 This document outlines the steps required to help you configure automatic provisioning/deprovisioning of your users and groups in Pulumi using SCIM 2.0.
 
-Please note that some advanced SCIM features aren't supported yet. For more information, see [Known Limitations](#known-limitations).
+For the capabilities and attributes Pulumi's SCIM implementation supports, see [Pulumi Cloud & SCIM](/docs/administration/access-identity/scim/#capabilities).
 
 ## Prerequisites
 
@@ -29,9 +29,9 @@ Please note that some advanced SCIM features aren't supported yet. For more info
 
 In order to enable SCIM provisioning in Okta, navigate to the Pulumi application configured in your Okta org. Under the **General** tab, in the **App Settings** dialog box, locate the **Provisioning** section and select **SCIM** by clicking **Edit** in the top right corner of the dialog box. Click **Save** to save your changes.
 
-    {{% notes type="warning" %}}
-> **Important:** If you do not see the SCIM option in the **App Settings** under the **General** tab, you may need to email **Okta support** at [support@okta.com](mailto:support@okta.com) and request that they enable `SCIM_PROVISIONING` for your Okta account.
-    {{% /notes %}}
+{{% notes type="warning" %}}
+**Important:** If you do not see the SCIM option in the **App Settings** under the **General** tab, you may need to email **Okta support** at [support@okta.com](mailto:support@okta.com) and request that they enable `SCIM_PROVISIONING` for your Okta account.
+{{% /notes %}}
 
 ![Okta Enabling SCIM](/images/docs/reference/service/scim/okta/general-enable-scim.png)
 
@@ -60,9 +60,10 @@ To configure the SCIM connector, click the **Provisioning** tab, and then select
 
 1. SCIM connector base URL: `https://api.pulumi.com/scim/v2/<orgName>`, where `<orgName>` must be replaced with your organization’s login name (not display name). If you do not know this, navigate to your SAML settings and look at the SSO URL. It will have your organization’s login name in the URL.
 2. Supported provisioning actions: Check **Push New Users** and **Push Profile Updates**.
-    {{% notes type="info" %}}
-If you also want to support pushing existing Okta groups, the steps in [Enabling Group Provisioning](#enablegroupprovisioning) describe how to set that up.
-    {{% /notes %}}
+
+    {{< notes type="info" >}}
+    If you also want to support pushing existing Okta groups, the steps in [Enabling Group Provisioning](#enablegroupprovisioning) describe how to set that up.
+    {{< /notes >}}
 
 3. Unique identifier field for users: Set to `userName`.
 4. Authentication Mode: `HTTP Header`
@@ -70,9 +71,9 @@ If you also want to support pushing existing Okta groups, the steps in [Enabling
 
     To generate a token, navigate to your org in the Pulumi Cloud, click on the **Settings** tab, and then click **Access Management**. Scroll down to the **SCIM** section and generate a new token if you have never generated one for your org, or regenerate it if you have already done so in the past.
 
-    {{% notes type="info" %}}
-Once you generate the token, save it securely. Neither the Pulumi Cloud nor Pulumi support can retrieve a token once it's been initially generated. If you lose and need the SCIM token again, you'll have to generate a new token, invalidating any previous tokens for your Pulumi organization.
-    {{% /notes %}}
+    {{< notes type="info" >}}
+    Once you generate the token, save it securely. Neither the Pulumi Cloud nor Pulumi support can retrieve a token once it's been initially generated. If you lose and need the SCIM token again, you'll have to generate a new token, invalidating any previous tokens for your Pulumi organization.
+    {{< /notes >}}
 
 6. Paste the token from the Pulumi Cloud into the Okta **Authorization** field under the **HTTP Header** section.
 
@@ -135,12 +136,12 @@ To set this up, you need to enable Push Groups as a supported provisioning actio
 
 ## Setting up Group Provisioning {#setupgroupprovisioning}
 
-    {{% notes type="warning" %}}
- **Important:** If there are members in a group that are not yet assigned to the Pulumi Cloud application in Okta, they will not be added to the team in the Pulumi Cloud. Ensure that all members in the group have been assigned to the application before pushing the group.
-     {{% /notes %}}
+{{% notes type="warning" %}}
+**Important:** If there are members in a group that are not yet assigned to the Pulumi Cloud application in Okta, they will not be added to the team in the Pulumi Cloud. Ensure that all members in the group have been assigned to the application before pushing the group.
+{{% /notes %}}
 
- {{% notes type="warning" %}}
- **Team name character limit**: Pulumi team names created via SCIM must not exceed 40 characters. If your Okta group name is longer than this limit, you’ll need to rename the group before pushing it to Pulumi. Otherwise, the provisioning will fail.
+{{% notes type="warning" %}}
+**Team name character limit**: Pulumi team names created via SCIM must be 100 characters or fewer. If your Okta group name is longer than that, rename the group before pushing it to Pulumi. Otherwise, provisioning fails.
 {{% /notes %}}
 
 To specify which groups you would like to push with group provisioning, select the **Push Groups** tab in your Pulumi Cloud application in Okta and complete the following steps.
@@ -163,14 +164,6 @@ To confirm that the groups were provisioned correctly, sign in to the Pulumi Clo
 
 Teams provisioned with SCIM will be marked with a blue SSO icon. Select the provisioned team and verify its membership.
 
-    {{% notes type="info" %}}
+{{% notes type="info" %}}
 SCIM provisioned team memberships cannot be altered within the Pulumi Cloud. If any membership changes are needed, they must be done within Okta. This ensures your teams on the Pulumi side will always mirror the groups you have configured in Okta.
-    {{% /notes %}}
-
-## Known Limitations
-
-Some SCIM features are currently not supported:
-
-* Secondary emails
-* Password sync
-* Bulk importing
+{{% /notes %}}

--- a/content/docs/administration/access-identity/scim/onelogin.md
+++ b/content/docs/administration/access-identity/scim/onelogin.md
@@ -17,10 +17,11 @@ pulumi_cloud_feature: scim
 
 This document outlines the steps required to help you configure automatic provisioning/deprovisioning of your users and groups in Pulumi using SCIM 2.0.
 
-Please note that some advanced SCIM features aren't supported yet. For more information, see [Known Limitations](#known-limitations).
+For the capabilities and attributes Pulumi's SCIM implementation supports, see [Pulumi Cloud & SCIM](/docs/administration/access-identity/scim/#capabilities).
 
 ## Prerequisites
 
+* Your organization must already be configured to use [SAML SSO](/docs/administration/access-identity/saml/onelogin/) with Pulumi.
 * You must be an admin of your Pulumi organization.
 * (Optional, but highly recommended) You should have more than one admin for your Pulumi organization.
 
@@ -80,6 +81,10 @@ Be sure to check the *Include in SAML assertion* checkbox for each of the added 
 
 Optionally, you can override the default value for *scimusername* and use the `Macro` setting. For example, `{firstname}{lastname}` as per [OneLogin Macros](https://onelogin.service-now.com/kb_view_customer.do?sysparm_article=KB0010609)
 
+{{% notes type="warning" %}}
+Whatever value you choose for *scimusername*, it must stay stable for the lifetime of the account. Pulumi usernames are immutable, so an update that changes *scimusername* for an existing user fails. See [Usernames cannot change](/docs/administration/access-identity/scim/#usernames-cannot-change).
+{{% /notes %}}
+
 Select **Save** to save the application settings.
 
 ## Configuring Communications Between Pulumi and OneLogin
@@ -116,9 +121,9 @@ At this point, SCIM provisioning of users into the Pulumi organization will work
 
 Beyond managing users, Pulumi's SCIM support enables you to manage Pulumi Teams and team membership. To set this up, Pulumi supports using OneLogin's Role-Group mapping to manage Pulumi teams membership.
 
-    {{% notes type="warning" %}}
- **Team name character limit**: Pulumi team names created via SCIM must not exceed 40 characters. If your OneLogin group name is longer than this limit, you’ll need to rename the group before pushing it to Pulumi. Otherwise, the provisioning will fail.
-     {{% /notes %}}
+{{% notes type="warning" %}}
+**Team name character limit**: Pulumi team names created via SCIM must be 100 characters or fewer. If your OneLogin group name is longer than that, rename the group before pushing it to Pulumi. Otherwise, provisioning fails.
+{{% /notes %}}
 
 ### Set up OneLogin Application to Manage Groups in Pulumi
 

--- a/content/docs/support/faq/scim.md
+++ b/content/docs/support/faq/scim.md
@@ -114,7 +114,7 @@ Suggested Resolution: Update the attribute mappings in the identity provider and
 
 ### A failure occurred when attempting to provision group members.
 
-The creation (POST), update (PATCH), or replacement (PUT) of a group performs member validation prior to running the operation. If any of the members provided are not provisioned into your Pulumi organization, or are not active, the request fails with the following response:
+The creation (POST), update (PATCH), or replacement (PUT) of a group performs member validation before running the operation. If any of the members provided are not provisioned into your Pulumi organization, or are not active, the request fails with the following response:
 
 ```
 Status: 400 BAD REQUEST

--- a/content/docs/support/faq/scim.md
+++ b/content/docs/support/faq/scim.md
@@ -27,10 +27,10 @@ These errors can occur when attempting to create (POST), replace (PUT), or updat
 
 ```json
 {
-    "status": 409,
+    "status": "409",
     "response": {
         "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
-        "status": 409,
+        "status": "409",
         "scimType": "uniqueness",
         "detail": "Email {email} already in use by another Pulumi account."
     }
@@ -53,10 +53,10 @@ If the existing account is already managed by SAML SSO in another Pulumi organiz
 
 ```json
 {
-    "status": 409,
+    "status": "409",
     "response": {
         "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
-        "status": 409,
+        "status": "409",
         "scimType": "uniqueness",
         "detail": "User with userName {userName} already exists."
     }
@@ -71,10 +71,10 @@ Suggested Resolution: Update the username attribute in your identity provider’
 
 ```json
 {
-    "status": 400,
+    "status": "400",
     "response": {
         "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
-        "status": 400,
+        "status": "400",
         "scimType": "immutability",
         "detail": "Attribute 'userName' is immutable."
     }
@@ -89,10 +89,10 @@ Suggested Resolution: Update the attribute mapping in the identity provider so t
 
 ```json
 {
-    "status": 400,
+    "status": "400",
     "response": {
         "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
-        "status": 400,
+        "status": "400",
         "scimType": "invalidPath",
         "detail": "Unknown path: {path}."
     }

--- a/content/docs/support/faq/scim.md
+++ b/content/docs/support/faq/scim.md
@@ -19,7 +19,7 @@ aliases:
 
 This page contains information on how to resolve issues that may occur when configuring SCIM provisioning.
 
-### A failure occurred when attempting to provision a user.
+### A failure occurred when attempting to provision a user
 
 These errors can occur when attempting to create (POST), replace (PUT), or update (PATCH) a user. If you encounter difficulties resolving these issues, please contact our [customer support](https://support.pulumi.com/) for assistance.
 
@@ -112,24 +112,38 @@ Provisioning jobs that try to add or update any other attribute fail. For the co
 
 Suggested Resolution: Update the attribute mappings in the identity provider and delete all unsupported attributes. _This action must be done by an admin on the identity provider side (e.g. Okta)_.
 
-### A failure occurred when attempting to provision group members.
+### A failure occurred when attempting to provision group members
 
 The creation (POST), update (PATCH), or replacement (PUT) of a group performs member validation before running the operation. If any of the members provided are not provisioned into your Pulumi organization, or are not active, the request fails with the following response:
 
-```
-Status: 400 BAD REQUEST
-Bad Request: Cannot add invalid members to team. Invalid member ids: [comma separated list of invalid member ids]
+```json
+{
+    "status": "400",
+    "response": {
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        "status": "400",
+        "scimType": "invalidValue",
+        "detail": "Cannot add invalid members to team. Invalid member ids: {comma separated list of invalid member ids}"
+    }
+}
 ```
 
 The suggested way to resolve this conflict would be to synchronize all the group members to guarantee every member is successfully provisioned and update the user's status. _This action must be done by an admin on the identity provider side (e.g. Okta)_.
 
-### A failure occurred when attempting to provision a group.
+### A failure occurred when attempting to provision a group
 
 #### Display name is too long
 
-```
-Status: 400 BAD REQUEST
-Bad Request: Display name is too long. It must be 100 characters or less
+```json
+{
+    "status": "400",
+    "response": {
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        "status": "400",
+        "scimType": "invalidValue",
+        "detail": "Display name is too long. It must be 100 characters or less"
+    }
+}
 ```
 
 Cause: Pulumi team names created through SCIM must be 100 characters or fewer, and the group being pushed has a longer display name.

--- a/content/docs/support/faq/scim.md
+++ b/content/docs/support/faq/scim.md
@@ -81,7 +81,7 @@ Suggested Resolution: Update the username attribute in your identity provider’
 }
 ```
 
-Cause: Pulumi usernames are immutable and cannot be updated.
+Cause: Pulumi usernames are immutable and cannot be updated. See [Usernames cannot change](/docs/administration/access-identity/scim/#usernames-cannot-change).
 
 Suggested Resolution: Update the attribute mapping in the identity provider so that `userName` is updated only during creation, not creation and update. _This action must be done by an admin on the identity provider side (e.g. Okta)_.
 
@@ -103,17 +103,18 @@ Cause: Pulumi only supports adding or updating the following user attributes:
 
 - `userName`
 - `displayName`
-- `givenName`
-- `familyName`
+- `name.givenName`
+- `name.familyName`
+- `emails[type eq "work"].value`
 - `active`
 
-Provisioning jobs that try to add or update any other attribute will fail.
+Provisioning jobs that try to add or update any other attribute fail. For the complete supported surface, including group attributes, see [Supported attributes](/docs/administration/access-identity/scim/#supported-attributes).
 
 Suggested Resolution: Update the attribute mappings in the identity provider and delete all unsupported attributes. _This action must be done by an admin on the identity provider side (e.g. Okta)_.
 
 ### A failure occurred when attempting to provision group members.
 
-The creation (POST), update (PATCH) or replacement (PUT) of a group performs member validation prior running the operation. If any of the members provided are not provisioned into your Pulumi organization or is not active, the request will fail with the following response:
+The creation (POST), update (PATCH), or replacement (PUT) of a group performs member validation prior to running the operation. If any of the members provided are not provisioned into your Pulumi organization, or are not active, the request fails with the following response:
 
 ```
 Status: 400 BAD REQUEST
@@ -121,6 +122,19 @@ Bad Request: Cannot add invalid members to team. Invalid member ids: [comma sepa
 ```
 
 The suggested way to resolve this conflict would be to synchronize all the group members to guarantee every member is successfully provisioned and update the user's status. _This action must be done by an admin on the identity provider side (e.g. Okta)_.
+
+### A failure occurred when attempting to provision a group.
+
+#### Display name is too long
+
+```
+Status: 400 BAD REQUEST
+Bad Request: Display name is too long. It must be 100 characters or less
+```
+
+Cause: Pulumi team names created through SCIM must be 100 characters or fewer, and the group being pushed has a longer display name.
+
+Suggested Resolution: Rename the group in the identity provider so that its name fits within the limit, then push it again. _This action must be done by an admin on the identity provider side (e.g. Okta)_.
 
 ### Can I manage Pulumi-local teams if using SCIM?
 

--- a/layouts/shortcodes/sso-scim-limits-info.html
+++ b/layouts/shortcodes/sso-scim-limits-info.html
@@ -1,2 +1,2 @@
 {{- $idp := .Get "idp" | default "your Identity Provider" -}}
-Pulumi supports only one Pulumi organization per SCIM application. If your team manages multiple Pulumi organizations, you must configure separate SCIM applications for each organization in {{ $idp }}.
+Pulumi supports only one Pulumi Cloud organization per SCIM application. If your team manages multiple Pulumi Cloud organizations, you must configure separate SCIM applications for each Pulumi Cloud organization in {{ $idp }}.

--- a/layouts/shortcodes/sso-scim-limits-info.markdown.md
+++ b/layouts/shortcodes/sso-scim-limits-info.markdown.md
@@ -1,2 +1,2 @@
 {{- $idp := .Get "idp" | default "your Identity Provider" -}}
-Pulumi supports only one Pulumi organization per SCIM application. If your team manages multiple Pulumi organizations, you must configure separate SCIM applications for each organization in {{ $idp }}.
+Pulumi supports only one Pulumi Cloud organization per SCIM application. If your team manages multiple Pulumi Cloud organizations, you must configure separate SCIM applications for each Pulumi Cloud organization in {{ $idp }}.


### PR DESCRIPTION
Fixes #20943.

The SCIM docs were three IdP walkthroughs with no shared statement of what SCIM actually does, so a reader couldn't answer basic questions ("can SCIM assign roles?", "does deprovisioning delete the user?") without reading all three pages and inferring. Every claim was verified against `pulumi-service` @ `a5402c5c31`.

## Changes

- **`scim/_index.md`**: new `Capabilities`, `Supported attributes`, and `What SCIM does not manage` sections, plus `Behavior to plan for` — which promotes four facts that each previously lived on a single provider page (soft-delete-only deprovisioning, `userName` immutability, group members must be provisioned first, group `externalId` ignored). Also states up front that SCIM provisions users → org members and groups → teams.
- **Team-name limit 40 → 100** on all three provider guides. The column was widened in Nov 2024 (`maxDefaultNameLength = 100`, `validation.go:32`); the docs were ~21 months stale. Entra's warning also moved into its group-provisioning section, where Okta's and OneLogin's already were.
- **Dead `#known-limitations` anchor** on the OneLogin page fixed. The duplicated `Known Limitations` sections on Okta/Entra now link to the shared reference instead.
- **FAQ**: completed the "Unknown path" attribute list (added `emails[type eq "work"].value`, corrected to the `name.givenName` / `name.familyName` paths the server actually matches), and added a "Display name is too long" answer — the one documented failure mode with no FAQ coverage.
- **OneLogin**: added the SAML SSO prerequisite and the `userName` immutability guidance the other two guides already had.
- **Rendering fix**: indented `{{% notes %}}` blocks inside Okta's ordered list were splitting one six-step procedure into three lists (`</ol>…<ol start="3">`) with callouts orphaned between them. Converted to the `{{< notes >}}` form per AGENTS.md.

## Notes for reviewers

- The provider-agnostic framing is deliberately **descriptive** ("Pulumi implements a single SCIM 2.0 endpoint… only the IdP-side setup differs") rather than a support commitment. The stronger statement — that any spec-compliant SCIM 2.0 IdP should work — needs product sign-off.
- The issue's **self-hosted Enterprise** availability line was dropped as unverifiable; no self-hosted doc mentions SCIM. Happy to add it if someone can confirm.
- No hand-written editions section: `pulumi_cloud_feature: scim` already renders the Business Critical callout.
- `layouts/shortcodes/sso-scim-limits-info.*` also affects the **SAML index page** — intentional ("each Pulumi Cloud organization"), rendering verified on both.
- Removing the `Known Limitations` headings means external `#known-limitations` deep links will land at page top.