### PR TITLE
content-review: fall back to the shipped GSC-only export for reader signals

### DIFF
--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -263,10 +263,13 @@ jobs:
       # The reader-signals export (Search Console impressions/CTR, docs
       # feedback-widget vote counts, real-404 hits per URL) follows the exact
       # same pattern as the traffic snapshot above: produced weekly by the data
-      # team, latest-object URI published on their Airflow stack. Until that
-      # export ships, this resolve logs the skip and selection scores exactly
-      # as before — the consumer side here is inert-but-ready by design
-      # (pulumi/docs#20078 item 4.5).
+      # team, latest-object URI published on their Airflow stack. The combined
+      # envelope (docsReaderSignalsLatestS3Uri) is not exported yet — until it
+      # is, fall back to the GSC-only export the data team already ships weekly
+      # (docsTrafficGscLatestS3Uri, pulumi/data#865 phase 2);
+      # load_reader_signals() accepts its bare shape directly. With neither
+      # output published, this resolve logs the skip and selection scores
+      # exactly as before (pulumi/docs#20078 item 4.5).
       - name: Resolve reader-signals URI
         id: signals-uri
         continue-on-error: true
@@ -275,6 +278,13 @@ jobs:
         run: |
           URI=$(pulumi stack output docsReaderSignalsLatestS3Uri \
             --stack pulumi/dwh-workflows-orchestrate-airflow/production 2>/dev/null || true)
+          if [ -z "$URI" ]; then
+            URI=$(pulumi stack output docsTrafficGscLatestS3Uri \
+              --stack pulumi/dwh-workflows-orchestrate-airflow/production 2>/dev/null || true)
+            if [ -n "$URI" ]; then
+              echo "reader-signals envelope not published; falling back to the GSC-only export"
+            fi
+          fi
           if [ -n "$URI" ]; then
             echo "resolved reader-signals export URI: $URI"
             echo "uri=$URI" >> "$GITHUB_OUTPUT"

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -240,6 +240,12 @@ def load_reader_signals(
             "gsc":      {"source", "period", "pages": {url: {impressions, clicks, position}}},
             "feedback": {"source", "period", "pages": {url: {yes, no}}}}}
 
+    A bare GSC section with no {"signals": ...} envelope is also accepted —
+    that is the shape of the export the data team ships today
+    (pulumi/data#865 phase 2, the Airflow stack's docsTrafficGscLatestS3Uri):
+
+        {"source", "period", "generated", "pages": {url: {clicks, impressions, position}}}
+
     Returns (gsc, feedback, meta). A missing/unreadable/malformed file — or a
     missing section — degrades that signal to unavailable, mirroring
     load_traffic: selection then scores exactly as if the signal never existed.
@@ -262,7 +268,13 @@ def load_reader_signals(
         return gsc, feedback, meta
     sections = data.get("signals")
     if not isinstance(sections, dict):
-        return gsc, feedback, meta
+        # No envelope: accept the bare GSC-only export (pulumi/data#865
+        # phase 2) so the signal activates on what ships today. The full
+        # envelope (adding feedback) supersedes it whenever it lands.
+        if isinstance(data.get("pages"), dict):
+            sections = {"gsc": data}
+        else:
+            return gsc, feedback, meta
 
     def _int(v) -> int:
         try:

--- a/scripts/content-review/test_select_articles.py
+++ b/scripts/content-review/test_select_articles.py
@@ -364,6 +364,24 @@ def main() -> int:
         qg2 = run_select(repo, tiers, empty, "--count", "20", "--signals-file", str(gscf))
         check(scores(qg2) == sg, "signal-boosted selection is deterministic")
 
+        print("reader signals: bare GSC export (no envelope) parses identically")
+        bare = tmp / "signals-gsc-bare.json"
+        bare.write_text(json.dumps({
+            "source": "fct_google_search_console_metrics",
+            "period": {"start": "2026-03-14", "end": "2026-06-11"},
+            "generated": "2026-06-11T00:00:00Z",
+            "pages": {
+                "/docs/misc/one/": {"impressions": 50000, "clicks": 250},
+                "/docs/misc/two/": {"impressions": 50000, "clicks": 5000},
+                "/docs/misc/protected/keep/": {"impressions": 100, "clicks": 1},
+            }}))
+        qbare = run_select(repo, tiers, empty, "--count", "20", "--signals-file", str(bare))
+        check(scores(qbare) == sg, "bare GSC export scores identically to the enveloped one")
+        check(qbare["reader_signals"]["gsc"]["available"] is True,
+              "bare GSC export marked available")
+        check(qbare["reader_signals"]["feedback"]["available"] is False,
+              "bare GSC export leaves feedback unavailable")
+
         print("reader signals: --paths entries carry the signals block")
         qp = run_select(repo, tiers, empty, "--paths", ONE, "--signals-file", str(gscf))
         check(qp["articles"][0]["signals"]["gsc"]["low_ctr_flag"] is True,


### PR DESCRIPTION
### Proposed changes

Resolves the reader-signals contract mismatch found in the DWH ingestion audit — from the docs side, using what the data team already ships.

The selector was built to consume a combined reader-signals envelope (`docsReaderSignalsLatestS3Uri`: GSC + feedback + not_found, pulumi/docs#20078 item 4.5) that the data team's Airflow stack never exports. The stack *does* export a bare GSC snapshot weekly (`docsTrafficGscLatestS3Uri` → `latest_gsc.json`, pulumi/data#865 phase 2). Because every consumer degrades silently, `signals_available` has been `false` on 100% of ledger records and GSC-weighted article selection has never activated.

- `.github/workflows/review-existing-content.yml`: the "Resolve reader-signals URI" step now falls back from the (unpublished) envelope output to the GSC-only output, logging which one it used.
- `scripts/content-review/select-articles.py`: `load_reader_signals()` accepts the bare export shape (`{source, period, generated, pages: {url: {clicks, impressions, position}}}`) by treating it as a GSC-only snapshot. The envelope shape still takes precedence and supersedes the fallback whenever it ships.
- `scripts/content-review/test_select_articles.py`: new self-test case asserting the bare export scores byte-identically to the enveloped equivalent, with feedback correctly left unavailable.

Deliberately narrow: the `feedback` and `not_found` sections still require the envelope, so the check-links 404 merge stays an inert no-op, and the parked blog-review lane is untouched.

Validation: `make test-review-pipeline` — all pytest suites, standalone harnesses (95/95 in `test_select_articles.py`), and every `--self-test` pass; workflow YAML parses.

### Unreleased product version (optional)

n/a

### Related issues (optional)

- pulumi/data#949 (audit follow-up; the reader-signals contract line item)
- pulumi/data#865 (phase-2 GSC export this now consumes)
- pulumi/docs#20078 (item 4.5 — the original inert-but-ready consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZAVbmmwVmJhfPw3LiAQa7

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZAVbmmwVmJhfPw3LiAQa7)_