### PR TITLE
Cut the fixed cost of the example-code test workflow

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -30,57 +30,16 @@ env:
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: ARM_CLIENT_ID=ARM_CLIENT_ID,ARM_CLIENT_SECRET=ARM_CLIENT_SECRET,ARM_TENANT_ID=ARM_TENANT_ID,ARM_SUBSCRIPTION_ID=ARM_SUBSCRIPTION_ID,PULUMI_ACCESS_TOKEN=PULUMI_ACCESS_TOKEN
 
 jobs:
-  # Checkout-free gate. On a pull request, test.sh only ever tests the programs
-  # under static/programs that the PR touched, so ask the API which files
-  # changed rather than paying for a clone to find out. The vast majority of
-  # PRs here are content-only: without this gate they still spend the job's
-  # whole fixed cost (disk cleanup, a ~1 GB clone, a master fetch, six
-  # toolchains, a KinD cluster) to run zero tests.
-  changes:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      programs: ${{ steps.filter.outputs.programs }}
-    steps:
-      - name: Check whether the PR touches any example programs
-        id: filter
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          changed="$(gh api --paginate "repos/$REPO/pulls/$PR/files" \
-            --jq '.[].filename' | grep '^static/programs/' || true)"
-          if [ -n "$changed" ]; then
-            echo "programs=true" >> "$GITHUB_OUTPUT"
-            echo "Example programs changed:"
-            echo "$changed"
-          else
-            echo "programs=false" >> "$GITHUB_OUTPUT"
-            echo "No example programs changed; skipping the test job."
-          fi
-
   test:
-    needs: [changes]
-    # Skip tests for Dependabot PRs since they don't have access to ESC secrets,
-    # and for PRs that don't touch an example program (nothing to test). The
-    # changes job is skipped for schedule/workflow_dispatch, which always test
-    # every program.
-    if: |
-      !cancelled() && (github.event_name != 'pull_request' || (
-        github.event.pull_request.user.login != 'dependabot[bot]'
-        && needs.changes.outputs.programs == 'true'
-      ))
+    # Skip tests for Dependabot PRs since they don't have access to ESC secrets
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ${{ matrix.platform }}
     # The nightly full run takes ~3h; anything past 4h is stuck, not slow.
     timeout-minutes: 240
     permissions:
       contents: read
       id-token: write
+      pull-requests: read # for the changed-files gate below
     strategy:
       matrix:
         platform:
@@ -97,7 +56,37 @@ jobs:
           - 11
 
     steps:
+      # test.sh only tests the programs under static/programs that a PR
+      # touched, and the overwhelming majority of PRs here are content-only.
+      # Ask the API which files changed before paying for the rest of this job
+      # — a ~1.2 GB clone, a master fetch, six toolchains and a KinD cluster,
+      # all to run zero tests. Note that the job itself still runs, so the
+      # matrix-expanded check name that branch protection requires is always
+      # reported; only the expensive steps are conditional. Skipping the whole
+      # job would instead report a check named bare "test" — GitHub doesn't
+      # expand the matrix for a skipped job — leaving the required check
+      # unreported and the PR stuck waiting for it.
+      - name: Check whether this PR touches any example programs
+        id: gate
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          changed="$(gh api --paginate "repos/$REPO/pulls/$PR/files" \
+            --jq '.[].filename' | grep '^static/programs/' || true)"
+          if [ -n "$changed" ]; then
+            echo "programs=true" >> "$GITHUB_OUTPUT"
+            echo "Example programs changed:"
+            echo "$changed"
+          else
+            echo "programs=false" >> "$GITHUB_OUTPUT"
+            echo "No example programs changed; nothing to test."
+          fi
+
       - name: Free Disk Space (Ubuntu)
+        if: steps.gate.outputs.programs != 'false'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
@@ -105,19 +94,24 @@ jobs:
           dotnet: false
 
       - name: Fetch secrets from ESC
+        if: steps.gate.outputs.programs != 'false'
         id: esc-secrets
         uses: pulumi/esc-action@v3
 
       - name: Check out the code
+        if: steps.gate.outputs.programs != 'false'
         uses: actions/checkout@v7
 
       # test.sh only needs master's tip to diff the PR against, so fetch one
       # commit instead of the branch's entire history.
       - name: Fetch master branch
-        if: github.ref != 'refs/heads/master'
+        if: |
+          steps.gate.outputs.programs != 'false'
+          && github.ref != 'refs/heads/master'
         run: git fetch --depth=1 origin master:master
 
       - name: Install Node.js
+        if: steps.gate.outputs.programs != 'false'
         uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
@@ -129,38 +123,45 @@ jobs:
             theme/stencil/yarn.lock
 
       - name: Install Python
+        if: steps.gate.outputs.programs != 'false'
         uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Go
+        if: steps.gate.outputs.programs != 'false'
         uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Install Java
+        if: steps.gate.outputs.programs != 'false'
         uses: actions/setup-java@v5.6.0
         with:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
 
       - name: Install DotNet
+        if: steps.gate.outputs.programs != 'false'
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
       - name: Install Hugo
+        if: steps.gate.outputs.programs != 'false'
         uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: "0.157.0"
           extended: true
 
       - name: Install Pulumi
+        if: steps.gate.outputs.programs != 'false'
         uses: pulumi/actions@v7
         with:
           pulumi-version: latest
 
       - name: Configure AWS Credentials
+        if: steps.gate.outputs.programs != 'false'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -171,16 +172,19 @@ jobs:
           role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
 
       - name: Authenticate to Google Cloud
+        if: steps.gate.outputs.programs != 'false'
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: projects/${{ env.GOOGLE_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GOOGLE_CI_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GOOGLE_CI_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Kubernetes KinD Cluster
+        if: steps.gate.outputs.programs != 'false'
         id: kind
         uses: helm/kind-action@v1
 
       - name: Run the tests
+        if: steps.gate.outputs.programs != 'false'
         run: make test
         env:
           TEST_MODE: ${{ github.event_name }}

--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -9,10 +9,13 @@ on:
   workflow_dispatch: {}
 
 # Stacked pushes to a PR branch used to leave every superseded run cloning this
-# ~1 GB repo to completion. Collapse them onto the newest head; never cancel a
-# scheduled or manual run, which is the one that actually tests every program.
+# ~1.2 GB repo to completion. Collapse those onto the newest head. The event
+# name is part of the group so the nightly, a manual run and a PR never share
+# one: schedule and workflow_dispatch both resolve to refs/heads/master, and a
+# shared group would queue a dispatch behind the ~3h nightly (and cancel it if
+# a second dispatch arrived while it waited).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -74,8 +77,19 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
         run: |
-          changed="$(gh api --paginate "repos/$REPO/pulls/$PR/files" \
-            --jq '.[].filename' | grep '^static/programs/' || true)"
+          # Keep the API call's own failure distinguishable from "the PR
+          # changed nothing": one `|| true` over the whole pipeline would let a
+          # rate-limited or 5xx response look like a content-only PR and skip
+          # every test behind a green required check. If the gate can't tell,
+          # fall back to what this job did before it existed — run the setup and
+          # let test.sh decide from `git diff`, which is authoritative anyway.
+          files="$(gh api --paginate "repos/$REPO/pulls/$PR/files" \
+            --jq '.[].filename')" || {
+            echo "::warning::Could not list the PR's changed files; running the tests rather than assuming there are none."
+            echo "programs=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          changed="$(printf '%s\n' "$files" | grep '^static/programs/' || true)"
           if [ -n "$changed" ]; then
             echo "programs=true" >> "$GITHUB_OUTPUT"
             echo "Example programs changed:"

--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -8,6 +8,13 @@ on:
       - master
   workflow_dispatch: {}
 
+# Stacked pushes to a PR branch used to leave every superseded run cloning this
+# ~1 GB repo to completion. Collapse them onto the newest head; never cancel a
+# scheduled or manual run, which is the one that actually tests every program.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   AWS_REGION: "us-west-2"
@@ -23,10 +30,54 @@ env:
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: ARM_CLIENT_ID=ARM_CLIENT_ID,ARM_CLIENT_SECRET=ARM_CLIENT_SECRET,ARM_TENANT_ID=ARM_TENANT_ID,ARM_SUBSCRIPTION_ID=ARM_SUBSCRIPTION_ID,PULUMI_ACCESS_TOKEN=PULUMI_ACCESS_TOKEN
 
 jobs:
+  # Checkout-free gate. On a pull request, test.sh only ever tests the programs
+  # under static/programs that the PR touched, so ask the API which files
+  # changed rather than paying for a clone to find out. The vast majority of
+  # PRs here are content-only: without this gate they still spend the job's
+  # whole fixed cost (disk cleanup, a ~1 GB clone, a master fetch, six
+  # toolchains, a KinD cluster) to run zero tests.
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      programs: ${{ steps.filter.outputs.programs }}
+    steps:
+      - name: Check whether the PR touches any example programs
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          changed="$(gh api --paginate "repos/$REPO/pulls/$PR/files" \
+            --jq '.[].filename' | grep '^static/programs/' || true)"
+          if [ -n "$changed" ]; then
+            echo "programs=true" >> "$GITHUB_OUTPUT"
+            echo "Example programs changed:"
+            echo "$changed"
+          else
+            echo "programs=false" >> "$GITHUB_OUTPUT"
+            echo "No example programs changed; skipping the test job."
+          fi
+
   test:
-    # Skip tests for Dependabot PRs since they don't have access to ESC secrets
-    if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
+    needs: [changes]
+    # Skip tests for Dependabot PRs since they don't have access to ESC secrets,
+    # and for PRs that don't touch an example program (nothing to test). The
+    # changes job is skipped for schedule/workflow_dispatch, which always test
+    # every program.
+    if: |
+      !cancelled() && (github.event_name != 'pull_request' || (
+        github.event.pull_request.user.login != 'dependabot[bot]'
+        && needs.changes.outputs.programs == 'true'
+      ))
     runs-on: ${{ matrix.platform }}
+    # The nightly full run takes ~3h; anything past 4h is stuck, not slow.
+    timeout-minutes: 240
     permissions:
       contents: read
       id-token: write
@@ -60,9 +111,11 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v7
 
+      # test.sh only needs master's tip to diff the PR against, so fetch one
+      # commit instead of the branch's entire history.
       - name: Fetch master branch
         if: github.ref != 'refs/heads/master'
-        run: git fetch origin master:master
+        run: git fetch --depth=1 origin master:master
 
       - name: Install Node.js
         uses: actions/setup-node@v7
@@ -136,6 +189,7 @@ jobs:
     if: (failure() && github.event_name == 'schedule')
     name: Send slack notification
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [test]
     steps:
       - name: Fetch secrets from ESC


### PR DESCRIPTION
### Proposed changes

`scheduled-test.yml` got slow today (2026-08-19): the median PR run went from ~6 min to ~11 min, p75 from ~7 min to ~24 min, and a third of runs took over 20 minutes — several over an hour. This makes the workflow cheap enough that the next slow day doesn't matter much.

**What's actually slow.** Nothing in the tests. In [run 32260499131](https://github.com/pulumi/docs/actions/runs/32260499131) (68 min), `Check out the code` took 21m34s and `Fetch master branch` took 43m00s, and then `Run the tests` finished in **one second** because the PR touched no example programs. Same shape in [32282708797](https://github.com/pulumi/docs/actions/runs/32282708797) (56 min: 23m checkout, 29m fetch, 1s of tests). Baseline for those two steps is ~25s and ~1m49s. So the slowdown is entirely git transfer against a ~1.2 GB working tree, and it's intermittent — runs before ~13:50 UTC today were all normal, and some runs after are still 5–6 min. No workflow or repo-size change explains it (this file was last touched in Jan 2025; the largest blob added in the last 200 commits is a 430 KB event card). The same tail shows up in the `Pull Request` build, whose slowest run today spent 28 of its 45 minutes inside `actions/checkout`.

**What this PR changes** — none of it alters what gets tested:

- **A changed-files gate as the job's first step.** `test.sh` only tests the `static/programs` directories a PR touched, so the job now asks the API which files changed and skips its remaining steps when the answer is "none". Content-only PRs — the overwhelming majority here — cost a runner start plus one API call instead of the job's whole fixed cost (disk cleanup, ~1.2 GB clone, master fetch, six toolchains, a KinD cluster).
- **A concurrency group** with `cancel-in-progress` on pull requests only. One branch had six overlapping runs today, each cloning the repo to completion. Scheduled and manual runs are never cancelled.
- **`git fetch --depth=1`** for master. `test.sh` only diffs against master's tip; the branch's full history was never needed.
- **`timeout-minutes`** on each job (240 for `test`, which the ~3h nightly needs). One run on 2026-08-17 hung for 26 hours.

The nightly cron run is unaffected — it has been a steady ~185 min for the past week and still tests every program.

**Why the gate is on the steps and not on the job.** `test (ubuntu-latest, 1.26.x, 24.x, 3.9, 8.0.x, 11)` is a required status check, and GitHub does not expand the matrix for a job it never starts: a job skipped by an `if:` reports a check named bare `test`. You can see this on any Dependabot PR, which the job already skips — [#20939's checks](https://github.com/pulumi/docs/pull/20939) list `test` (skipped), with no matrix-expanded entry anywhere. Gating the job would therefore have left the required check unreported and every content-only PR stuck waiting on it. Keeping the job running and gating its steps means the check is always reported under the name branch protection expects. (First commit here had it the wrong way round; second commit fixes it.)

**Possible follow-up, not in this PR:** `content/blog/` is 776 MB of the 1.2 GB tree, nearly all of it post videos and images, and it's why every checkout in every workflow is expensive. A `sparse-checkout` limited to `scripts` and `static/programs` would make even a bad git day cheap for this job specifically; getting the media out of git would help every workflow. Both deserve their own change.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A
