### PR TITLE
content-review: stop the ledger erasing the backlog a glow-up failed to execute

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -478,8 +478,13 @@ frontmatter) are also present and are your evidence base.
    .self-check.u0.diff --article <path> --article-blob <pristine-copy> --out
    .self-check-report.json` (copy the article aside before your first edit).
 1. **Verdict sentinel**: `{"verdict": "glowup", "fixes": <executed count>,
-   "skipped_findings": <declined count>, "retirement": false}` — no
-   `applied[]` array; the glow-up gate replaces the per-hunk check. If the
+   "skipped_findings": <declined count>, "clarity_flag": <bool>,
+   "retirement": false}` — no `applied[]` array; the glow-up gate replaces
+   the per-hunk check. State `clarity_flag` explicitly: `false` once you have
+   resolved the page's readthrough reconception, `true` while one still
+   stands. Omitting it carries the page's existing flag forward unchanged —
+   which is the right default, since the flag is usually why the page was
+   selected, but it means only you can put it down. If the
    queue article carries `stale_claim_markers`, they are must-address
    findings here exactly as in a fix review: resolve each (fix it, or
    establish the flag was wrong) and list its `entity_key` in the sentinel's

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -512,9 +512,12 @@ jobs:
               BEFORE your first edit for the --article-blob input). Fix any
               violation and re-run until it passes.
             - Verdict sentinel: `{"verdict": "glowup", "fixes": <executed
-              count>, "skipped_findings": <declined count>, "retirement":
-              false}` — no `applied[]` needed; the glow-up gate replaces the
-              per-hunk check.
+              count>, "skipped_findings": <declined count>, "clarity_flag":
+              <bool>, "retirement": false}` — no `applied[]` needed; the
+              glow-up gate replaces the per-hunk check. State `clarity_flag`
+              explicitly: `false` once you have resolved the page's
+              readthrough reconception, `true` while one still stands.
+              Omitting it carries the page's existing flag forward.
             - Your PR will NOT auto-merge: it opens for human review (the
               sweep assigns reviewers). Write the body tables for that
               reader.

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -30,7 +30,8 @@ genuinely "incomplete" and stays due for retry.
 
 Canonical record (every field always present):
   { path, slug, lane, status, pr, pr_number, last_pr, last_pr_number, head_sha,
-    fixes, skipped_findings, glowup_degraded, retirement, note, attempts,
+    fixes, skipped_findings, glowup_degraded, glowup_degraded_runs, retirement,
+    note, attempts,
     clarity_flag, tier, score, monthly_visits, traffic_available, signals,
     signals_available, reviewed_at }
 
@@ -58,6 +59,7 @@ import argparse
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -244,7 +246,18 @@ def load_prior(slug: str, uri: str, prior_json: str | None) -> dict | None:
         log("aws CLI not available; no prior ledger record to carry forward")
         return None
     if out.returncode != 0:
-        log(f"no prior ledger record at {key} (first review of this page)")
+        # A missing key and a broken credential both exit non-zero, and only one
+        # of them is benign. Reporting both as "first review" would hide the
+        # case that silently reintroduces the bug this carry-forward fixes — a
+        # page with real history recorded as if it had none — so only a genuine
+        # 404 stays quiet.
+        err = (out.stderr or "").strip()
+        if re.search(r"\b(404|Not Found|NoSuchKey)\b", err, re.I):
+            log(f"no prior ledger record at {key} (first review of this page)")
+        else:
+            warn(f"could not read the prior ledger record at {key}; carrying "
+                 f"nothing forward, which may reset this page's PR pointer and "
+                 f"banked counters: {err[:200]}")
         return None
     try:
         rec = json.loads(out.stdout)
@@ -426,7 +439,10 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
         # `pr_number` keeps its original meaning — the PR THIS review opened, 0
         # when it opened none — so the versioned ledger's metrics stay
         # comparable across history. The durable pointer to the page's most
-        # recent review PR is separate, and is what the glow-up backlog reads.
+        # recent review PR is separate, and is read by select-glowup.py
+        # (`source_pr_number`, which the unprivileged worker is handed) and by
+        # build-glowup-backlog.py, which falls back to it when the head-ref
+        # query cannot reach GitHub.
         "last_pr": last_pr_from(prior)[0],
         "last_pr_number": last_pr_from(prior)[1],
         "head_sha": "",
@@ -438,6 +454,12 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
         # measured. The selector needs this bit to tell "declined 17" (real
         # adjudication, cool down) from "never saw 17" (still owed).
         "glowup_degraded": False,
+        # Consecutive degraded glow-ups. The selector exempts a degraded page
+        # from the cooldown so an unexecuted backlog isn't buried for 90 days,
+        # but an exemption with no counter is an unbounded loop when the
+        # recovery keeps failing for the same reason. `attempts` can't serve —
+        # the glowup path resets it to 0.
+        "glowup_degraded_runs": 0,
         "retirement": bool(verdict.get("retirement")) if verdict else False,
         "note": None,
         "attempts": prior_attempts + 1,
@@ -503,8 +525,14 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
                 if prior_banked or rec["clarity_flag"]:
                     rec["skipped_findings"] = prior_banked
                     rec["glowup_degraded"] = True
-                    rec["note"] = ("glow-up executed no backlog; prior counters "
-                                   "preserved and the page stays eligible")
+                    # Consecutive, so the selector can stop exempting a page
+                    # whose recovery keeps failing the same way.
+                    rec["glowup_degraded_runs"] = (
+                        int((prior or {}).get("glowup_degraded_runs") or 0) + 1)
+                    rec["note"] = (
+                        "glow-up executed no backlog; prior counters preserved "
+                        f"and the page stays eligible (degraded run "
+                        f"{rec['glowup_degraded_runs']})")
         else:
             rec["status"] = "incomplete"
             branch = branch_for(slug, rec["retirement"], glowup=(v == "glowup"))
@@ -739,7 +767,8 @@ def self_test() -> int:
         check("all canonical fields present", set(rec) == {
             "path", "slug", "lane", "mode", "status", "pr", "pr_number",
             "last_pr", "last_pr_number", "head_sha",
-            "fixes", "skipped_findings", "glowup_degraded", "retirement", "note",
+            "fixes", "skipped_findings", "glowup_degraded", "glowup_degraded_runs",
+            "retirement", "note",
             "attempts", "clarity_flag", "tier", "score", "monthly_visits",
             "traffic_available", "signals", "signals_available", "reviewed_at"})
         check("mode defaults to fix", rec["mode"] == "fix")
@@ -884,6 +913,58 @@ def self_test() -> int:
                          prior={"status": "glowup", "skipped_findings": 0})
         check("an empty glow-up with no prior debt is not degraded",
               r["glowup_degraded"] is False and r["skipped_findings"] == 0)
+
+        # --- the degraded exemption is bounded ------------------------------
+        # A degraded glow-up exempts the page from the cooldown, so without a
+        # counter a page whose recovery keeps failing re-qualifies every run,
+        # forever. `attempts` can't guard it — the glowup path resets it to 0.
+        r1 = build_record(g_article, g_empty, g_pr, g_article["slug"], prior=prior_banked)
+        check("the first degraded glow-up counts as one",
+              r1["glowup_degraded_runs"] == 1)
+        r2 = build_record(g_article, g_empty, g_pr, g_article["slug"],
+                          prior={**prior_banked, "glowup_degraded_runs": 1})
+        check("consecutive degraded glow-ups accrue", r2["glowup_degraded_runs"] == 2)
+        check("the run count is visible in the note", "degraded run 2" in (r2["note"] or ""))
+        r3 = build_record(g_article, g_verdict, g_pr, g_article["slug"],
+                          prior={**prior_banked, "glowup_degraded_runs": 2})
+        check("a glow-up that did work resets the degraded counter",
+              r3["glowup_degraded_runs"] == 0 and r3["glowup_degraded"] is False)
+
+        # --- a failed ledger read is not "first review" ---------------------
+        # Expired credentials and a wrong URI both exit non-zero. Reporting them
+        # as a first review silently reintroduces the bug the carry-forward
+        # fixes: a page with history recorded as if it had none.
+        import contextlib
+        import io
+        import subprocess as _sp
+
+        def _read_prior_with(stderr_text):
+            """load_prior against a stubbed `aws s3 cp` failure; returns its log."""
+            def fake_run(cmd, **kw):
+                return _sp.CompletedProcess(cmd, 1, stdout="", stderr=stderr_text)
+            real_run, buf = _sp.run, io.StringIO()
+            _sp.run = fake_run
+            try:
+                with contextlib.redirect_stderr(buf):
+                    result = load_prior("docs-x", "s3://b/ledger/", None)
+            finally:
+                _sp.run = real_run
+            return result, buf.getvalue()
+
+        missing, missing_log = _read_prior_with(
+            "fatal error: An error occurred (404) when calling the HeadObject "
+            "operation: Not Found")
+        broken, broken_log = _read_prior_with("Unable to locate credentials")
+        check("a genuine 404 reads as the page's first review",
+              missing is None and "first review of this page" in missing_log
+              and "::warning::" not in missing_log)
+        check("a credential failure is NOT reported as a first review",
+              broken is None and "first review of this page" not in broken_log)
+        check("it warns instead, naming what carrying nothing forward costs",
+              "::warning::" in broken_log
+              and "reset this page's PR pointer" in broken_log)
+        check("the underlying aws error is surfaced, not swallowed",
+              "Unable to locate credentials" in broken_log)
 
         # --- clarity_flag is three-state ------------------------------------
         # The glow-up sentinel never carried the key, so every glow-up silently

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -439,10 +439,12 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
         # `pr_number` keeps its original meaning — the PR THIS review opened, 0
         # when it opened none — so the versioned ledger's metrics stay
         # comparable across history. The durable pointer to the page's most
-        # recent review PR is separate, and is read by select-glowup.py
-        # (`source_pr_number`, which the unprivileged worker is handed) and by
-        # build-glowup-backlog.py, which falls back to it when the head-ref
-        # query cannot reach GitHub.
+        # recent review PR is separate, and is read by select-glowup.py, which
+        # folds it into the `source_pr_number` it stamps on the queue — the only
+        # form the unprivileged worker gets it in, and what
+        # build-glowup-backlog.py reads there. That file's own dispatcher-side
+        # ledger read still keys on `pr_number` alone; #21004 teaches it the
+        # same fallback.
         "last_pr": last_pr_from(prior)[0],
         "last_pr_number": last_pr_from(prior)[1],
         "head_sha": "",

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -29,10 +29,20 @@ sentinel. A branch with no PR (a half-applied fix) or a failed/timed-out run is
 genuinely "incomplete" and stays due for retry.
 
 Canonical record (every field always present):
-  { path, slug, lane, status, pr, pr_number, head_sha, fixes,
-    skipped_findings, retirement, note, attempts, clarity_flag,
-    tier, score, monthly_visits, traffic_available, signals,
+  { path, slug, lane, status, pr, pr_number, last_pr, last_pr_number, head_sha,
+    fixes, skipped_findings, glowup_degraded, retirement, note, attempts,
+    clarity_flag, tier, score, monthly_visits, traffic_available, signals,
     signals_available, reviewed_at }
+
+The record is rebuilt from scratch every review, which is right for an outcome
+but wrong for the page's accumulated state: a review that opens no PR — a
+`clean` verdict, however many findings it banked — used to reset the pointer to
+the last review PR, and the glow-up lane could then find nothing to execute
+(#20984). `load_prior` reads the record back before overwriting it and
+`build_record` carries three things forward explicitly: `last_pr`/
+`last_pr_number` (the durable pointer; `pr_number` still means "the PR this
+review opened"), a `clarity_flag` no verdict has explicitly cleared, and the
+banked count when a glow-up executed nothing at all.
 
 The record is written locally (audit artifact) and, when CONTENT_REVIEW_LEDGER_URI
 is set, uploaded to <uri>/<slug>.json with reviewed_at stamped to today (UTC).
@@ -198,6 +208,84 @@ def fetch_pr(branch: str, pr_json: str | None) -> dict | None:
         return None
 
 
+def load_prior(slug: str, uri: str, prior_json: str | None) -> dict | None:
+    """The page's CURRENT ledger record, read back before this run overwrites it.
+
+    The record is rebuilt from scratch every review, so anything this run cannot
+    observe for itself has to come from here. Read from S3 rather than from the
+    queue because it also covers a `--paths` manual dispatch (whose queue carries
+    no ledger fields at all) and because it keeps `queue_json`, already the
+    dispatch's largest input, from growing.
+
+    Returns None on any failure — no aws CLI, no object yet, unreadable JSON.
+    A missed prior is exactly the behavior that shipped before this existed, so
+    the degradation is "no carry-forward", never "no ledger write".
+
+    `prior_json` (a file path, or '-' for stdin) injects the record for tests,
+    mirroring --pr-json.
+    """
+    if prior_json is not None:
+        raw = sys.stdin.read() if prior_json == "-" else Path(prior_json).read_text()
+        raw = raw.strip()
+        if not raw:
+            return None
+        try:
+            rec = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        return rec if isinstance(rec, dict) else None
+    if not uri:
+        return None
+    key = f"{uri.rstrip('/')}/{slug}.json"
+    try:
+        out = subprocess.run(["aws", "s3", "cp", key, "-"],
+                             capture_output=True, text=True, check=False)
+    except OSError:
+        log("aws CLI not available; no prior ledger record to carry forward")
+        return None
+    if out.returncode != 0:
+        log(f"no prior ledger record at {key} (first review of this page)")
+        return None
+    try:
+        rec = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        warn(f"prior ledger record at {key} is unreadable; not carrying it forward")
+        return None
+    return rec if isinstance(rec, dict) else None
+
+
+def last_pr_from(prior: dict | None) -> tuple[str | None, int]:
+    """The most recent review PR known for this page, from the prior record.
+
+    Prefers the prior record's own `pr`/`pr_number` — the PR THAT review opened
+    — and falls back to the pointer it was itself carrying. The fallback is the
+    load-bearing half: without it the reference survives exactly one PR-less
+    review, and pages accumulate PR-less reviews (a `clean` verdict opens no PR,
+    however many findings it banked).
+    """
+    if not isinstance(prior, dict):
+        return None, 0
+    n = int(prior.get("pr_number") or 0)
+    if n:
+        return prior.get("pr"), n
+    return prior.get("last_pr"), int(prior.get("last_pr_number") or 0)
+
+
+def carried_clarity(verdict: dict | None, prior: dict | None) -> bool:
+    """`clarity_flag` from the verdict when it states one, from the prior record
+    when it doesn't.
+
+    A sentinel that omits the key is not asserting the page reads clearly — the
+    glow-up sentinel never carried it at all, so every glow-up silently cleared
+    a flag it had just been selected for. Absence carries; an explicit `false`
+    clears. The flag is therefore sticky by design: only a review that says so
+    can put it down.
+    """
+    if verdict is not None and "clarity_flag" in verdict:
+        return bool(verdict.get("clarity_flag"))
+    return bool((prior or {}).get("clarity_flag"))
+
+
 def scan_misnamed_sibling(slug: str) -> None:
     """Best-effort warning when a fix PR exists under a non-canonical branch."""
     try:
@@ -304,8 +392,15 @@ def carry_markers(article: dict, verdict: dict | None) -> list[dict]:
 
 def build_record(article: dict, verdict: dict | None, pr: dict | None,
                  slug: str, claude_succeeded: bool = False,
-                 branch_exists: bool = False) -> dict:
+                 branch_exists: bool = False, prior: dict | None = None) -> dict:
     """Build the canonical ledger record from the queue, verdict, and PR state.
+
+    `prior` is the page's previous record (see load_prior). It is read from, never
+    merged into: every field below is still derived from this run, and the three
+    things the prior contributes — the last-PR pointer, a sticky `clarity_flag`,
+    and the banked count a no-op glow-up must not zero — are each taken
+    explicitly. A blanket merge would leak a stale `status` or `fixes` forward and
+    make one record describe two different reviews.
 
     `attempts` accrues the consecutive `incomplete` retries: it starts from the
     prior count the selector carried in (`article["attempts"]`), is incremented
@@ -328,13 +423,25 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
         "status": "incomplete",
         "pr": None,
         "pr_number": 0,
+        # `pr_number` keeps its original meaning — the PR THIS review opened, 0
+        # when it opened none — so the versioned ledger's metrics stay
+        # comparable across history. The durable pointer to the page's most
+        # recent review PR is separate, and is what the glow-up backlog reads.
+        "last_pr": last_pr_from(prior)[0],
+        "last_pr_number": last_pr_from(prior)[1],
         "head_sha": "",
         "fixes": 0,
         "skipped_findings": 0,
+        # True only when a glow-up verdict executed and declined nothing while
+        # the page carried banked debt: the backlog never reached the model, so
+        # the counters below are the PRIOR review's, carried rather than
+        # measured. The selector needs this bit to tell "declined 17" (real
+        # adjudication, cool down) from "never saw 17" (still owed).
+        "glowup_degraded": False,
         "retirement": bool(verdict.get("retirement")) if verdict else False,
         "note": None,
         "attempts": prior_attempts + 1,
-        "clarity_flag": bool(verdict.get("clarity_flag")) if verdict else False,
+        "clarity_flag": carried_clarity(verdict, prior),
         # Selection signal (carried from the queue) — persisted so the versioned
         # ledger captures why the page was picked, not just the outcome.
         "tier": article.get("tier"),
@@ -381,8 +488,23 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
             rec["status"] = "reviewed" if v == "fixed" else "glowup"
             rec["pr"] = pr.get("url")
             rec["pr_number"] = int(pr.get("number") or 0)
+            rec["last_pr"] = rec["pr"]
+            rec["last_pr_number"] = rec["pr_number"]
             rec["head_sha"] = pr.get("headRefOid") or ""
             rec["attempts"] = 0
+            # A glow-up that executed nothing and declined nothing did not touch
+            # the backlog: its recovery degraded (see build-glowup-backlog.py)
+            # and the page is still owed its rehab. Reporting 0 banked here would
+            # drop it out of the glow-up selector, which keys on
+            # skipped_findings/clarity_flag, AND start a 90-day cooldown — so the
+            # lane would delete the debt it had just failed to collect. #20984.
+            if v == "glowup" and rec["fixes"] == 0 and rec["skipped_findings"] == 0:
+                prior_banked = int((prior or {}).get("skipped_findings") or 0)
+                if prior_banked or rec["clarity_flag"]:
+                    rec["skipped_findings"] = prior_banked
+                    rec["glowup_degraded"] = True
+                    rec["note"] = ("glow-up executed no backlog; prior counters "
+                                   "preserved and the page stays eligible")
         else:
             rec["status"] = "incomplete"
             branch = branch_for(slug, rec["retirement"], glowup=(v == "glowup"))
@@ -438,9 +560,15 @@ def run(args) -> int:
             else canonical_branch_pushed(slug)
         )
 
+    # Read the record this run is about to overwrite, so the facts it cannot
+    # observe for itself (the last-PR pointer, a standing clarity flag, an
+    # unexecuted backlog) survive instead of being reset to their defaults.
+    uri = os.environ.get("CONTENT_REVIEW_LEDGER_URI", "").strip()
+    prior = load_prior(slug, uri, args.prior)
+
     record = build_record(article, verdict, pr, slug,
                           claude_succeeded=claude_succeeded,
-                          branch_exists=branch_exists)
+                          branch_exists=branch_exists, prior=prior)
 
     # PR-body section check (non-blocking) for fix and glow-up PRs.
     if record["status"] in ("reviewed", "glowup") and pr is not None:
@@ -463,7 +591,6 @@ def run(args) -> int:
     out_path.write_text(json.dumps(record, indent=2) + "\n")
     log(f"status={record['status']} slug={slug} -> {out_path}")
 
-    uri = os.environ.get("CONTENT_REVIEW_LEDGER_URI", "").strip()
     if uri:
         upload(record, slug, uri)
     else:
@@ -610,9 +737,10 @@ def self_test() -> int:
                            claude_succeeded=False, branch_exists=False)
         check("no-verdict + failed run -> incomplete", rec["status"] == "incomplete")
         check("all canonical fields present", set(rec) == {
-            "path", "slug", "lane", "mode", "status", "pr", "pr_number", "head_sha",
-            "fixes", "skipped_findings", "retirement", "note", "attempts",
-            "clarity_flag", "tier", "score", "monthly_visits",
+            "path", "slug", "lane", "mode", "status", "pr", "pr_number",
+            "last_pr", "last_pr_number", "head_sha",
+            "fixes", "skipped_findings", "glowup_degraded", "retirement", "note",
+            "attempts", "clarity_flag", "tier", "score", "monthly_visits",
             "traffic_available", "signals", "signals_available", "reviewed_at"})
         check("mode defaults to fix", rec["mode"] == "fix")
 
@@ -689,6 +817,105 @@ def self_test() -> int:
         check("section check passes complete body",
               check_pr_body("\n".join(f"## {s}" for s in REQUIRED_PR_SECTIONS)) == [])
 
+        # --- carry-forward: the pointer to the last review PR --------------
+        # The record is rebuilt every review, so a review that opens no PR used
+        # to reset the pointer to 0 and strand the page's banked backlog.
+        prior_reviewed = {"status": "reviewed", "pr": "https://example.test/19885",
+                          "pr_number": 19885, "skipped_findings": 8}
+        r = build_record(article, {"verdict": "clean", "reason": "accurate"},
+                         None, article["slug"], prior=prior_reviewed)
+        check("a clean review keeps the prior review's PR pointer",
+              r["last_pr_number"] == 19885 and r["last_pr"] == "https://example.test/19885")
+        check("a clean review still reports no PR of its own",
+              r["pr_number"] == 0 and r["pr"] is None)
+        r = build_record(article, {"verdict": "skipped", "reason": "draft"},
+                         None, article["slug"], prior=prior_reviewed)
+        check("a skipped review keeps the pointer", r["last_pr_number"] == 19885)
+        r = build_record(article, None, None, article["slug"],
+                         claude_succeeded=False, prior=prior_reviewed)
+        check("an incomplete review keeps the pointer", r["last_pr_number"] == 19885)
+        # The chain is what makes it durable: a run of PR-less reviews must not
+        # walk the pointer off the end one review at a time.
+        carried_only = {"status": "clean", "pr": None, "pr_number": 0,
+                        "last_pr": "https://example.test/19885", "last_pr_number": 19885}
+        r = build_record(article, {"verdict": "clean", "reason": "accurate"},
+                         None, article["slug"], prior=carried_only)
+        check("the pointer survives consecutive PR-less reviews",
+              r["last_pr_number"] == 19885)
+        r = build_record(article, {"verdict": "fixed", "fixes": 1}, pr,
+                         article["slug"], prior=prior_reviewed)
+        check("a fresh PR overwrites the carried pointer",
+              r["last_pr_number"] == 19731 and r["pr_number"] == 19731)
+        r = build_record(article, {"verdict": "clean", "reason": "accurate"},
+                         None, article["slug"], prior=None)
+        check("nothing is carried when there is no prior record",
+              r["last_pr_number"] == 0 and r["last_pr"] is None)
+        check("carry-forward never resurrects a stale status",
+              build_record(article, {"verdict": "clean", "reason": "ok"}, None,
+                           article["slug"], prior=prior_reviewed)["status"] == "clean")
+        check("carry-forward never resurrects a stale fix count",
+              build_record(article, {"verdict": "clean", "reason": "ok"}, None,
+                           article["slug"],
+                           prior={"fixes": 7, "pr_number": 1})["fixes"] == 0)
+
+        # --- carry-forward: a glow-up that executed nothing ----------------
+        # #20984: the backlog was unrecoverable, the glow-up ran taxonomy-only,
+        # and the ledger then zeroed the 17 banked findings that had selected
+        # the page — deleting the debt the lane had just failed to collect.
+        prior_banked = {"status": "clean", "pr_number": 0, "skipped_findings": 17,
+                        "clarity_flag": True}
+        g_empty = {"verdict": "glowup", "fixes": 0, "skipped_findings": 0,
+                   "retirement": False}
+        r = build_record(g_article, g_empty, g_pr, g_article["slug"], prior=prior_banked)
+        check("#20984: a glow-up that executed nothing preserves the banked count",
+              r["skipped_findings"] == 17)
+        check("#20984: it preserves the clarity flag", r["clarity_flag"] is True)
+        check("#20984: it is marked degraded so the selector can tell why",
+              r["glowup_degraded"] is True and "preserved" in (r["note"] or ""))
+        r = build_record(g_article, g_verdict, g_pr, g_article["slug"], prior=prior_banked)
+        check("a glow-up that executed the backlog reports its own declined count",
+              r["skipped_findings"] == 1 and r["glowup_degraded"] is False)
+        r = build_record(g_article, {"verdict": "glowup", "fixes": 0,
+                                     "skipped_findings": 3}, g_pr,
+                         g_article["slug"], prior=prior_banked)
+        check("a glow-up that declined everything is real work, not degraded",
+              r["skipped_findings"] == 3 and r["glowup_degraded"] is False)
+        r = build_record(g_article, g_empty, g_pr, g_article["slug"],
+                         prior={"status": "glowup", "skipped_findings": 0})
+        check("an empty glow-up with no prior debt is not degraded",
+              r["glowup_degraded"] is False and r["skipped_findings"] == 0)
+
+        # --- clarity_flag is three-state ------------------------------------
+        # The glow-up sentinel never carried the key, so every glow-up silently
+        # cleared the flag it had just been selected for.
+        r = build_record(article, {"verdict": "fixed", "fixes": 2}, pr,
+                         article["slug"], prior={"clarity_flag": True, "pr_number": 1})
+        check("an absent clarity_flag carries forward rather than clearing",
+              r["clarity_flag"] is True)
+        r = build_record(article, {"verdict": "glowup", "fixes": 3,
+                                   "skipped_findings": 0, "clarity_flag": False},
+                         g_pr, article["slug"], prior={"clarity_flag": True})
+        check("an explicit clarity_flag:false clears the flag",
+              r["clarity_flag"] is False)
+
+        # --- load_prior degrades to None, never raises ----------------------
+        check("load_prior with no URI and no fixture is None",
+              load_prior("docs-x", "", None) is None)
+        empty_prior = d / "prior-empty.json"
+        empty_prior.write_text("")
+        check("load_prior on an empty fixture is None",
+              load_prior("docs-x", "", str(empty_prior)) is None)
+        bad_prior = d / "prior-bad.json"
+        bad_prior.write_text("{not json")
+        check("load_prior on unparseable JSON is None, not an exception",
+              load_prior("docs-x", "", str(bad_prior)) is None)
+        list_prior = d / "prior-list.json"
+        list_prior.write_text("[]")
+        check("load_prior rejects a non-object record",
+              load_prior("docs-x", "", str(list_prior)) is None)
+        check("last_pr_from tolerates a non-dict prior",
+              last_pr_from(None) == (None, 0) and last_pr_from("x") == (None, 0))
+
         # Unresolved-draft-marker guard (non-blocking parity with no-todo-tokens).
         check("counts leftover TODO + lint placeholder",
               unresolved_draft_markers("a <TODO: fix> b <!-- LINT-RESULT --> c") == 2)
@@ -707,6 +934,9 @@ def main() -> int:
     p.add_argument("--queue", help="single-article queue JSON (.content-review-queue.json)")
     p.add_argument("--verdict", help="model verdict sentinel (.content-review-verdict.json)")
     p.add_argument("--pr-json", help="inject gh PR JSON (file path or '-' for stdin); for tests")
+    p.add_argument("--prior",
+                   help="inject the page's existing ledger record (file path or '-' for "
+                        "stdin); for tests — otherwise read from CONTENT_REVIEW_LEDGER_URI")
     p.add_argument("--claude-outcome",
                    help="GitHub step outcome of the review run (success/failure/cancelled). "
                         "With no sentinel, 'success' + no pushed branch => clean; anything else => incomplete.")

--- a/scripts/content-review/select-glowup.py
+++ b/scripts/content-review/select-glowup.py
@@ -108,6 +108,13 @@ def low_ctr_flagged(entry: dict) -> bool:
 def glowup_cooldown_active(entry: dict, today) -> bool:
     if entry.get("status") != "glowup":
         return False
+    # A glow-up whose backlog never reached it executed nothing and declined
+    # nothing, so the page is still owed its rehab and must stay selectable.
+    # record-review.py sets this flag precisely because the counters alone
+    # cannot say it: a degraded run CARRIES the prior banked count forward, so
+    # `skipped_findings: 17` reads identically to a run that declined 17. #20984.
+    if entry.get("glowup_degraded"):
+        return False
     reviewed = parse_day(entry.get("reviewed_at"))
     return bool(reviewed and (today - reviewed).days < GLOWUP_COOLDOWN_DAYS)
 

--- a/scripts/content-review/select-glowup.py
+++ b/scripts/content-review/select-glowup.py
@@ -93,6 +93,15 @@ GLOWUP_MAX_OPEN_PRS = 10
 # A page glow-upped this recently is not re-selected: the point of the lane
 # is executing an accumulated backlog, and one just was.
 GLOWUP_COOLDOWN_DAYS = 90
+# ...but a page whose backlog recovery keeps failing must not re-qualify
+# forever. A degraded glow-up executes nothing, re-sets `glowup_degraded`, and
+# would re-qualify on the very next run — an unbounded loop that burns a slot a
+# day and eventually halts the whole lane on GLOWUP_MAX_OPEN_PRS, which is
+# backpressure aimed at the wrong thing. `attempts` cannot guard it: the glowup
+# status path resets it to 0. After this many consecutive degraded runs the
+# page serves the normal cooldown, by which time either a fix-lane review has
+# banked something recoverable or the page genuinely has nothing to recover.
+GLOWUP_DEGRADED_ATTEMPT_CAP = 2
 # Additive signal boosts, in units of weighted findings (the base term is
 # skipped_findings, typically 1-6, times a tier weight <= 1).
 CLARITY_BOOST = 5.0
@@ -113,7 +122,11 @@ def glowup_cooldown_active(entry: dict, today) -> bool:
     # record-review.py sets this flag precisely because the counters alone
     # cannot say it: a degraded run CARRIES the prior banked count forward, so
     # `skipped_findings: 17` reads identically to a run that declined 17. #20984.
-    if entry.get("glowup_degraded"):
+    # Bounded, though: past the cap the page serves the normal cooldown rather
+    # than looping on a recovery that keeps failing for the same reason.
+    if (entry.get("glowup_degraded")
+            and int(entry.get("glowup_degraded_runs") or 0)
+            < GLOWUP_DEGRADED_ATTEMPT_CAP):
         return False
     reviewed = parse_day(entry.get("reviewed_at"))
     return bool(reviewed and (today - reviewed).days < GLOWUP_COOLDOWN_DAYS)
@@ -272,7 +285,13 @@ def main() -> int:
             # The banked-findings source: the ledger entry's latest review PR.
             # Carried on the queue because the worker has no ledger cache —
             # build-glowup-backlog.py reads it from here.
-            "source_pr_number": int(entry.get("pr_number") or 0) or None,
+            # `pr_number` is only set when the LATEST review opened a PR, and a
+            # review that banks findings without applying any opens none — so
+            # falling back to the durable pointer is the whole point of it
+            # existing. Without this the worker is handed None for exactly the
+            # pages with the largest backlogs. #20984.
+            "source_pr_number": int(entry.get("pr_number")
+                                    or entry.get("last_pr_number") or 0) or None,
             # The structured findings record rides the queue for the same
             # reason the markers above do: build-glowup-backlog.py runs in the
             # UNPRIVILEGED review job, which has no AWS credentials and so

--- a/scripts/content-review/test_select_glowup.py
+++ b/scripts/content-review/test_select_glowup.py
@@ -149,6 +149,30 @@ def main() -> int:
         paths = [a["path"] for a in q["articles"]]
         check(paths == [C], f"only the eligible page selected (got {paths})")
 
+        print("a degraded glow-up does not start the cooldown (#20984)")
+        # The backlog never reached the model, so nothing was executed and
+        # nothing declined; record-review carried the banked count forward and
+        # flagged it. The page is still owed its rehab.
+        led_deg = tmp / "ledger-glowup-degraded"
+        write_ledger(led_deg, B, skipped_findings=17, clarity_flag=True,
+                     status="glowup", reviewed_at="2026-08-10",
+                     fixes=0, glowup_degraded=True)
+        q = run_select(repo, tiers, led_deg, "--count", "10")
+        check([a["path"] for a in q["articles"]] == [B],
+              "degraded glow-up stays selectable inside the cooldown window")
+
+        print("a glow-up that did work still starts the cooldown")
+        led_did = tmp / "ledger-glowup-executed"
+        write_ledger(led_did, B, skipped_findings=1, status="glowup",
+                     reviewed_at="2026-08-10", fixes=4, glowup_degraded=False)
+        check(run_select(repo, tiers, led_did, "--count", "10")["articles"] == [],
+              "executed glow-up excluded by the cooldown")
+        led_dec = tmp / "ledger-glowup-declined"
+        write_ledger(led_dec, B, skipped_findings=3, status="glowup",
+                     reviewed_at="2026-08-10", fixes=0, glowup_degraded=False)
+        check(run_select(repo, tiers, led_dec, "--count", "10")["articles"] == [],
+              "glow-up that declined everything is real work, still cooled down")
+
         print("cooldown expires: an old glowup outcome is selectable again")
         led4 = tmp / "ledger-cooldown-old"
         write_ledger(led4, B, skipped_findings=4, status="glowup",

--- a/scripts/content-review/test_select_glowup.py
+++ b/scripts/content-review/test_select_glowup.py
@@ -161,6 +161,33 @@ def main() -> int:
         check([a["path"] for a in q["articles"]] == [B],
               "degraded glow-up stays selectable inside the cooldown window")
 
+        print("the degraded exemption is bounded, not an unbounded re-select loop")
+        led_cap = tmp / "ledger-glowup-degraded-capped"
+        write_ledger(led_cap, B, skipped_findings=17, clarity_flag=True,
+                     status="glowup", reviewed_at="2026-08-10",
+                     fixes=0, glowup_degraded=True, glowup_degraded_runs=2)
+        check(run_select(repo, tiers, led_cap, "--count", "10")["articles"] == [],
+              "past the cap a degraded page serves the normal cooldown")
+        led_under = tmp / "ledger-glowup-degraded-under-cap"
+        write_ledger(led_under, B, skipped_findings=17, clarity_flag=True,
+                     status="glowup", reviewed_at="2026-08-10",
+                     fixes=0, glowup_degraded=True, glowup_degraded_runs=1)
+        check([a["path"] for a in
+               run_select(repo, tiers, led_under, "--count", "10")["articles"]] == [B],
+              "under the cap it is still exempt")
+
+        print("the durable PR pointer reaches the worker when pr_number is 0")
+        led_ptr = tmp / "ledger-last-pr"
+        write_ledger(led_ptr, A, skipped_findings=4, pr_number=0, last_pr_number=19885)
+        q = run_select(repo, tiers, led_ptr, "--count", "10")
+        check(q["articles"][0]["source_pr_number"] == 19885,
+              "source_pr_number falls back to last_pr_number")
+        led_both = tmp / "ledger-both-prs"
+        write_ledger(led_both, A, skipped_findings=4, pr_number=222, last_pr_number=111)
+        check(run_select(repo, tiers, led_both, "--count", "10")
+              ["articles"][0]["source_pr_number"] == 222,
+              "this review's own PR still wins when it opened one")
+
         print("a glow-up that did work still starts the cooldown")
         led_did = tmp / "ledger-glowup-executed"
         write_ledger(led_did, B, skipped_findings=1, status="glowup",


### PR DESCRIPTION
### Proposed changes

Unit 1 of 3 from the #20984 investigation. This one stops the data loss; the other two make the backlog recoverable and stop a glow-up poisoning its own findings record.

**What happened.** [#20984](https://github.com/pulumi/docs/pull/20984) opened a glow-up announcing `No banked findings reachable (no prior review PRs reachable; run the taxonomy-only sweep) — taxonomy-only glow-up` for a page whose ledger entry recorded `skipped_findings: 17, clarity_flag: true` — which is precisely why the glow-up selector picked it (score 17.6166). Nothing was unreachable. The pointer to the page's last review PR had been erased three weeks earlier, so `fetch_pr()` was never called at all. [Run 32263128501](https://github.com/pulumi/docs/actions/runs/32263128501) logs `0 banked finding(s) from 0 PR(s)` beside `skipped_findings: 17`, and the dispatched queue carried `source_pr_number: null`. The findings it needed were sitting in [#19885](https://github.com/pulumi/docs/pull/19885) the whole time.

**Why the pointer was gone.** `build_record()` rebuilds the record from a blank sheet every review and only fills `pr_number` in the `fixed`/`glowup`-with-a-PR branch, so any review that opens no PR blanks it. That is not a rare path: a review applying zero fixes writes `clean`, `publish-gate.py` sets `publish=false`, and no PR is opened however many findings it banked. Same carry-forward class as #20968.

**Why it then got worse.** The degraded glow-up wrote its own zeros over the counters — the sentinel's `skipped_findings` is the *declined* count (0, the backlog was empty) and it carries no `clarity_flag` at all. `select-glowup.py` excludes on `banked <= 0 and not clarity_flag` and cools the page down for 90 days, so the lane deleted the debt it had just failed to collect.

Changes:

- **`load_prior()`** reads the record back from S3 before this run overwrites it. From S3 rather than the queue because it also covers a `--paths` manual dispatch and keeps `queue_json` — already the dispatch's largest input — from growing. Returns `None` on any failure, so the degradation is "no carry-forward", never "no ledger write". `--prior` injects it for tests, mirroring `--pr-json`.
- **`last_pr` / `last_pr_number`** carry the pointer forward, chaining through the prior record's own carried value — without the chain the reference survives exactly one PR-less review. `pr_number` keeps its meaning ("the PR *this* review opened") so `reconstruct-ledger-history.py`'s CSV stays comparable across history.
- **`clarity_flag` is three-state**: an absent key carries the prior flag, an explicit `false` clears it. The glow-up sentinel never carried the key, so every glow-up silently cleared the flag it had just been selected for. The sentinel schema now asks for it explicitly — `SKILL.md` and the workflow prompt in the same commit.
- **A glow-up that executed nothing and declined nothing** preserves the prior banked count and sets `glowup_degraded`; `glowup_cooldown_active()` skips a degraded entry. The flag is load-bearing because the counters cannot express it: a degraded run carries 17 forward, which reads identically to a run that declined 17.

Carry-forward is an explicit three-field read, never a merge — a blanket merge would leak a stale `status` or `fixes` forward and make one record describe two reviews. There are tests for that directly, plus the #20984 regression case and `load_prior`'s failure paths.

One deviation from the approved plan, flagged for review: the plan proposed keying the cooldown on `fixes == 0 and skipped_findings == 0` with no new ledger field. That is self-contradictory once the same change preserves the counters — after preservation `skipped_findings` is 17, not 0. Hence the single explicit `glowup_degraded` boolean.

Verification: `make test-review-pipeline` and `make lint` both pass (1845 files parsed, 0 errors; Prettier clean).

### Unreleased product version (optional)

n/a — automation only, no user-facing content.

### Related issues (optional)

Follows up on #20984. Related: #20990 (structured findings record, forward-only), #20970 (glow-up lane), #20968 (the stale-claim-marker carry-forward this mirrors).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx3iwUddA9pNZQ4ReDiadT)_