### PR TITLE
docs: correct stale Go SDK majors and the packages-in-Pulumi.yaml version

### DIFF
--- a/content/docs/iac/concepts/providers/_index.md
+++ b/content/docs/iac/concepts/providers/_index.md
@@ -86,7 +86,7 @@ The generated SDK will include a `.gitignore` so it can be safely committed to v
 #### About provider packages in the project configuration file
 
 {{% notes type="info" %}}
-When using `pulumi package add` with Pulumi version 3.157.0 or later, packages are automatically added to your project configuration file (`Pulumi.yaml`).
+When using `pulumi package add` with Pulumi version 3.163.0 or later, packages are automatically added to your project configuration file (`Pulumi.yaml`).
 {{% /notes %}}
 
 When you run `pulumi package add`, the package is automatically added to your Pulumi project configuration file under the [`packages`](/docs/iac/concepts/projects/project-file/#packages-options) key. For the example in the previous section, the following entry would be added to your `Pulumi.yaml`:

--- a/content/docs/iac/get-started/gcp/create-component.md
+++ b/content/docs/iac/get-started/gcp/create-component.md
@@ -172,7 +172,7 @@ class GcpStorageWebsite(pulumi.ComponentResource):
 package main
 
 import (
-    "github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/storage"
+    "github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/storage"
     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -434,7 +434,7 @@ class GcpStorageWebsite(pulumi.ComponentResource):
 package main
 
 import (
-    "github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/storage"
+    "github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/storage"
     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/content/docs/iac/get-started/terraform/terraform-providers.md
+++ b/content/docs/iac/get-started/terraform/terraform-providers.md
@@ -181,7 +181,7 @@ Then use it in your Pulumi program:
 package main
 
 import (
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/elb"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/elb"
 	"github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )


### PR DESCRIPTION
### Proposed changes

Three version facts the nightly claims re-verification flagged as `contradicted` on 2026-08-15 ([run 31871415141](https://github.com/pulumi/docs/actions/runs/31871415141), entities `version/go-component`, `version/go-example`, `version/pulumi-package`). **Each was re-verified against upstream before I touched it** — see the evidence column — because a cross-run comparison of runs #36–40 showed ~11% of repeat entities changing verdict between nights, so a single run's verdict isn't sufficient grounds for an edit on its own.

| Page | Was | Now | Evidence (checked 2026-08-18) |
| --- | --- | --- | --- |
| `get-started/gcp/create-component.md` (×2) | `pulumi-gcp/sdk/v7/go/gcp/storage` | `…/sdk/v9/…` | [`pulumi-gcp/sdk/go.mod`](https://github.com/pulumi/pulumi-gcp/blob/master/sdk/go.mod) declares `module github.com/pulumi/pulumi-gcp/sdk/v9` — a v7 path does not resolve against the current major |
| `get-started/terraform/terraform-providers.md` | `pulumi-aws/sdk/v6/go/aws/elb` | `…/sdk/v7/…` | [`pulumi-aws/sdk/go.mod`](https://github.com/pulumi/pulumi-aws/blob/master/sdk/go.mod) declares `module github.com/pulumi/pulumi-aws/sdk/v7` |
| `concepts/providers/_index.md` | "Pulumi version 3.157.0 or later" | "3.163.0 or later" | [pulumi/pulumi CHANGELOG](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md): 3.157.0 has only *"[yaml] Introduce the packages section in Pulumi.yaml"*; the behavior this note describes — *"[cli/package] Save package source to `packages` in Pulumi.yaml on `package add`"* — is listed under **3.163.0** |

### One flagged finding deliberately not applied

The same run flagged `github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3/random` on the terraform-providers page as a nonexistent import path. **I believe that verdict is a false positive and left it alone.** That path is the synthetic module path emitted for a *locally generated* Terraform-provider SDK (`pulumi package add terraform-provider hashicorp/random`), which needn't resolve on GitHub at all, and the same pattern is documented independently at `concepts/providers/any-terraform-provider.md:214`. There is a real latent inconsistency worth a follow-up from someone who can confirm the codegen's module naming — that page's own prose says the local SDK is importable "under the same import path that the published version would use", and its Python sibling example does exactly that (`import pulumi_random`) while the Go one doesn't — but resolving it is a question about codegen behavior, not a docs typo, so it isn't something to guess at here.

`ignorechanges.md` was also named in the `version/go-example` finding; its `pulumi-aws/sdk/v7` import is already correct and is unchanged.

### Why this is a hand-written PR

The automated loop that is supposed to fix flagged pages already tried and failed on one of these: `concepts/providers/_index.md` was boosted to the front of the review queue by this exact marker, reviewed in #20927, and merged yesterday with a one-line unrelated prose repair — the version bug untouched, and the marker cleared. Details in the run-#36–40 evaluation; the pipeline fixes for that are separate work.

**Validation:** `make lint` passes (1,844 files, 0 errors; Prettier clean).

### Unreleased product version (optional)

n/a

### Related issues (optional)

Findings from claims-reverify runs #36–40. Sibling PRs: #20893 (report artifact upload, merged), #20894 (verifier locale preference, open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp4LqiP4u81uT48MS8Hea4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp4LqiP4u81uT48MS8Hea4)_