### PR TITLE
Unblock #20984: ignore the glow-up lane's root artifacts in prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,11 @@ _vendor/
 /.applied.paths
 /.fix-scope-report.json
 /.review-snapshot/
+# Glow-up lane equivalents (`.glowup-backlog.json`, the composed work list,
+# and `.glowup-scope-report.json`, the scope gate's report). Both are written
+# to the repo root before the `make lint` re-gate, so an unignored one makes
+# `prettier --check .` fail and strands the PR in draft.
+/.glowup-*.json
 # docs-review pre-computation artifacts the worker generates before the
 # review (claim extraction/verification, Vale, frontmatter, cross-sibling,
 # readthrough).

--- a/.prettierignore
+++ b/.prettierignore
@@ -80,6 +80,7 @@ static/js
 /.vale-findings.json
 /.content-review-*.json
 /.fix-scope-report.json
+/.glowup-*.json
 /.review-snapshot/
 /.pr-body-draft.md
 /.lint.log


### PR DESCRIPTION
### Proposed changes

Fixes the false `make lint` failure that stranded #20984 in draft.

`content-review-article.yml` writes two artifacts to the repo root during the glow-up lane — `.glowup-backlog.json` (the composed work list) and `.glowup-scope-report.json` (the scope gate's report) — and then re-runs `make lint` on the applied tree **in that same workspace**. Neither file was listed in `.gitignore` or `.prettierignore`, so `prettier --check .` picked up the untracked JSON:

```
[warn] .glowup-scope-report.json
[warn] Code style issues found in the above file. Forgot to run Prettier?
```

The re-gate treats that as a lint failure, opens the PR as a draft, and skips the triage → review chain — even though the reviewed page is clean. (The #20984 body notes the same thing happening locally on `.glowup-backlog.json`.)

This adds `/.glowup-*.json` to both ignore files, right beside `/.fix-scope-report.json`, which already carries exactly this treatment for the non-glow-up lane. No content changes; the glow-up diff on this branch is untouched.

**Verification** — with both artifacts present in the working tree:

- `prettier --check .` (2.8.8) → `All matched files use Prettier code style!`, exit 0; before the change it flagged `.glowup-scope-report.json`.
- `git status` is clean, so neither artifact can ride along in a `git add -A`.

#20992 is the follow-up against `master`: it prevents the whole class of failure (nine other gitignored artifacts have the same latent problem today, including a developer's local `.mcp.json`) by making `make lint` honor `.gitignore`. This PR is deliberately independent of it so #20984 can move now.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Unblocks #20984. Followed by #20992.