### PR TITLE
content-review: close the loop between the claims detector and the fixer

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -82,6 +82,10 @@ Read `.content-review-queue.json` from the repo root (written by
   for a contradicted version pin was once reviewed, reported "0 contradicted"
   across 74 re-extracted claims, and merged an unrelated one-line repair while
   the flagged bug stayed on master.
+  A marker carrying `"escalated": true` has already survived two reviews
+  unresolved, so it no longer jumps the page to the front of the queue and a
+  human may be looking at it — but it is still a live finding and still yours
+  to resolve if you can. Treat it like any other marker.
   For each marker, either apply the fix, or establish that the flag was wrong
   (the nightly verdicts are single-sample and do produce false positives —
   a synthetic module path for a locally generated SDK was once flagged as a

--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -52,6 +52,15 @@ Read `.content-review-queue.json` from the repo root (written by
         "feedback": { "yes": 4, "no": 9, "neg_rate": 0.6923, "multiplier": 1.27 }
       },
       "last_reviewed": null,
+      "stale_claims": 1,
+      "stale_claim_markers": [
+        { "entity_key": "version/pulumi-package",
+          "verdict": "contradicted",
+          "evidence": "CHANGELOG lists \"Save package source to `packages` in Pulumi.yaml on `package add`\" under 3.163.0, not 3.157.0.",
+          "source": "gh api repos/pulumi/pulumi/releases",
+          "checked_at": "2026-08-15",
+          "unresolved_reviews": 0 }
+      ],
       "score": 0.91 }
   ]
 }
@@ -60,8 +69,27 @@ Read `.content-review-queue.json` from the repo root (written by
 - `lane` — `priority` (scored pick) or `manual` (workflow_dispatch override).
 - `stale_claims` (when present) — count of this page's volatile claims the
   nightly re-verification found contradicted (see §Claims index below). A
-  non-zero count is why the page jumped the queue: treat the ledger markers'
-  entity keys and evidence as priority findings to re-check first.
+  non-zero count is why the page jumped the queue.
+- `stale_claim_markers` (when present) — **those findings in full**, each with
+  the `entity_key`, the `verdict`, the `evidence` the nightly verifier
+  recorded, the `source` it reached, and `unresolved_reviews` (how many prior
+  reviews saw this marker and left it unresolved). **These are the highest-
+  priority findings in your queue and you must address every one of them.**
+  The nightly lane has already done the expensive part — it identified the
+  entity, reached an authoritative source, and wrote down what that source
+  says — so start here rather than waiting to see whether your own claim
+  extraction happens to re-derive the same finding. It may not: a page boosted
+  for a contradicted version pin was once reviewed, reported "0 contradicted"
+  across 74 re-extracted claims, and merged an unrelated one-line repair while
+  the flagged bug stayed on master.
+  For each marker, either apply the fix, or establish that the flag was wrong
+  (the nightly verdicts are single-sample and do produce false positives —
+  a synthetic module path for a locally generated SDK was once flagged as a
+  broken import). Then list its `entity_key` in the verdict sentinel's
+  `resolved_claims`. A marker you do not resolve is carried onto the next
+  review with `unresolved_reviews` incremented, and after two such rounds it
+  is escalated for a human — so silently skipping one does not make it go
+  away, it just delays it.
 - `no_retire` — when true, retirement must never be proposed for this page.
   This is the **hard veto** on retirement — honor it regardless of evidence.
 - `reader_signals` / `signals` — Search Console and feedback-widget figures
@@ -335,6 +363,7 @@ the canonical ledger record, and uploads it to S3 keyed by slug.
   "skipped_findings": 2,
   "retirement": false,
   "clarity_flag": true,
+  "resolved_claims": ["version/pulumi-package"],
   "applied": [
     { "category": "claim", "file": "content/docs/iac/concepts/stacks/_index.md",
       "lines": [42, 43], "source": "verified-claims:c3" },
@@ -362,6 +391,12 @@ the canonical ledger record, and uploads it to S3 keyed by slug.
   `len(applied)`. The workflow's scope gate cross-checks these against the
   artifacts and the branch diff; for link fixes (which have no artifact) the
   declared lines must actually carry the link in the pre-fix file.
+- `resolved_claims`: optional; the `entity_key` of every
+  `stale_claim_markers` entry you resolved this run — fixed, or shown to be a
+  false positive (say which, in the PR body). Omit or leave empty when the
+  queue item carried no markers. Anything you leave out is carried forward to
+  the next review rather than cleared, so this list is the only way a marker
+  retires.
 - `clarity_flag`: optional; `true` when you flagged a readthrough `reconception`
   for this page. Carries onto the ledger record so the page's structural
   follow-up is durable even when the verdict is `clean` or `fixed` (the

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -527,6 +527,28 @@ def self_test() -> int:
               rec_e["stale_claims"][0]["unresolved_reviews"] == 2
               and rec_e["stale_claims"][0]["escalated"] is True)
 
+        # The other half of the round-trip: select-articles.py hands escalated
+        # markers through, so they must survive rather than be filtered out
+        # here — otherwise the ledger loses them and the entity re-enters the
+        # nightly pool.
+        esc_marker = {**marker, "entity_key": "version/old-miss",
+                      "unresolved_reviews": 2, "escalated": True}
+        with_esc = {**article, "stale_claim_markers": [marker, esc_marker]}
+        rec_esc = build_record(with_esc, {"verdict": "clean", "reason": "x"},
+                               None, with_esc["slug"])
+        carried = {m["entity_key"]: m for m in rec_esc["stale_claims"]}
+        check("escalated marker persists through a review",
+              "version/old-miss" in carried)
+        check("escalated marker stays escalated and keeps counting",
+              carried["version/old-miss"]["escalated"] is True
+              and carried["version/old-miss"]["unresolved_reviews"] == 3)
+        check("an escalated marker can still be resolved",
+              "stale_claims" not in build_record(
+                  {**article, "stale_claim_markers": [esc_marker]},
+                  {"verdict": "fixed", "fixes": 1,
+                   "resolved_claims": ["version/old-miss"]},
+                  None, article["slug"]))
+
         rec_none = build_record(article, {"verdict": "clean", "reason": "x"},
                                 None, article["slug"])
         check("no markers -> no stale_claims key", "stale_claims" not in rec_none)

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -130,6 +130,9 @@ def load_queue_article(queue_path: Path) -> dict:
         # verbatim from the queue entry; null on a signal-blind run.
         "signals": a.get("signals"),
         "signals_available": bool((data.get("reader_signals") or {}).get("available")),
+        # Stale-claim markers in full (entity_key/verdict/evidence/source/...).
+        # carry_markers() needs them to decide which survive this review.
+        "stale_claim_markers": a.get("stale_claim_markers") or [],
     }
 
 
@@ -243,6 +246,43 @@ def canonical_branch_pushed(slug: str) -> bool:
 # ---- derivation -------------------------------------------------------------
 
 
+# A stale-claim marker survives this many reviews that saw it and did not
+# resolve it; after that it is kept but flagged `escalated`, which stops
+# select-articles.py boosting the page (see MARKER_ESCALATION_CAP there).
+MARKER_ESCALATION_CAP = 2
+
+
+def carry_markers(article: dict, verdict: dict | None) -> list[dict]:
+    """Stale-claim markers that outlive this review, with their retry state.
+
+    The nightly re-verification writes a marker when a volatile claim goes
+    contradicted; the marker boosts the page into this worker's queue. Before
+    this function existed the marker simply vanished when the review's ledger
+    record landed, whether or not anything had been done about it — so a review
+    that missed the finding silently cleared the flag and the entity went back
+    into the pool to be re-flagged, re-boosted, and re-missed on a ~2-day cycle
+    (observed end-to-end in pulumi/docs#20927).
+
+    A marker is retired only when the verdict names its entity in
+    `resolved_claims` — the worker asserting it either fixed the claim or
+    determined the flag was wrong. Everything else is carried forward with
+    `unresolved_reviews` incremented, and flagged `escalated` once that count
+    reaches MARKER_ESCALATION_CAP so a human is the next step rather than
+    another identical pass.
+    """
+    resolved = {str(k) for k in ((verdict or {}).get("resolved_claims") or [])}
+    carried: list[dict] = []
+    for m in article.get("stale_claim_markers") or []:
+        if not isinstance(m, dict):
+            continue
+        if m.get("entity_key") in resolved:
+            continue
+        seen = int(m.get("unresolved_reviews") or 0) + 1
+        carried.append({**m, "unresolved_reviews": seen,
+                        "escalated": seen >= MARKER_ESCALATION_CAP})
+    return carried
+
+
 def build_record(article: dict, verdict: dict | None, pr: dict | None,
                  slug: str, claude_succeeded: bool = False,
                  branch_exists: bool = False) -> dict:
@@ -285,6 +325,9 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
         "signals_available": bool(article.get("signals_available")),
         "reviewed_at": datetime.now(timezone.utc).date().isoformat(),
     }
+    markers = carry_markers(article, verdict)
+    if markers:
+        rec["stale_claims"] = markers
 
     if verdict is None:
         if claude_succeeded and not branch_exists:
@@ -456,6 +499,42 @@ def self_test() -> int:
         check("signal-blind queue -> signals null, signals_available False",
               blind_article["signals"] is None
               and blind_article["signals_available"] is False)
+        # --- stale-claim marker retention -------------------------------
+        marker = {"entity_key": "version/pulumi-package", "verdict": "contradicted",
+                  "evidence": "CHANGELOG says 3.163.0", "source": "gh release view",
+                  "checked_at": "2026-08-15"}
+        marked = {**article, "stale_claim_markers": [marker]}
+
+        rec_m = build_record(marked, {"verdict": "clean", "reason": "accurate"},
+                             None, marked["slug"])
+        check("a review that resolves nothing carries the marker forward",
+              [m["entity_key"] for m in rec_m["stale_claims"]] == ["version/pulumi-package"])
+        check("carried marker counts the miss",
+              rec_m["stale_claims"][0]["unresolved_reviews"] == 1
+              and rec_m["stale_claims"][0]["escalated"] is False)
+        check("carried marker keeps its evidence",
+              rec_m["stale_claims"][0]["evidence"] == "CHANGELOG says 3.163.0")
+
+        rec_r = build_record(marked, {"verdict": "fixed", "fixes": 1,
+                                      "resolved_claims": ["version/pulumi-package"]},
+                             None, marked["slug"])
+        check("a resolved marker retires", "stale_claims" not in rec_r)
+
+        second = {**article, "stale_claim_markers": [rec_m["stale_claims"][0]]}
+        rec_e = build_record(second, {"verdict": "clean", "reason": "x"},
+                             None, second["slug"])
+        check("second unresolved review escalates the marker",
+              rec_e["stale_claims"][0]["unresolved_reviews"] == 2
+              and rec_e["stale_claims"][0]["escalated"] is True)
+
+        rec_none = build_record(article, {"verdict": "clean", "reason": "x"},
+                                None, article["slug"])
+        check("no markers -> no stale_claims key", "stale_claims" not in rec_none)
+
+        rec_incomplete = build_record(marked, None, None, marked["slug"])
+        check("marker survives an incomplete run too",
+              rec_incomplete["stale_claims"][0]["unresolved_reviews"] == 1)
+
         blind_rec = build_record(blind_article, None, None, blind_article["slug"])
         check("signal-blind record persists null/false",
               blind_rec["signals"] is None and blind_rec["signals_available"] is False)

--- a/scripts/content-review/reverify-claims.py
+++ b/scripts/content-review/reverify-claims.py
@@ -233,7 +233,8 @@ def load_ledger(ledger_dir: Path) -> dict[str, dict]:
     return entries
 
 
-def apply_markers(ledger: dict[str, dict], stale: list[dict], today: date) -> dict[str, dict]:
+def apply_markers(ledger: dict[str, dict], stale: list[dict], today: date,
+                  repo_root: Path | None = None) -> dict[str, dict]:
     """Fold stale entity verdicts into the affected pages' ledger entries.
 
     Returns {slug: updated entry (without bookkeeping keys)} for every entry
@@ -243,7 +244,19 @@ def apply_markers(ledger: dict[str, dict], stale: list[dict], today: date) -> di
     not synthesized: every changed entry is uploaded to the same S3 key
     record-review.py owns, so a two-field stub would silently destroy that
     page's status / reviewed_at / attempts / tier / score. The entity simply
-    stays unmarked and comes back around on a later rotation."""
+    stays unmarked and comes back around on a later rotation.
+
+    A page with no markdown source on disk is skipped for a different and more
+    important reason. `select-articles.py` builds its candidate set by globbing
+    `content/docs/**/*.md`, so a page rendered by a Hugo content adapter (the
+    pre-built policy-pack tables, generated from `data/`) can never be selected
+    for review — which means a marker written there can never be cleared, and
+    `already_marked()` would then exclude that entity from re-verification
+    permanently. Three entities were lost that way over five nights before this
+    guard existed. Such a contradiction is real and worth acting on, but the
+    action is upstream of this repo (fix the `data/` source or the product
+    metadata behind it), so the verdict is reported and left in the pool rather
+    than converted into a marker nothing can retire."""
     changed: dict[str, dict] = {}
     for s in stale:
         marker = {
@@ -254,6 +267,12 @@ def apply_markers(ledger: dict[str, dict], stale: list[dict], today: date) -> di
             "checked_at": today.isoformat(),
         }
         for page in s["pages"]:
+            if repo_root is not None and not (repo_root / page["path"]).is_file():
+                warn(
+                    f"{page['path']} has no source file (generated page); reporting "
+                    f"{s['entity_key']} without a marker no review could ever clear"
+                )
+                continue
             entry = ledger.get(page["path"])
             if entry is None:
                 warn(
@@ -395,7 +414,7 @@ def run(args) -> int:
     report["meta"]["n_demoted"] = sum(1 for r in results if r["demoted_from"])
 
     if stale:
-        changed = apply_markers(ledger, stale, today)
+        changed = apply_markers(ledger, stale, today, repo_root)
         uri = os.environ.get("CONTENT_REVIEW_LEDGER_URI", "").strip()
         for slug, entry in sorted(changed.items()):
             local = Path(args.ledger_dir) / f"{slug}.json"
@@ -413,6 +432,7 @@ def run(args) -> int:
 
 
 def self_test() -> int:
+    import tempfile
     failures = []
 
     def check(name, cond):
@@ -514,6 +534,31 @@ def self_test() -> int:
     check("re-marking is idempotent",
           len(changed2["docs-a"]["stale_claims"]) == 1)
 
+    # Generated pages have no markdown source, so select-articles.py can never
+    # queue them and a marker there could never be cleared. Report, don't mark.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / "content/docs").mkdir(parents=True)
+        (root / "content/docs/a.md").write_text("real page\n")
+        gen = [{"entity_key": "numerical/pack-count", "verdict": "contradicted",
+                "evidence": "", "source": "",
+                "pages": [{"path": "content/docs/reference/generated.md",
+                           "slug": "docs-reference-generated"}]}]
+        led = {"content/docs/reference/generated.md": {
+            "path": "content/docs/reference/generated.md",
+            "slug": "docs-reference-generated", "status": "clean"}}
+        check("sourceless page gets no marker",
+              apply_markers(led, gen, today, root) == {})
+        check("sourceless page's ledger entry is left untouched",
+              "stale_claims" not in led["content/docs/reference/generated.md"])
+        # ...while a page that does exist on disk is still marked normally.
+        led2 = {"content/docs/a.md": {"path": "content/docs/a.md",
+                                      "slug": "docs-a", "status": "clean"}}
+        on_disk = [{**gen[0], "pages": [{"path": "content/docs/a.md",
+                                         "slug": "docs-a"}]}]
+        check("page with a source file is still marked",
+              set(apply_markers(led2, on_disk, today, root)) == {"docs-a"})
+
     check("already_marked sees the marker",
           already_marked("version/pulumi-gcp", ents["version/pulumi-gcp"], ledger))
     check("already_marked ignores other entities",
@@ -522,7 +567,6 @@ def self_test() -> int:
 
     # Health-observation meta: the early-exit paths must say why they stopped
     # (signal-health.py's reverify signal reads these fields).
-    import tempfile
 
     def run_report(d: Path, extra_env_unset: list[str]) -> dict:
         saved = {k: os.environ.pop(k) for k in extra_env_unset if k in os.environ}

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -149,9 +149,34 @@ TIER_WEIGHTS = {1: 1.0, 2: 0.6, 3: 0.3}
 # — see reverify-claims.py). Sized to outrank a top-importance page that has
 # gone unreviewed for a year (1.0 * 365), so a known-stale fact beats any
 # ordinary staleness — while an ancient never-reviewed page can still win, so
-# the sweep is never fully starved. The marker vanishes when the page's next
-# review rewrites its ledger entry, so the boost self-clears.
+# the sweep is never fully starved. A marker retires when the page's next
+# review resolves it (record-review.py), so the boost self-clears.
 STALE_CLAIM_BOOST = 400.0
+
+# A marker the last MARKER_ESCALATION_CAP reviews each saw and left unresolved
+# stops boosting. Carrying an unresolved marker forward is what keeps a missed
+# finding from evaporating (record-review.py), but an unboundedly boosted page
+# would be re-picked every sweep and starve the rest of the queue, which is the
+# same failure the marker was meant to cure. Past the cap the marker stays on
+# the ledger entry — visible, still reported, still blocking re-verification
+# churn — but it stops jumping the page to the front. That is the signal a
+# human needs to look at it.
+MARKER_ESCALATION_CAP = 2
+
+
+def active_markers(entry: dict | None) -> list[dict]:
+    """This entry's stale-claim markers that still warrant priority handling.
+
+    Escalated markers (see MARKER_ESCALATION_CAP) are excluded: they neither
+    boost the page nor ride along in the queue item, because repeated reviews
+    have already failed to act on them and another automated pass is not the
+    remedy.
+    """
+    out = []
+    for m in (entry or {}).get("stale_claims") or []:
+        if isinstance(m, dict) and not m.get("escalated"):
+            out.append(m)
+    return out
 
 # Reader-signal boost tuning. Both multipliers floor at exactly 1.0 (see the
 # module docstring); the caps keep the maximum combined boost (~1.63x) well
@@ -581,6 +606,16 @@ def main() -> int:
             "last_reviewed": entry.get("reviewed_at"),
             "attempts": int(entry.get("attempts", 0)),
             "stale_claims": len(entry.get("stale_claims") or []),
+            # The markers themselves, not just how many there are. The nightly
+            # re-verification already did the expensive work — it identified the
+            # entity, reached an authoritative source, and wrote down the
+            # evidence — and the review skill is told to treat those as priority
+            # findings. Passing only the count meant the worker had to re-derive
+            # the finding from scratch and could silently miss it (pulumi/docs
+            # #20927: a page boosted for a contradicted version pin was reviewed,
+            # reported "0 contradicted" across 74 re-extracted claims, and merged
+            # a one-line unrelated repair while the flagged bug stayed on master).
+            "stale_claim_markers": active_markers(entry),
             "score": score,
         }
 
@@ -647,7 +682,7 @@ def main() -> int:
                 effective_last_review(path, ledger.get(path), newest_non_bot, created),
                 today,
                 have_traffic,
-                stale_claims=bool((ledger.get(path) or {}).get("stale_claims")),
+                stale_claims=bool(active_markers(ledger.get(path))),
                 gsc_m=gsc_m,
                 feedback_m=fb_m,
             ),

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -164,19 +164,30 @@ STALE_CLAIM_BOOST = 400.0
 MARKER_ESCALATION_CAP = 2
 
 
-def active_markers(entry: dict | None) -> list[dict]:
-    """This entry's stale-claim markers that still warrant priority handling.
+def all_markers(entry: dict | None) -> list[dict]:
+    """Every stale-claim marker on this ledger entry, escalated or not.
 
-    Escalated markers (see MARKER_ESCALATION_CAP) are excluded: they neither
-    boost the page nor ride along in the queue item, because repeated reviews
-    have already failed to act on them and another automated pass is not the
-    remedy.
+    This is what rides in the queue item, and it is deliberately unfiltered.
+    record-review.py rebuilds the ledger entry from the queue and writes back
+    whatever markers survive the review, so a marker withheld here would be
+    dropped from the ledger the next time the page is reviewed for any reason
+    — and `already_marked()` in reverify-claims.py would then let the entity
+    back into the nightly pool, restarting the detect/boost/miss/clear cycle
+    this whole mechanism exists to break.
     """
-    out = []
-    for m in (entry or {}).get("stale_claims") or []:
-        if isinstance(m, dict) and not m.get("escalated"):
-            out.append(m)
-    return out
+    return [m for m in (entry or {}).get("stale_claims") or [] if isinstance(m, dict)]
+
+
+def active_markers(entry: dict | None) -> list[dict]:
+    """The subset of markers that still earn the page a priority boost.
+
+    Escalated markers (see MARKER_ESCALATION_CAP) are excluded *from the
+    boost only*: repeated reviews have already failed to act on them, so
+    another jump to the front of the queue is not the remedy. They still
+    travel in the queue item and still persist on the ledger — see
+    all_markers().
+    """
+    return [m for m in all_markers(entry) if not m.get("escalated")]
 
 # Reader-signal boost tuning. Both multipliers floor at exactly 1.0 (see the
 # module docstring); the caps keep the maximum combined boost (~1.63x) well
@@ -605,7 +616,7 @@ def main() -> int:
             "signals": signal_terms(path)[2],
             "last_reviewed": entry.get("reviewed_at"),
             "attempts": int(entry.get("attempts", 0)),
-            "stale_claims": len(entry.get("stale_claims") or []),
+            "stale_claims": len(all_markers(entry)),
             # The markers themselves, not just how many there are. The nightly
             # re-verification already did the expensive work — it identified the
             # entity, reached an authoritative source, and wrote down the
@@ -615,7 +626,7 @@ def main() -> int:
             # #20927: a page boosted for a contradicted version pin was reviewed,
             # reported "0 contradicted" across 74 re-extracted claims, and merged
             # a one-line unrelated repair while the flagged bug stayed on master).
-            "stale_claim_markers": active_markers(entry),
+            "stale_claim_markers": all_markers(entry),
             "score": score,
         }
 

--- a/scripts/content-review/test_select_articles.py
+++ b/scripts/content-review/test_select_articles.py
@@ -428,6 +428,37 @@ def main() -> int:
             else:
                 check("tiers" not in proc.stderr.lower(), "real tiers file parses")
 
+    # --- stale-claim markers ride the queue, and escalation stops the boost ---
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        repo = make_repo(tmp)
+        tiers = tmp / "tiers.yaml"
+        tiers.write_text(REPO_TIERS.read_text() if REPO_TIERS.is_file() else "rules: []\n")
+
+        marker = {"entity_key": "version/pulumi-package", "verdict": "contradicted",
+                  "evidence": "CHANGELOG says 3.163.0", "source": "gh release view",
+                  "checked_at": "2026-08-15"}
+
+        led = tmp / "ledger-markers"
+        # STACKS is freshly reviewed, so absent a marker it never reaches the queue.
+        write_ledger(led, STACKS, TODAY, stale_claims=[marker])
+        q = run_select(repo, tiers, led)
+        entry = next((a for a in q["articles"] if a["path"] == STACKS), None)
+        check(entry is not None, "marked page is boosted into the queue")
+        if entry:
+            check(entry["stale_claims"] == 1, "count field preserved")
+            check([m["entity_key"] for m in entry.get("stale_claim_markers") or []]
+                  == ["version/pulumi-package"], "queue item carries the marker itself")
+            check((entry["stale_claim_markers"][0].get("evidence") or "")
+                  == "CHANGELOG says 3.163.0", "marker evidence reaches the worker")
+
+        led_esc = tmp / "ledger-escalated"
+        write_ledger(led_esc, STACKS, TODAY,
+                     stale_claims=[{**marker, "unresolved_reviews": 2, "escalated": True}])
+        q_esc = run_select(repo, tiers, led_esc)
+        esc = next((a for a in q_esc["articles"] if a["path"] == STACKS), None)
+        check(esc is None, "an escalated marker no longer boosts the page")
+
     print(f"\n{_passes} passed, {len(_failures)} failed")
     return 1 if _failures else 0
 

--- a/scripts/content-review/test_select_articles.py
+++ b/scripts/content-review/test_select_articles.py
@@ -452,12 +452,40 @@ def main() -> int:
             check((entry["stale_claim_markers"][0].get("evidence") or "")
                   == "CHANGELOG says 3.163.0", "marker evidence reaches the worker")
 
+        # An escalated marker must still ride in the queue item and still be
+        # counted: record-review.py rebuilds the ledger entry from the queue,
+        # so a marker withheld here is a marker deleted from the ledger the
+        # next time this page is reviewed for any reason.
+        led_mixed = tmp / "ledger-mixed"
+        write_ledger(led_mixed, STACKS, TODAY, stale_claims=[
+            marker,
+            {**marker, "entity_key": "version/old-miss",
+             "unresolved_reviews": 2, "escalated": True},
+        ])
+        q_mixed = run_select(repo, tiers, led_mixed)
+        mixed = next((a for a in q_mixed["articles"] if a["path"] == STACKS), None)
+        check(mixed is not None, "page with one active marker is still boosted")
+        if mixed:
+            keys = [m["entity_key"] for m in mixed.get("stale_claim_markers") or []]
+            check("version/old-miss" in keys,
+                  "escalated marker still travels in the queue item (survives the round-trip)")
+            check(mixed["stale_claims"] == len(mixed["stale_claim_markers"]),
+                  "stale_claims count matches the marker list it describes")
+
         led_esc = tmp / "ledger-escalated"
         write_ledger(led_esc, STACKS, TODAY,
                      stale_claims=[{**marker, "unresolved_reviews": 2, "escalated": True}])
         q_esc = run_select(repo, tiers, led_esc)
         esc = next((a for a in q_esc["articles"] if a["path"] == STACKS), None)
-        check(esc is None, "an escalated marker no longer boosts the page")
+        check(esc is None, "an escalated marker alone no longer boosts the page")
+
+        # ...and when such a page is reviewed anyway (staleness, --paths), the
+        # escalated marker must reach record-review.py rather than evaporating.
+        q_paths = run_select(repo, tiers, led_esc, "--paths", STACKS)
+        forced = q_paths["articles"][0]
+        check([m["entity_key"] for m in forced.get("stale_claim_markers") or []]
+              == ["version/pulumi-package"],
+              "escalated marker reaches a --paths review instead of being dropped")
 
     print(f"\n{_passes} passed, {len(_failures)} failed")
     return 1 if _failures else 0


### PR DESCRIPTION
### Proposed changes

The nightly claims re-verification is finding real bugs, and the per-article review worker is not acting on them. This was observed end-to-end last week:

1. **2026-08-15** — run [31871415141](https://github.com/pulumi/docs/actions/runs/31871415141) flagged `version/pulumi-package` on `concepts/providers/_index.md` as `contradicted`, high confidence, with `gh`-sourced evidence. A `stale_claims` marker was written.
1. **2026-08-17** — the marker boosted the page to the front of the queue (score 409.7, tier 1). #20927 reviewed it, re-extracted **74 claims**, reported **"0 contradicted"**, applied a one-line unrelated readthrough repair, and merged.
1. The flagged bug was still on master afterwards — it took a hand-written PR (#20961) to fix.
1. The marker cleared when that review's ledger record landed, returning the entity to the pool to be re-flagged and re-missed on a ~2-day cycle.

Net cost per cycle: a verifier call, a marker, a tier-1 page displaced at the front of the review queue, and a complete content-review run — for zero movement on the actual bug. Three distinct defects produce that, and this PR fixes each.

#### 1. The evidence never reached the worker

`select-articles.py` put only `len(stale_claims)` — a bare integer — into the queue item. Meanwhile `review-existing-content/SKILL.md` instructed the worker to "treat the ledger markers' entity keys and evidence as priority findings". It was being asked to act on data it was never given, so it re-derived the page's claims from scratch and missed the finding. (The workflow reads the ledger only to *write* it after the review, so there was no other path to the markers either.)

The queue item now carries `stale_claim_markers` in full — `entity_key`, `verdict`, `evidence`, `source`, `checked_at`, `unresolved_reviews`, `escalated` — and the skill documents them as findings that **must** be addressed, with the #20927 miss cited as the reason not to wait for one's own extraction to rediscover them. The `stale_claims` count is retained and is computed over that same list, so the two never disagree.

#### 2. Unresolved markers were silently cleared

`build_record()` rebuilds the ledger entry from the queue and simply dropped `stale_claims`, whether or not anything had been done about them. A marker now retires **only** when the verdict names its entity in a new optional `resolved_claims` field — the worker asserting it either fixed the claim or established the flag was wrong. Everything else carries forward with `unresolved_reviews` incremented.

Carrying markers forward indefinitely would create a new problem: a permanently-boosted page would be re-picked every sweep and starve the rest of the queue — the same failure mode in a different place. So a marker that survives `MARKER_ESCALATION_CAP` (2) unresolved reviews is flagged `escalated`, which **removes its scoring boost only**. Escalation is a boost policy, not a visibility policy: an escalated marker still travels in the queue item, still persists on the ledger through subsequent reviews, still increments its counter, and can still be retired via `resolved_claims`. It simply stops jumping the page to the front of the queue, which is the signal that a human rather than another identical automated pass is the next step.

That distinction is load-bearing, and the first version of this PR got it wrong — see the [review thread](https://github.com/pulumi/docs/pull/20968#discussion_r3807333731). Filtering escalated markers out of the queue item meant `build_record()` — which rebuilds the entry from the queue — silently deleted them from the ledger the next time the page came up for review for any reason, letting the entity back into the nightly pool and restarting the very cycle this PR exists to break. Fixed in 54daa9fe: `all_markers()` feeds the queue item and the count, `active_markers()` gates only the boost.

**The nightly verdicts are single-sample and do produce false positives** — a cross-run comparison of runs #36–40 found ~11% of repeat entities changing verdict between nights, and run #37 was 3-for-4 (it flagged a synthetic module path for a locally generated SDK as a broken import). So `resolved_claims` deliberately accepts "I showed this flag was wrong" as a resolution, not just "I fixed it".

#### 3. Markers on generated pages could never be cleared at all

`select-articles.py` builds its candidate set by globbing `content/docs/**/*.md`. An adapter-generated page — the pre-built policy-pack tables, rendered from `data/` — has no such file and can therefore never be selected for review, so a marker written there can never be cleared. `already_marked()` then excluded those entities from re-verification **permanently**.

**19 of 54 volatile entities (35%) live on such pages, and three were consumed this way in five nights**: `iam-user-unused-credentials-90` (run #36), `redshift-backup-enabled` (#37), and `cloud-logging-retention-period-365` (#38) — each confirmed absent from the next same-chunk run while unmarked siblings persisted.

`apply_markers()` now skips pages with no source file on disk and reports the verdict without marking, leaving the entity in the pool. Those contradictions are real, but the fix is upstream of this repo (the policy-pack metadata behind `data/`), so a marker nothing can retire is the wrong instrument. Tracked in #20969.

### Testing

`make test-review-pipeline` passes in full (pytest + every standalone harness + all `--self-test` suites); `make lint` passes. New coverage:

- `record-review.py --self-test` — carry-forward, retirement via `resolved_claims`, the escalation threshold, marker survival across an incomplete run, escalated markers persisting with their counter still incrementing and remaining resolvable, and the no-markers no-op.
- `reverify-claims.py --self-test` — a sourceless page gets no marker and its ledger entry is untouched, while a page that exists on disk is still marked normally.
- `test_select_articles.py` — the queue item carries the marker and its evidence, an escalated marker no longer boosts the page but still rides the queue item and reaches a `--paths` review, and the count matches the list it describes (91 → 104 passing checks).

The three round-trip checks were verified to **fail** against the pre-fix code and pass against this one.

### Rollout note

Existing markers in the ledger predate `unresolved_reviews`, so they start at 0 and get two review attempts before escalating — the intended behavior for a backlog, not a special case.

### Unreleased product version (optional)

n/a

### Related issues (optional)

From the claims-reverify runs #36–40 evaluation, tracked in #20969. Sibling PRs: #20893 (report artifact upload), #20894 (verifier locale), #20961 (the version-pin bugs this loop failed to fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp4LqiP4u81uT48MS8Hea4