### PR TITLE
Consolidate the duplicate "Pulumi Content Team" author records

### DIFF
--- a/content/docs/iac/comparisons/terraform-cloud.md
+++ b/content/docs/iac/comparisons/terraform-cloud.md
@@ -1,7 +1,7 @@
 ---
 title_tag: "Best Terraform Cloud Alternative for Multi-Cloud Teams"
 faq_schema: true
-authors: ["content-team"]
+authors: ["pulumi-content-team"]
 meta_desc: "The best Terraform Cloud alternative for large multi-cloud teams: Pulumi pairs real languages with one platform for policy, secrets, and AI."
 title: Terraform Cloud
 h1: "Pulumi vs. Terraform Cloud: The Best Alternative for Large Multi-Cloud Teams"

--- a/data/team/team/content-team.toml
+++ b/data/team/team/content-team.toml
@@ -1,4 +1,0 @@
-id = "content-team"
-name = "Pulumi Content Team"
-title = "Product Team"
-status = "active"

--- a/data/team/team/pulumi-content-team.toml
+++ b/data/team/team/pulumi-content-team.toml
@@ -1,3 +1,9 @@
+# The canonical house byline for posts and pages without a named individual
+# author. A second record with the same display name ("Pulumi Content Team",
+# id "content-team") was retired in favor of this one: two ids sharing a
+# display name split the /blog/author/ term pages in two and left authors
+# picking between them at random. Use this id; do not add another generic
+# byline alongside it.
 id = "pulumi-content-team"
 name = "Pulumi Content Team"
 title = "Content Team"

--- a/data/team/team/pulumi-content-team.toml
+++ b/data/team/team/pulumi-content-team.toml
@@ -4,10 +4,14 @@
 # display name split the /blog/author/ term pages in two and left authors
 # picking between them at random. Use this id; do not add another generic
 # byline alongside it.
+#
+# status is "active" because this byline is in current use. In this data
+# set "inactive" marks people who have left the company (~46 records);
+# it was wrong on a house byline that is still being assigned.
 id = "pulumi-content-team"
 name = "Pulumi Content Team"
 title = "Content Team"
 company = "Pulumi"
 weight = 1
 
-status = "inactive"
+status = "active"

--- a/scripts/redirects/author-consolidation-redirects.txt
+++ b/scripts/redirects/author-consolidation-redirects.txt
@@ -1,0 +1,5 @@
+# The "content-team" author record was retired in favor of "pulumi-content-team",
+# which carries the same display name ("Pulumi Content Team") and an avatar.
+# Its taxonomy term page (permalinks.term.authors = /blog/author/:slug/) goes
+# with it. See data/team/team/pulumi-content-team.toml.
+blog/author/content-team/index.html|/blog/author/pulumi-content-team/


### PR DESCRIPTION
### Proposed changes

`data/team/team/` carried **two** author records with the identical display name "Pulumi Content Team":

| file | `id` | `title` | `status` | avatar | used by |
| --- | --- | --- | --- | --- | --- |
| `content-team.toml` | `content-team` | Product Team | active | **missing** | 1 page (`docs/iac/comparisons/terraform-cloud.md`) |
| `pulumi-content-team.toml` | `pulumi-content-team` | Content Team | inactive | present | 2 pages (`blog/best-terraform-alternatives`, `what-is/what-is-infrastructure-as-code`) |

`authors` is a Hugo taxonomy (`permalinks.term.authors = /blog/author/:slug/`), so the two ids generated **two term pages under the same display name**, splitting the house byline's posts between them. Anyone reaching for a generic author had a coin flip to lose, and recent PRs have landed on both sides of it — which is what surfaced this.

This keeps `pulumi-content-team` and retires the other:

- **Repoint** `content/docs/iac/comparisons/terraform-cloud.md` at `pulumi-content-team`.
- **Delete** `data/team/team/content-team.toml`, now unreferenced.
- **Redirect** the retired term page — `blog/author/content-team/index.html|/blog/author/pulumi-content-team/`, following the taxonomy-move precedent in `blog-series-redirects.txt`.
- **Correct the survivor's `status`** from `inactive` to `active`.
- **Record why** in the surviving file, so the duplicate doesn't get recreated.

`pulumi-content-team` is the one to keep because `layouts/taxonomy/author.html` renders `/images/team/{{ .id }}.jpg` and only that id has an image — the retired record's term page was rendering a broken avatar. Its `title` is also accurate for a byline, where the other read "Product Team".

The `status` fix is a data correction with no rendering change. In this data set `inactive` marks people who have left the company (~46 of 240 records), so it said the opposite of what is true about a byline still being assigned to new posts. `status` is read in three places in `layouts/`, all for the Guest badge and the puluminary listings, and nothing filters team members on `"active"` — so the output is unchanged either way.

**Verification.** `make lint` and `make build` could not run in this environment — no `hugo` on PATH, Node 22 against the repo's required 24, and no registry access to install `js-yaml` for the markdown linter. Instead:

- Searched the **whole repo** for the string `content-team` across all file types (excluding `.git`, `node_modules`, build output). Three content references existed, all now pointing at `pulumi-content-team`.
- Confirmed all three referencing pages are live on `master` — `best-terraform-alternatives` is `draft: false`, dated 2026-07-18; the what-is and comparison pages are published.
- Parsed the edited frontmatter as YAML and the edited TOML with `tomllib`.
- Diffed the redirect line against existing `blog-series-redirects.txt` entries for format.

Worth flagging for whoever reviews: this repo uses several author-frontmatter syntaxes — `authors: ["id"]`, `authors: [id]`, `authors: [ id ]`, and `- "id"` list items among them. A pattern-matched search for one form will quietly miss the others; the whole-repo substring search above is what actually establishes the reference count.

CI is the real gate.

### Related issues (optional)

Surfaced while reviewing #20515, where a byline was moved off a departed author and landed on the unused duplicate. #20515 and #20631 both still need their bylines pointed at `pulumi-content-team`; that's separate from this change.