### PR TITLE
Glow-up follow-up: bring the AWS create-component page into line

### DIFF
--- a/content/docs/iac/get-started/aws/create-component.md
+++ b/content/docs/iac/get-started/aws/create-component.md
@@ -102,9 +102,9 @@ update the one component definition and have all uses of it benefit.
 
 {{% choosable language "typescript,python,go,csharp,java,yaml" %}}
 
-To define a new component, create a class called `AwsS3Website` that derives from `ComponentResource`. It'll have a mostly-empty
-constructor to start with but you will add the AWS S3 resources to it in the next step. You'll also define the inputs for the
-component -- the `files` to add to the website -- and outputs -- a single property with the website `url`.
+To define a new component, create a class called `AwsS3Website` that derives from `ComponentResource`. Its constructor
+starts out empty except for the base call, and you will add the AWS S3 resources to it in the next step. You'll also define the
+component's inputs -- the `files` to add to the website -- and its outputs -- a single property with the website `url`.
 
 {{% /choosable %}}
 
@@ -825,18 +825,18 @@ output "url" {
 
 ### Instantiate the component
 
-Now go back to your original file {{< langfile >}}. Now that you have moved all of the resources, you can start over with a clean slate.
-Ensure the file is empty and we will build it back up by importing and instantiating our new component.
+Now go back to your original file {{< langfile >}}. The resources have moved into the component, so start that file over from scratch:
+delete everything still in it, then build it back up by importing and instantiating the new component.
 
 Add this to your now-empty {{< langfile >}}:
 
 {{% choosable language typescript %}}
 
 ```typescript
-// Import from our new component module:
+// Import from the new component module:
 import { AwsS3Website } from "./website";
 
-// Create an instance of our component with the same files as before:
+// Create an instance of the component with the same files as before:
 const website = new AwsS3Website("my-website", {
     files: [ "index.html" ],
 });
@@ -852,10 +852,10 @@ export const url = website.url;
 ```python
 import pulumi
 
-# Import from our new component module:
+# Import from the new component module:
 from website import AwsS3Website
 
-# Create an instance of our component with the same files as before:
+# Create an instance of the component with the same files as before:
 website = AwsS3Website('my-website', files=['index.html'])
 
 # And export its autoassigned URL:
@@ -875,7 +875,7 @@ import (
 
 func main() {
     pulumi.Run(func(ctx *pulumi.Context) error {
-        // Create an instance of our component with the same files as before:
+        // Create an instance of the component with the same files as before:
         website, err := NewAwsS3Website(ctx, "my-website", AwsS3WebsiteArgs{
             Files: []string{"index.html"},
         })
@@ -902,7 +902,7 @@ using System.Collections.Generic;
 
 return await Pulumi.Deployment.RunAsync(() =>
 {
-    // Create an instance of our component with the same files as before:
+    // Create an instance of the component with the same files as before:
     var website = new AwsS3Website("my-website", new AwsS3WebsiteArgs()
     {
         Files = new[] { "index.html" }
@@ -928,7 +928,7 @@ import com.pulumi.Pulumi;
 public class App {
     public static void main(String[] args) {
         Pulumi.run(ctx -> {
-            // Create an instance of our component with the same files as before:
+            // Create an instance of the component with the same files as before:
             var website = new AwsS3Website("my-website",
                 new AwsS3WebsiteArgs(new String[] { "index.html" }));
 
@@ -954,7 +954,7 @@ Unfortunately, YAML lacks the language facilities to author components. Feel fre
 {{% choosable language hcl %}}
 
 ```hcl
-# Instantiate our new component with the same files as before; the source is the
+# Instantiate the new component with the same files as before; the source is the
 # directory the module lives in:
 module "my-website" {
   source = "./website"
@@ -975,7 +975,7 @@ Now deploy the resulting component instantiation. To do so, run `pulumi up` as u
 
 {{% choosable language "typescript,python,go,csharp,java,yaml" %}}
 
-```
+```output
 $ pulumi up
 Previewing update (dev)
 
@@ -1008,7 +1008,7 @@ Do you want to perform this update?  [Use arrows to move, type to filter]
 
 {{% choosable language hcl %}}
 
-```
+```output
 $ pulumi up
 Previewing update (dev)
 
@@ -1042,16 +1042,16 @@ directory the module lives in; the `components:index:` prefix is fixed.
 
 {{% /choosable %}}
 
-This preview shows you a few things. First, you'll see our website component with all of its child
-resources neatly parented underneath it. This helps to see what resources relate to which components. Next,
-you'll see that your old resources are being destroyed.
+This preview shows you a few things. First, you'll see your new website component with all of its child
+resources neatly parented underneath it, which makes it easy to see which resources belong to which component.
+Next, you'll see that your old resources are being destroyed.
 
 {{% notes type="info" %}}
 
-If you're wondering why Pulumi didn't simply update the resources in place, it's because certain changes -- like
-refactoring resources into a component -- fundamentally change a resource's identity. Many changes like updating
-properties or moving resources between files are not disruptive like this. In such cases, you can assign
-[aliases](/docs/iac/concepts/resources/options/aliases/) to prevent deletions from happening.
+If you're wondering why Pulumi didn't update the resources in place, it's because certain changes -- like
+refactoring resources into a component -- fundamentally change a resource's identity. Most changes, such as updating
+properties or moving resources between files, aren't disruptive in this way. When a change does affect identity, you can assign
+[aliases](/docs/iac/concepts/resources/options/aliases/) to prevent the deletions.
 
 {{% /notes %}}
 
@@ -1059,7 +1059,7 @@ Accept the changes by selecting `yes` and the deployment will occur:
 
 {{% choosable language "typescript,python,go,csharp,java,yaml" %}}
 
-```
+```output
 Updating (dev)
 
      Type                                       Name                 Status
@@ -1091,7 +1091,7 @@ Duration: 10s
 
 {{% choosable language hcl %}}
 
-```
+```output
 Updating (dev)
 
      Type                                       Name                 Status

--- a/content/docs/iac/get-started/aws/create-component.md
+++ b/content/docs/iac/get-started/aws/create-component.md
@@ -1149,6 +1149,6 @@ $ curl $(pulumi stack output url)
 
 {{% /choosable %}}
 
-Once you are ready to move on, let's destroy everything we've spun up in this tutorial.
+Once you are ready to move on, destroy everything you've spun up in this tutorial.
 
 {{< get-started-stepper >}}


### PR DESCRIPTION
### Proposed changes

Follow-up sweep for the divergence note in #20984. That PR glowed up `content/docs/iac/get-started/kubernetes/create-component.md`, but glow-up scope bounds limit edits to the queued page, so the AWS, Azure, and GCP siblings were left carrying the original wording. This PR brings the **AWS** page into line; the Azure and GCP pages ship as their own PRs (one per page, so each can be adjudicated independently).

Every change here is a direct port of an edit already reviewed on the Kubernetes page — no new editorial decisions:

| Location | Change | Source finding on #20984 |
| --- | --- | --- |
| L102-104 | Dropped the `mostly-empty` weasel word and tightened the inputs/outputs sentence: "Its constructor starts out empty except for the base call… the component's inputs -- the `files` to add to the website -- and its outputs". | Secondary sweep, style (Vale) |
| L828-829 | Rewrote the "Instantiate the component" intro so it *gives* the instruction instead of assuming it, and dropped the `a clean slate` cliché, the wordy `all of`, and the narrative-`we` voice: "The resources have moved into the component, so start that file over from scratch: delete everything still in it, then build it back up by importing and instantiating the new component." | Readthrough `missing-step` (`local_repair`) + style |
| Code comments (TypeScript, Python, Go, C#, Java, HCL) | `our new component module` / `an instance of our component` / `Instantiate our new component` → `the …`. Comment text only; no code semantics touched. | Secondary sweep, style |
| L1045-1047 | `our website component` → `your new website component` (second-person point of view per STYLE-GUIDE §Grammar and punctuation), and folded the flat "This helps to see what resources relate to which components" into the same sentence. | Secondary sweep, style |
| L1051-1054 | "Many changes like updating properties … are not disruptive like this. In such cases…" → "Most changes, such as updating properties or moving resources between files, aren't disruptive in this way. When a change does affect identity, you can assign [aliases](/docs/iac/concepts/resources/options/aliases/) to prevent the deletions." Also drops `simply` from the opening clause (the Kubernetes page never had it). | Secondary sweep, style |
| L978, L1011, L1062, L1094 | The four `pulumi up` console blocks (preview and update, both the general and HCL variants) were unlabeled fences; tagged them `output` per STYLE-GUIDE.md §Code Blocks and Console Output. | Secondary sweep, code formatting |

**Not ported:** the Python import fix from #20984 (`from nginx` → `from website`) was Kubernetes-only — this page's Python snippet already reads `from website import AwsS3Website`, matching `{{< compfile >}}`. The Java `isMinikube` issue and the repeated YAML callout flagged on #20984 are likewise out of scope here (the former is Kubernetes-only; the latter is a family-wide edit that would need its own change).

### Verification

- `node ./scripts/lint/lint-markdown.js`: clean (1845 files parsed, 0 errors).
- `yarn prettier --check` on the changed file: clean.
- `make lint` / `make lint-prose` could not be run end to end in this environment — `hugo` and `vale` are not installed here, so the two stages above were run directly instead. No Hugo templates, shortcodes, or data files are touched by this diff.
- Diff is prose and code comments only; no code semantics, frontmatter, links, or images changed.

### Unreleased product version (optional)

N/A.

### Related issues (optional)

Follows up on #20984.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYADr6ZZ4FaeUkY2vBvh9S)_