### PR TITLE
content-review: take a glow-up's findings disposition from its own sentinel

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -486,8 +486,15 @@ frontmatter) are also present and are your evidence base.
    .self-check-report.json` (copy the article aside before your first edit).
 1. **Verdict sentinel**: `{"verdict": "glowup", "fixes": <executed count>,
    "skipped_findings": <declined count>, "clarity_flag": <bool>,
-   "retirement": false}` — no `applied[]` array; the glow-up gate replaces
-   the per-hunk check. State `clarity_flag` explicitly: `false` once you have
+   "executed_ids": [...], "declined_ids": [...], "retirement": false}` — no
+   `applied[]` array; the glow-up gate replaces the per-hunk check.
+   `executed_ids` and `declined_ids` are the `id` values from
+   `.glowup-backlog.json` for the rows you put in the Backlog executed and
+   Backlog declined tables — the same partition, reported as data. Every
+   banked id belongs in exactly one of them; both lists are empty only when
+   the backlog itself was empty. Without them the findings record cannot
+   tell what you executed from what you left, so it records nothing at all
+   rather than filing your completed work as still outstanding. State `clarity_flag` explicitly: `false` once you have
    resolved the page's readthrough reconception, `true` while one still
    stands. Omitting it carries the page's existing flag forward unchanged —
    which is the right default, since the flag is usually why the page was

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -632,11 +632,18 @@ jobs:
               violation and re-run until it passes.
             - Verdict sentinel: `{"verdict": "glowup", "fixes": <executed
               count>, "skipped_findings": <declined count>, "clarity_flag":
-              <bool>, "retirement": false}` — no `applied[]` needed; the
-              glow-up gate replaces the per-hunk check. State `clarity_flag`
+              <bool>, "executed_ids": [...], "declined_ids": [...],
+              "retirement": false}` — no `applied[]` needed; the glow-up
+              gate replaces the per-hunk check. State `clarity_flag`
               explicitly: `false` once you have resolved the page's
-              readthrough reconception, `true` while one still stands.
-              Omitting it carries the page's existing flag forward.
+              readthrough reconception, `true` while one still stands;
+              omitting it carries the page's existing flag forward.
+              `executed_ids`/`declined_ids` are the `id` values from
+              `.glowup-backlog.json` for the rows you put in the Backlog
+              executed and Backlog declined tables — every banked id in
+              exactly one list. Without them the findings record would file
+              the work you just did as still outstanding, so it records
+              nothing for the run instead.
             - Your PR will NOT auto-merge: it opens for human review (the
               sweep assigns reviewers). Write the body tables for that
               reader.
@@ -1150,6 +1157,7 @@ jobs:
             --vale-findings .review-snapshot/.vale-findings.json \
             --readthrough .review-snapshot/.readthrough-findings.json \
             --frontmatter .review-snapshot/.frontmatter-validation.json \
+            --backlog .review-snapshot/.glowup-backlog.json \
             --out .page-findings.json \
             --uri "${{ steps.ledger-bucket.outputs.findings_uri }}"
 

--- a/scripts/content-review/record-page-findings.py
+++ b/scripts/content-review/record-page-findings.py
@@ -54,10 +54,16 @@ GLOW-UP RUNS are the exception, and take their disposition from the sentinel's
 `executed_ids`/`declined_ids` instead (`--backlog` supplies the id mapping). A
 glow-up carries no `applied[]` by design, so the line-overlap match above finds
 nothing and would file every finding — including everything the glow-up just
-executed — as deferred. A sentinel carrying neither list means NO record is
-written for that run: the previous record then stands, so `reviewed_at` can lag
-the ledger's. That is deliberate. The fix-lane record is the truthful one, and a
-stale-but-true record beats a fresh-but-wrong one that re-proposes finished work.
+executed — as deferred. Two states mean NO record is written for that run: a sentinel carrying neither
+list, and a sentinel whose executed ids ALL fail to resolve to a finding here
+(a missing backlog snapshot, or labels that have drifted). Both are the same
+information state — the disposition is unknown — and the all-False record that
+would otherwise be written re-banks everything the glow-up just finished. A
+PARTIAL resolve still writes; so does a glow-up that executed only pr-body
+items, which have no counterpart on this record and are expected to resolve to
+nothing. When the write is skipped the previous record stands, so `reviewed_at`
+can lag the ledger's. That is deliberate: the fix-lane record is the truthful
+one, and a stale-but-true record beats a fresh-but-wrong one.
 
 Usage:
     record-page-findings.py --queue .content-review-queue.json \
@@ -229,9 +235,17 @@ def mark_from_backlog(findings: list[dict], verdict: dict | None,
 
     labels = [str(f.get("label") or "").strip() for f in findings]
     applied_idx: set[int] = set()
+    # Executed ids that SHOULD have resolved to a finding on this record —
+    # everything except the pr-body items, which are prose with no counterpart
+    # here and are expected to resolve to nothing. Only these can tell a total
+    # resolution failure from a glow-up that legitimately executed prose.
+    resolvable: set[str] = set()
     for bid in sorted(executed):
         item = banked.get(bid)
         if item is None:
+            # Unknown id: either the backlog is missing entirely or the sentinel
+            # named something that was never banked. Both should have resolved.
+            resolvable.add(bid)
             warn(f"executed id {bid!r} is not in the backlog; leaving the "
                  "corresponding finding deferred")
             continue
@@ -240,6 +254,7 @@ def mark_from_backlog(findings: list[dict], verdict: dict | None,
         # That gap is exactly what the structured record exists to close.
         if item.get("source") != "findings-record":
             continue
+        resolvable.add(bid)
         text = str(item.get("text") or "").strip()
         hit = next((i for i, lab in enumerate(labels)
                     if lab and i not in applied_idx and text.startswith(lab)), None)
@@ -249,6 +264,21 @@ def mark_from_backlog(findings: list[dict], verdict: dict | None,
                  "by position")
             continue
         applied_idx.add(hit)
+
+    # The sentinel named executed items and not one of them resolved — the
+    # backlog snapshot is missing or unreadable, or every label has drifted.
+    # That is the same information state as a sentinel carrying no lists at
+    # all, so it takes the same exit: writing the all-False record this would
+    # otherwise produce re-banks everything the glow-up just finished, which
+    # is the failure the whole function exists to prevent. A PARTIAL resolve
+    # still writes — those findings are genuinely known, and the unresolved
+    # ones already warned above.
+    if resolvable and not applied_idx:
+        warn(f"none of the {len(resolvable)} executed id(s) that should map to a "
+             "finding on this record resolved to one; "
+             "skipping the write rather than recording this glow-up's own work "
+             "as still outstanding")
+        return None
 
     out = []
     for i, f in enumerate(findings):
@@ -417,16 +447,30 @@ def self_test() -> int:
           glow() is None and mark_from_backlog(F, {"verdict": "glowup"}, BACKLOG) is None)
     check("an empty backlog is still a disposition, not a missing one",
           glow(executed_ids=[], declined_ids=[]) == [False] * 5)
-    check("an executed id with no matching finding is ignored, not crashed on",
-          glow(executed_ids=["findings-f99", "nonsense"]) == [False] * 5)
+    check("executed ids that resolve to nothing at all skip the write",
+          glow(executed_ids=["findings-f99", "nonsense"]) is None)
     check("a pr-body-sourced backlog item cannot mark a record finding",
           glow(executed_ids=["pr19885-findings-1"]) == [False] * 5)
-    # Without the backlog there is nothing to resolve `findings-f2` AGAINST,
-    # and the only way to honour it would be to trust the ordinal — the guess
-    # this function stopped making. Deferring everything is the safe direction.
-    check("a missing backlog marks nothing rather than guessing by position",
+    # Without the backlog there is nothing to resolve `findings-f2` AGAINST, and
+    # the only way to honour it would be to trust the ordinal — the guess this
+    # function stopped making. Writing the all-False record that falls out of
+    # that would re-bank the work the glow-up just did, so it takes the same
+    # exit as a sentinel carrying no lists at all.
+    check("a missing backlog skips the write rather than guessing by position",
+          mark_from_backlog(F, {"verdict": "glowup",
+                                "executed_ids": ["findings-f2"]}, None) is None)
+    check("...and so does an executed set where nothing resolves",
+          mark_from_backlog(F, {"verdict": "glowup",
+                                "executed_ids": ["findings-f404"]}, BACKLOG) is None)
+    check("a PARTIAL resolve still writes — those findings are genuinely known",
           [f["applied"] for f in
-           mark_from_backlog(F, {"verdict": "glowup", "executed_ids": ["findings-f2"]}, None)]
+           mark_from_backlog(F, {"verdict": "glowup",
+                                 "executed_ids": ["findings-f2", "findings-f404"]},
+                             BACKLOG)] == [False, True, False, False, False])
+    check("declining everything still writes a record, executing nothing",
+          [f["applied"] for f in
+           mark_from_backlog(F, {"verdict": "glowup", "executed_ids": [],
+                                 "declined_ids": ["findings-f2"]}, BACKLOG)]
           == [False] * 5)
     check("the record shape is identical on both paths",
           set(mark_from_backlog(F, {"verdict": "glowup", "executed_ids": []},
@@ -450,13 +494,14 @@ def self_test() -> int:
           mark_from_backlog(SHIFTED, {"verdict": "glowup",
                                       "executed_ids": ["findings-f2"]},
                             BACKLOG)[0]["label"].startswith("Vale filler (L48)"))
-    check("an item whose finding is gone leaves everything deferred",
-          [f["applied"] for f in
-           mark_from_backlog(F[3:], {"verdict": "glowup",
-                                     "executed_ids": ["findings-f2"]}, BACKLOG)]
-          == [False, False])
-    check("an executed id absent from the backlog marks nothing",
-          glow(executed_ids=["findings-f404"]) == [False] * 5)
+    check("an item whose only finding is gone skips the write",
+          mark_from_backlog(F[3:], {"verdict": "glowup",
+                                    "executed_ids": ["findings-f2"]}, BACKLOG) is None)
+    check("an executed id absent from the backlog is not silently ignored",
+          glow(executed_ids=["findings-f404"]) is None)
+    check("a pr-body item alongside a resolving one does not block the write",
+          glow(executed_ids=["findings-f2", "pr19885-findings-1"])
+          == [False, True, False, False, False])
     check("the detail suffix does not break the label match",
           glow(executed_ids=["findings-f3"])
           == [False, False, True, False, False])

--- a/scripts/content-review/record-page-findings.py
+++ b/scripts/content-review/record-page-findings.py
@@ -56,10 +56,10 @@ glow-up carries no `applied[]` by design, so the line-overlap match above finds
 nothing and would file every finding — including everything the glow-up just
 executed — as deferred. Two states mean NO record is written for that run: a
 sentinel carrying neither list, and one whose executed ids ALL fail to resolve
-to a finding here
-(a missing backlog snapshot, or labels that have drifted). Both are the same
-information state — the disposition is unknown — and the all-False record that
-would otherwise be written re-banks everything the glow-up just finished. A
+to a finding here (a missing backlog snapshot, or labels that have drifted).
+Both are the same information state — the disposition is unknown — and the
+all-False record that would otherwise be written re-banks everything the
+glow-up just finished. A
 PARTIAL resolve still writes; so does a glow-up that executed only pr-body
 items, which have no counterpart on this record and are expected to resolve to
 nothing. When the write is skipped the previous record stands, so `reviewed_at`
@@ -234,6 +234,10 @@ def mark_from_backlog(findings: list[dict], verdict: dict | None,
     """
     v = verdict or {}
     if "executed_ids" not in v and "declined_ids" not in v:
+        # Every None return from here warns first — the caller's log line defers
+        # to that, so a silent exit leaves it pointing at nothing.
+        warn("glow-up verdict carries neither executed_ids nor declined_ids; "
+             "disposition unknown")
         return None
     executed = {str(i) for i in (v.get("executed_ids") or [])}
     banked = {str(b.get("id")): b for b in ((backlog or {}).get("banked") or [])
@@ -465,6 +469,23 @@ def self_test() -> int:
     # function stopped making. Writing the all-False record that falls out of
     # that would re-bank the work the glow-up just did, so it takes the same
     # exit as a sentinel carrying no lists at all.
+    # build() logs "disposition unknown (see above)" and defers to this
+    # function for WHICH state it was, so a None return that doesn't warn
+    # leaves the operator reading a pointer to nothing.
+    import contextlib
+    import io
+
+    def none_path_warns(verdict):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            result = mark_from_backlog(F, verdict, BACKLOG)
+        return result is None and "::warning::" in buf.getvalue()
+
+    check("every None return warns first — no id lists at all",
+          none_path_warns({"verdict": "glowup"}))
+    check("every None return warns first — nothing resolved",
+          none_path_warns({"verdict": "glowup", "executed_ids": ["findings-f404"]}))
+
     check("a missing backlog skips the write rather than guessing by position",
           mark_from_backlog(F, {"verdict": "glowup",
                                 "executed_ids": ["findings-f2"]}, None) is None)

--- a/scripts/content-review/record-page-findings.py
+++ b/scripts/content-review/record-page-findings.py
@@ -54,8 +54,9 @@ GLOW-UP RUNS are the exception, and take their disposition from the sentinel's
 `executed_ids`/`declined_ids` instead (`--backlog` supplies the id mapping). A
 glow-up carries no `applied[]` by design, so the line-overlap match above finds
 nothing and would file every finding — including everything the glow-up just
-executed — as deferred. Two states mean NO record is written for that run: a sentinel carrying neither
-list, and a sentinel whose executed ids ALL fail to resolve to a finding here
+executed — as deferred. Two states mean NO record is written for that run: a
+sentinel carrying neither list, and one whose executed ids ALL fail to resolve
+to a finding here
 (a missing backlog snapshot, or labels that have drifted). Both are the same
 information state — the disposition is unknown — and the all-False record that
 would otherwise be written re-banks everything the glow-up just finished. A
@@ -219,12 +220,17 @@ def mark_from_backlog(findings: list[dict], verdict: dict | None,
     `banked_from_findings` builds each item's text as `label` (plus ` — detail`),
     so the label is a prefix of the text and the match is exact, not fuzzy.
 
-    An id that resolves to no finding leaves everything deferred and warns.
+    An id that resolves to no finding leaves everything deferred and warns —
+    unless NONE of the ids that should have resolved did, which is the same
+    information state as a sentinel carrying no lists and takes the same exit.
     That direction is deliberate: re-proposing finished work is irritating and
     visible, while marking the wrong item applied loses real work silently.
 
-    Returns None when the sentinel carries neither list, so the caller can
-    decline to write rather than write an all-false record.
+    Returns None when the disposition is unknown — the sentinel carries neither
+    list, or no executed id that should map to a finding here did — so the
+    caller can decline to write rather than write an all-false record. Ids
+    naming pr-body items don't count towards that: they have no counterpart on
+    this record and are expected to resolve to nothing.
     """
     v = verdict or {}
     if "executed_ids" not in v and "declined_ids" not in v:
@@ -313,9 +319,12 @@ def build(queue: dict, verdict: dict | None, artifacts: dict,
             # just did as still outstanding. Skipping leaves the previous
             # record standing, which is stale but true; the next fix-lane
             # review refreshes it from its own artifacts.
-            warn("glow-up verdict carries no executed_ids/declined_ids; "
-                 "skipping the findings write rather than recording every "
-                 "finding as deferred")
+            # mark_from_backlog already logged WHICH of its two unknown-
+            # disposition states this was; naming one of them here contradicted
+            # the other and sent debugging at the model's sentinel when the real
+            # cause was a missing backlog snapshot.
+            warn("glow-up disposition unknown (see above); skipping the findings "
+                 "write rather than recording every finding as deferred")
             return None
     else:
         marked = mark_applied(findings, verdict)

--- a/scripts/content-review/record-page-findings.py
+++ b/scripts/content-review/record-page-findings.py
@@ -198,10 +198,24 @@ def mark_from_backlog(findings: list[dict], verdict: dict | None,
     finished work. Re-proposing finished work is what erodes trust in the lane.
 
     The disposition already exists — the model writes the Backlog executed /
-    Backlog declined tables from `.glowup-backlog.json`, whose items carry
-    stable ids — so the sentinel reports those id lists rather than anything
-    being inferred here. Record-sourced backlog ids are `findings-<id>`
-    (build-glowup-backlog.py), which maps straight back onto a finding id.
+    Backlog declined tables from `.glowup-backlog.json` — so the sentinel
+    reports those id lists rather than anything being inferred here.
+
+    The ids locate the backlog ITEM; the finding it refers to is then resolved
+    by CONTENT. Finding ids are positional (`f1`, `f2`, ... in collect() order)
+    and a backlog id encodes the id from the PREVIOUS run's record, built over
+    separately collected artifacts. Any shift between the two — an intervening
+    fix-lane review applying a fix and removing its finding, which is the
+    expected case between glow-ups — renumbers everything after it, so old `f2`
+    is new `f1` and an ordinal map would mark the WRONG finding applied. That
+    is this function's own failure mode pointed backwards: the executed item
+    gets re-banked and an untouched one drops out of the backlog for good.
+    `banked_from_findings` builds each item's text as `label` (plus ` — detail`),
+    so the label is a prefix of the text and the match is exact, not fuzzy.
+
+    An id that resolves to no finding leaves everything deferred and warns.
+    That direction is deliberate: re-proposing finished work is irritating and
+    visible, while marking the wrong item applied loses real work silently.
 
     Returns None when the sentinel carries neither list, so the caller can
     decline to write rather than write an all-false record.
@@ -213,28 +227,40 @@ def mark_from_backlog(findings: list[dict], verdict: dict | None,
     banked = {str(b.get("id")): b for b in ((backlog or {}).get("banked") or [])
               if isinstance(b, dict)}
 
-    applied_ids: set[str] = set()
-    for bid in executed:
+    labels = [str(f.get("label") or "").strip() for f in findings]
+    applied_idx: set[int] = set()
+    for bid in sorted(executed):
         item = banked.get(bid)
+        if item is None:
+            warn(f"executed id {bid!r} is not in the backlog; leaving the "
+                 "corresponding finding deferred")
+            continue
         # A pr-body-sourced item is prose recovered from a PR description and
         # has no counterpart on this record, so it can never mark a finding.
         # That gap is exactly what the structured record exists to close.
-        if item is not None and item.get("source") != "findings-record":
+        if item.get("source") != "findings-record":
             continue
-        applied_ids.add(bid.removeprefix("findings-"))
+        text = str(item.get("text") or "").strip()
+        hit = next((i for i, lab in enumerate(labels)
+                    if lab and i not in applied_idx and text.startswith(lab)), None)
+        if hit is None:
+            warn(f"executed backlog item {bid!r} matches no finding on this page "
+                 f"({text[:80]!r}); leaving it deferred rather than marking one "
+                 "by position")
+            continue
+        applied_idx.add(hit)
 
     out = []
     for i, f in enumerate(findings):
-        fid = f"f{i + 1}"
         out.append({
-            "id": fid,
+            "id": f"f{i + 1}",
             "label": f.get("label", ""),
             "source": f.get("source", ""),
             "detail": f.get("detail", ""),
             "category": f.get("category", ""),
             "line_range": f.get("line_range", ""),
             "fix_candidate": bool(f.get("fix")),
-            "applied": fid in applied_ids,
+            "applied": i in applied_idx,
         })
     return out
 
@@ -359,9 +385,14 @@ def self_test() -> int:
     # A glow-up has no applied[], so mark_applied would file everything it
     # just executed as still outstanding, and the next glow-up would
     # re-propose finished work.
+    # Item text is what banked_from_findings() actually writes: the finding's
+    # label, plus " — detail" when there is one. Anything else here would be
+    # testing a shape the lane never produces.
     BACKLOG = {"banked": [
-        {"id": "findings-f2", "source": "findings-record", "text": "Vale filler (L48)"},
-        {"id": "findings-f3", "source": "findings-record", "text": "Vale wordiness (L200)"},
+        {"id": "findings-f2", "source": "findings-record",
+         "text": "Vale filler (L48): Don't start with 'There are'."},
+        {"id": "findings-f3", "source": "findings-record",
+         "text": "Vale wordiness (L200): 'all of' is too wordy. — editorial polish"},
         {"id": "pr19885-findings-1", "source": "pr-body", "text": "Claim (c17) — unverifiable"},
     ]}
 
@@ -390,16 +421,53 @@ def self_test() -> int:
           glow(executed_ids=["findings-f99", "nonsense"]) == [False] * 5)
     check("a pr-body-sourced backlog item cannot mark a record finding",
           glow(executed_ids=["pr19885-findings-1"]) == [False] * 5)
-    check("a missing backlog does not crash the id mapping",
+    # Without the backlog there is nothing to resolve `findings-f2` AGAINST,
+    # and the only way to honour it would be to trust the ordinal — the guess
+    # this function stopped making. Deferring everything is the safe direction.
+    check("a missing backlog marks nothing rather than guessing by position",
           [f["applied"] for f in
            mark_from_backlog(F, {"verdict": "glowup", "executed_ids": ["findings-f2"]}, None)]
-          == [False, True, False, False, False])
+          == [False] * 5)
     check("the record shape is identical on both paths",
           set(mark_from_backlog(F, {"verdict": "glowup", "executed_ids": []},
                                 BACKLOG)[0]) == set(mark_applied(F, None)[0]))
     check("a fix verdict still uses line overlap, untouched",
           applied({"category": "vale", "lines": [48, 48], "source": "vale"})
           == [False, True, False, False, False])
+
+    # Finding ids are positional and the backlog's ids come from the PREVIOUS
+    # run's record. If a fix-lane review removed an earlier finding in between,
+    # old f2 is new f1 — and an ordinal map would mark the wrong item applied,
+    # dropping real work out of the backlog for good.
+    SHIFTED = F[1:]  # the intervening review fixed and removed old f1
+    shifted_marks = [f["applied"] for f in
+                     mark_from_backlog(SHIFTED, {"verdict": "glowup",
+                                                 "executed_ids": ["findings-f2"]},
+                                       BACKLOG)]
+    check("a renumbered finding set still marks the right finding",
+          shifted_marks == [True, False, False, False])
+    check("and it is the one whose label the backlog item names",
+          mark_from_backlog(SHIFTED, {"verdict": "glowup",
+                                      "executed_ids": ["findings-f2"]},
+                            BACKLOG)[0]["label"].startswith("Vale filler (L48)"))
+    check("an item whose finding is gone leaves everything deferred",
+          [f["applied"] for f in
+           mark_from_backlog(F[3:], {"verdict": "glowup",
+                                     "executed_ids": ["findings-f2"]}, BACKLOG)]
+          == [False, False])
+    check("an executed id absent from the backlog marks nothing",
+          glow(executed_ids=["findings-f404"]) == [False] * 5)
+    check("the detail suffix does not break the label match",
+          glow(executed_ids=["findings-f3"])
+          == [False, False, True, False, False])
+    check("two executed ids cannot both claim the same finding",
+          sum(mark_from_backlog(
+              F, {"verdict": "glowup",
+                  "executed_ids": ["findings-f2", "findings-dup"]},
+              {"banked": BACKLOG["banked"] + [
+                  {"id": "findings-dup", "source": "findings-record",
+                   "text": "Vale filler (L48): Don't start with 'There are'."}]},
+          )[i]["applied"] for i in range(5)) == 1)
 
     print(f"\n{passes} passed, {len(failures)} failed")
     return 1 if failures else 0

--- a/scripts/content-review/record-page-findings.py
+++ b/scripts/content-review/record-page-findings.py
@@ -50,6 +50,15 @@ not form a second, looser opinion about it.
 Whole-page snapshot semantics, same as `record-claims.py`: a review sees the
 entire page, so overwriting `<slug>.json` is always correct.
 
+GLOW-UP RUNS are the exception, and take their disposition from the sentinel's
+`executed_ids`/`declined_ids` instead (`--backlog` supplies the id mapping). A
+glow-up carries no `applied[]` by design, so the line-overlap match above finds
+nothing and would file every finding — including everything the glow-up just
+executed — as deferred. A sentinel carrying neither list means NO record is
+written for that run: the previous record then stands, so `reviewed_at` can lag
+the ledger's. That is deliberate. The fix-lane record is the truthful one, and a
+stale-but-true record beats a fresh-but-wrong one that re-proposes finished work.
+
 Usage:
     record-page-findings.py --queue .content-review-queue.json \
         --verdict .content-review-verdict.json --out .page-findings.json \
@@ -176,8 +185,62 @@ def head_commit(repo_root: Path) -> str:
         return ""
 
 
+def mark_from_backlog(findings: list[dict], verdict: dict | None,
+                      backlog: dict | None) -> list[dict] | None:
+    """Flag findings from a GLOW-UP verdict's own disposition, or None.
+
+    A glow-up carries no `applied[]` — the glow-up scope gate replaces the
+    per-hunk check, so there is no line-range attribution to match on, and
+    `mark_applied` therefore flags every finding deferred. That is not a
+    degraded record, it is a WRONG one: the items the glow-up just executed
+    get filed as outstanding, and `build-glowup-backlog.banked_from_findings`
+    banks exactly the `applied: false` items, so the next run re-proposes
+    finished work. Re-proposing finished work is what erodes trust in the lane.
+
+    The disposition already exists — the model writes the Backlog executed /
+    Backlog declined tables from `.glowup-backlog.json`, whose items carry
+    stable ids — so the sentinel reports those id lists rather than anything
+    being inferred here. Record-sourced backlog ids are `findings-<id>`
+    (build-glowup-backlog.py), which maps straight back onto a finding id.
+
+    Returns None when the sentinel carries neither list, so the caller can
+    decline to write rather than write an all-false record.
+    """
+    v = verdict or {}
+    if "executed_ids" not in v and "declined_ids" not in v:
+        return None
+    executed = {str(i) for i in (v.get("executed_ids") or [])}
+    banked = {str(b.get("id")): b for b in ((backlog or {}).get("banked") or [])
+              if isinstance(b, dict)}
+
+    applied_ids: set[str] = set()
+    for bid in executed:
+        item = banked.get(bid)
+        # A pr-body-sourced item is prose recovered from a PR description and
+        # has no counterpart on this record, so it can never mark a finding.
+        # That gap is exactly what the structured record exists to close.
+        if item is not None and item.get("source") != "findings-record":
+            continue
+        applied_ids.add(bid.removeprefix("findings-"))
+
+    out = []
+    for i, f in enumerate(findings):
+        fid = f"f{i + 1}"
+        out.append({
+            "id": fid,
+            "label": f.get("label", ""),
+            "source": f.get("source", ""),
+            "detail": f.get("detail", ""),
+            "category": f.get("category", ""),
+            "line_range": f.get("line_range", ""),
+            "fix_candidate": bool(f.get("fix")),
+            "applied": fid in applied_ids,
+        })
+    return out
+
+
 def build(queue: dict, verdict: dict | None, artifacts: dict,
-          repo_root: Path) -> dict | None:
+          repo_root: Path, backlog: dict | None = None) -> dict | None:
     articles = queue.get("articles") or []
     if not articles:
         warn("queue has no article; nothing to record")
@@ -187,7 +250,19 @@ def build(queue: dict, verdict: dict | None, artifacts: dict,
     findings, _errors = cpb.collect(
         artifacts.get("verified"), artifacts.get("vale"),
         artifacts.get("readthrough"), artifacts.get("frontmatter"))
-    marked = mark_applied(findings, verdict)
+    if (verdict or {}).get("verdict") == "glowup":
+        marked = mark_from_backlog(findings, verdict, backlog)
+        if marked is None:
+            # Writing an all-false record here would file the work the glow-up
+            # just did as still outstanding. Skipping leaves the previous
+            # record standing, which is stale but true; the next fix-lane
+            # review refreshes it from its own artifacts.
+            warn("glow-up verdict carries no executed_ids/declined_ids; "
+                 "skipping the findings write rather than recording every "
+                 "finding as deferred")
+            return None
+    else:
+        marked = mark_applied(findings, verdict)
     n_applied = sum(1 for f in marked if f["applied"])
     return {
         "schema_version": SCHEMA_VERSION,
@@ -280,6 +355,52 @@ def self_test() -> int:
     check("deferred findings are recorded, not dropped",
           len(mark_applied(F, None)) == 5)
 
+    # --- glow-up disposition -------------------------------------------
+    # A glow-up has no applied[], so mark_applied would file everything it
+    # just executed as still outstanding, and the next glow-up would
+    # re-propose finished work.
+    BACKLOG = {"banked": [
+        {"id": "findings-f2", "source": "findings-record", "text": "Vale filler (L48)"},
+        {"id": "findings-f3", "source": "findings-record", "text": "Vale wordiness (L200)"},
+        {"id": "pr19885-findings-1", "source": "pr-body", "text": "Claim (c17) — unverifiable"},
+    ]}
+
+    def glow(**kw):
+        v = {"verdict": "glowup", "fixes": 1, "skipped_findings": 1, **kw}
+        marked = mark_from_backlog(F, v, BACKLOG)
+        return None if marked is None else [f["applied"] for f in marked]
+
+    check("the old line-overlap path would have filed executed work as deferred",
+          [f["applied"] for f in mark_applied(F, {"verdict": "glowup", "fixes": 1})]
+          == [False] * 5)
+    check("executed backlog ids mark their findings applied",
+          glow(executed_ids=["findings-f2"], declined_ids=["findings-f3"])
+          == [False, True, False, False, False])
+    check("declined backlog ids stay deferred",
+          glow(executed_ids=[], declined_ids=["findings-f2", "findings-f3"])
+          == [False] * 5)
+    check("several executed ids all land",
+          glow(executed_ids=["findings-f2", "findings-f3"])
+          == [False, True, True, False, False])
+    check("a sentinel with neither list records nothing at all",
+          glow() is None and mark_from_backlog(F, {"verdict": "glowup"}, BACKLOG) is None)
+    check("an empty backlog is still a disposition, not a missing one",
+          glow(executed_ids=[], declined_ids=[]) == [False] * 5)
+    check("an executed id with no matching finding is ignored, not crashed on",
+          glow(executed_ids=["findings-f99", "nonsense"]) == [False] * 5)
+    check("a pr-body-sourced backlog item cannot mark a record finding",
+          glow(executed_ids=["pr19885-findings-1"]) == [False] * 5)
+    check("a missing backlog does not crash the id mapping",
+          [f["applied"] for f in
+           mark_from_backlog(F, {"verdict": "glowup", "executed_ids": ["findings-f2"]}, None)]
+          == [False, True, False, False, False])
+    check("the record shape is identical on both paths",
+          set(mark_from_backlog(F, {"verdict": "glowup", "executed_ids": []},
+                                BACKLOG)[0]) == set(mark_applied(F, None)[0]))
+    check("a fix verdict still uses line overlap, untouched",
+          applied({"category": "vale", "lines": [48, 48], "source": "vale"})
+          == [False, True, False, False, False])
+
     print(f"\n{passes} passed, {len(failures)} failed")
     return 1 if failures else 0
 
@@ -292,6 +413,9 @@ def main() -> int:
     p.add_argument("--vale-findings", default=".vale-findings.json")
     p.add_argument("--readthrough", default=".readthrough-findings.json")
     p.add_argument("--frontmatter", default=".frontmatter-validation.json")
+    p.add_argument("--backlog", default="",
+                   help="the glow-up work list (.glowup-backlog.json); supplies the "
+                        "id -> finding mapping for a glow-up verdict's disposition")
     p.add_argument("--repo-root", default=".")
     p.add_argument("--out", default=".page-findings.json")
     p.add_argument("--uri", default="", help="s3://bucket/findings/ (skipped when empty)")
@@ -310,7 +434,8 @@ def main() -> int:
          "vale": read_json(Path(args.vale_findings)),
          "readthrough": read_json(Path(args.readthrough)),
          "frontmatter": read_json(Path(args.frontmatter))},
-        Path(args.repo_root))
+        Path(args.repo_root),
+        backlog=read_json(Path(args.backlog)) if args.backlog else None)
     if record is None:
         return 0
     Path(args.out).write_text(json.dumps(record, indent=2) + "\n")

--- a/scripts/content-review/record-page-findings.py
+++ b/scripts/content-review/record-page-findings.py
@@ -77,7 +77,9 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import importlib.util
+import io
 import json
 import subprocess
 import sys
@@ -469,12 +471,16 @@ def self_test() -> int:
     # function stopped making. Writing the all-False record that falls out of
     # that would re-bank the work the glow-up just did, so it takes the same
     # exit as a sentinel carrying no lists at all.
-    # build() logs "disposition unknown (see above)" and defers to this
-    # function for WHICH state it was, so a None return that doesn't warn
-    # leaves the operator reading a pointer to nothing.
-    import contextlib
-    import io
+    check("a missing backlog skips the write rather than guessing by position",
+          mark_from_backlog(F, {"verdict": "glowup",
+                                "executed_ids": ["findings-f2"]}, None) is None)
+    check("...and so does an executed set where nothing resolves",
+          mark_from_backlog(F, {"verdict": "glowup",
+                                "executed_ids": ["findings-f404"]}, BACKLOG) is None)
 
+    # build() logs "disposition unknown (see above)" and defers to this function
+    # for WHICH state it was, so a None return that doesn't warn leaves the
+    # operator reading a pointer to nothing.
     def none_path_warns(verdict):
         buf = io.StringIO()
         with contextlib.redirect_stderr(buf):
@@ -485,13 +491,6 @@ def self_test() -> int:
           none_path_warns({"verdict": "glowup"}))
     check("every None return warns first — nothing resolved",
           none_path_warns({"verdict": "glowup", "executed_ids": ["findings-f404"]}))
-
-    check("a missing backlog skips the write rather than guessing by position",
-          mark_from_backlog(F, {"verdict": "glowup",
-                                "executed_ids": ["findings-f2"]}, None) is None)
-    check("...and so does an executed set where nothing resolves",
-          mark_from_backlog(F, {"verdict": "glowup",
-                                "executed_ids": ["findings-f404"]}, BACKLOG) is None)
     check("a PARTIAL resolve still writes — those findings are genuinely known",
           [f["applied"] for f in
            mark_from_backlog(F, {"verdict": "glowup",


### PR DESCRIPTION
### Proposed changes

Unit 2 of 3 from the #20984 investigation. **Stacked on #21002** (it edits the same glow-up sentinel spec, so it targets that branch; GitHub will retarget to `master` when #21002 merges).

`record-page-findings.py` decides `applied` by overlapping each finding's line range against the verdict's `applied[]`. A glow-up verdict has no `applied[]` — by design, since `verify-glowup-scope.py` replaces the per-hunk check with whole-page bounds and there is no per-fix attribution to record. So `spans` is empty, every finding is written `applied: false`, and the record now claims the work the glow-up just finished is still outstanding.

`build-glowup-backlog.banked_from_findings()` banks exactly the `applied: false` items, so the next glow-up re-proposes work that already landed — which that function's own docstring names as the thing that erodes trust in the lane.

The disposition already exists and did not need inferring. The model partitions `.glowup-backlog.json` into the Backlog executed and Backlog declined tables, and those items carry stable ids; the sentinel now reports that partition as `executed_ids` / `declined_ids`, and `mark_from_backlog()` maps them back onto findings (`findings-<id>` → `<id>`). A pr-body-sourced backlog item is prose recovered from a PR description with no counterpart on the record, so it can never mark one — there's a test pinning that.

A glow-up sentinel carrying neither list writes **no record for the run** rather than an all-false one. The previous record stands — stale but true, refreshed by the next fix-lane review from its own artifacts — which beats a fresh record that is wrong in the one direction that costs reviewer trust. That means a glow-up run's findings `reviewed_at` can lag the ledger's; the docstring says so explicitly so nobody "fixes" it later.

Rejected: synthesizing `applied[]` from the glow-up diff. It would recreate the per-hunk attribution the glow-up gate deliberately avoids, and guessing is how the first cut of this file shipped the substring-matching bug (fixed in #20990).

The sentinel schema change lands here in both places it's specified — `SKILL.md` and the workflow prompt — or the model never emits the lists and the skip path fires on every glow-up. The fix-lane path is untouched, with a regression test asserting it still uses line overlap.

Verification: `make test-review-pipeline` and `make lint` pass (1845 files parsed, 0 errors; Prettier clean).

### Unreleased product version (optional)

n/a — automation only, no user-facing content.

### Related issues (optional)

Stacked on #21002. Follows up on #20984; the line-overlap matching this special-cases came from #20990.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx3iwUddA9pNZQ4ReDiadT)_