### PR TITLE
content-review: recover a page's banked backlog by head ref, and stop lying when it fails

### DIFF
--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -85,6 +85,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      # build-glowup-backlog.py reads every prior review PR for the page by
+      # head ref. Read-only, and the job still holds no push token.
+      pull-requests: read
     outputs:
       claude_outcome: ${{ steps.claude.outcome }}
     steps:

--- a/scripts/content-review/build-glowup-backlog.py
+++ b/scripts/content-review/build-glowup-backlog.py
@@ -16,17 +16,33 @@ backlog rather than a cold read:
                  "source_pr": 123, "text": "<the row/bullet>"}, ...],
      "notes": ["<degradation notes, if any>"]}
 
-Sources: the page's ledger entry (`--ledger-dir`) carries the latest review's
-`pr_number`; earlier PRs for the same page are discovered via `gh pr list`
-over the page's canonical branch names is NOT possible (branches are reused),
-so the backlog reads the PRs the ledger knows about — currently the latest —
-plus any extras passed via `--pr` (the workflow may pass several). Section
-extraction is heading-based and tolerant: a PR body without the section, an
-unreachable PR, or no PRs at all degrade to an empty `banked` list with a
-note — the skill then runs its taxonomy-only sweep.
+Sources, in order of authority:
 
-`--pr-json <file|->` injects PR view fixtures for tests (a JSON list of
-{number, url, body}), replacing every `gh` call.
+1. The structured findings record (`record-page-findings.py`), when the page has
+   one. Forward-only: pages last reviewed before 2026-08-19 have none.
+2. Every prior review PR for the page, found by HEAD REF. An earlier version of
+   this file asserted that reused branch names made older PRs undiscoverable, and
+   so read only the pointer the ledger happened to carry. That was wrong, and it
+   is why #20984 recovered nothing: `gh pr list --head <branch> --state all`
+   returns every PR that branch has ever carried, closed and merged included
+   (`content-review/docs-iac-concepts-providers` returns #20953, #20927 and
+   #20503). All three canonical heads are queried — fix, retire and glow-up —
+   because a prior glow-up's "Backlog declined" rows are debt too: they are what
+   `record-review.py` counts into `skipped_findings`, and the selector re-picks
+   the page on that number, so the backlog has to be able to name it.
+3. The ledger/queue PR pointer and any `--pr` extras, as defence in depth.
+
+Section extraction is heading-based, tolerant, and lane-aware — a glow-up PR body
+uses different headings from a fix PR's. Recovery never fails the run: the
+`recovery` block records which of four outcomes happened (`recovered`,
+`no_prior_prs`, `gh_unavailable`, `prs_carried_nothing`) and the skill falls back
+to its taxonomy-only sweep. When the ledger says findings were banked and none
+could be recovered, the backlog is stamped `degraded` and a `::warning::` is
+emitted — a silently empty backlog reads exactly like a clean page, which is how
+#20984 shipped a PR announcing it had nothing to do while 17 findings waited.
+
+`--pr-json <file|->` injects the discovered PR set for tests (a JSON list of
+{number, url, body, headRefName}), replacing every `gh` call.
 
 Self-contained smoke checks: `python3 build-glowup-backlog.py --self-test`.
 """
@@ -43,9 +59,17 @@ from pathlib import Path
 
 SCHEMA_VERSION = 1
 
+BRANCH_PREFIX = "content-review/"
+
 # The banked sections, in the order they appear in the fix-lane PR body
 # (compose-pr-body.py). "Fixes applied" is deliberately absent — those landed.
-BANKED_SECTIONS = ("Findings not applied", "Screenshot check", "Rendered content")
+FIX_BANKED_SECTIONS = ("Findings not applied", "Screenshot check", "Rendered content")
+# A glow-up PR body uses its own headings. "Backlog executed" is absent for the
+# same reason "Fixes applied" is: that work landed. "Backlog declined" is the
+# debt — the count record-review.py writes into skipped_findings, which is what
+# re-selects the page, so it has to be recoverable or the counter is unbacked.
+GLOWUP_BANKED_SECTIONS = ("Backlog declined", "Screenshot check")
+BANKED_SECTIONS = FIX_BANKED_SECTIONS  # back-compat alias
 
 # Section content that means "nothing banked here" — composer pre-fills and
 # reviewer boilerplate, not findings.
@@ -62,7 +86,26 @@ def warn(msg: str) -> None:
     print(f"::warning::build-glowup-backlog: {msg}", file=sys.stderr)
 
 
-def extract_sections(body: str) -> dict[str, list[str]]:
+def heads_for(slug: str) -> list[str]:
+    """The three canonical branch names a review of this page can have used."""
+    return [f"{BRANCH_PREFIX}{slug}",
+            f"{BRANCH_PREFIX}retire-{slug}",
+            f"{BRANCH_PREFIX}glowup-{slug}"]
+
+
+def sections_for(head: str) -> tuple[str, ...]:
+    """The banked-section vocabulary of the lane that opened this PR.
+
+    Keyed off the head ref rather than guessed from the body: the branch name
+    is what the publish job derived the lane from in the first place.
+    """
+    return (GLOWUP_BANKED_SECTIONS if head.startswith(f"{BRANCH_PREFIX}glowup-")
+            else FIX_BANKED_SECTIONS)
+
+
+def extract_sections(body: str,
+                     wanted: tuple[str, ...] = FIX_BANKED_SECTIONS
+                     ) -> dict[str, list[str]]:
     """Per banked section, the non-noise content lines (rows/bullets/prose)."""
     sections: dict[str, list[str]] = {}
     current: str | None = None
@@ -71,7 +114,7 @@ def extract_sections(body: str) -> dict[str, list[str]]:
         m = re.match(r"^##\s+(.*)$", line)
         if m:
             title = m.group(1).strip()
-            current = title if title in BANKED_SECTIONS else None
+            current = title if title in wanted else None
             continue
         if current is None or not line:
             continue
@@ -99,6 +142,93 @@ def fetch_pr(number: int) -> dict | None:
     except json.JSONDecodeError:
         warn(f"gh pr view {number} returned unparseable JSON")
         return None
+
+
+def prs_for_head(head: str) -> list[dict] | None:
+    """Every PR that has ever used this head ref, or None if the query failed.
+
+    None and [] are deliberately distinct: "GitHub would not answer" and "this
+    page has never been reviewed" degrade the same way but are not the same
+    fact, and collapsing them is what made #20984's PR body describe a lookup
+    failure that never happened.
+    """
+    proc = subprocess.run(
+        ["gh", "pr", "list", "--head", head, "--state", "all", "--limit", "50",
+         "--json", "number,url,body,headRefName,createdAt"],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        warn(f"gh pr list --head {head} failed: {proc.stderr.strip()[:200]}")
+        return None
+    try:
+        found = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        warn(f"gh pr list --head {head} returned unparseable JSON")
+        return None
+    return [p for p in found if isinstance(p, dict)]
+
+
+def discover_prs(slug: str, extra_numbers: list[int],
+                 pr_json: str | None) -> tuple[list[dict], dict]:
+    """Every prior review PR for this page, plus how the search went.
+
+    `pr_json` injects the discovered set for tests and suppresses every `gh`
+    call — the property the whole self-test suite depends on.
+    """
+    heads = heads_for(slug)
+    recovery = {"heads_queried": heads, "prs_found": 0, "prs_unreachable": [],
+                "prs_without_sections": [], "state": "no_prior_prs"}
+
+    if pr_json is not None:
+        raw = sys.stdin.read() if pr_json == "-" else Path(pr_json).read_text()
+        prs = [p for p in json.loads(raw or "[]") if isinstance(p, dict)]
+        recovery["prs_found"] = len(prs)
+        recovery["state"] = "recovered" if prs else "no_prior_prs"
+        return prs, recovery
+
+    seen: set[int] = set()
+    prs: list[dict] = []
+    failed_heads = 0
+    for head in heads:
+        found = prs_for_head(head)
+        if found is None:
+            failed_heads += 1
+            recovery["prs_unreachable"].append(head)
+            continue
+        for pr in found:
+            n = int(pr.get("number") or 0)
+            if n and n not in seen:
+                seen.add(n)
+                prs.append(pr)
+    # Defence in depth: the ledger/queue pointer and any --pr extras. After the
+    # head query these are nearly always redundant, which is the point — the
+    # pointer is the thing that kept going missing.
+    for n in extra_numbers:
+        if n in seen:
+            continue
+        pr = fetch_pr(n)
+        if pr is None:
+            recovery["prs_unreachable"].append(f"#{n}")
+        else:
+            seen.add(n)
+            prs.append(pr)
+
+    # Belt and braces: a PR that arrives without a body would extract zero
+    # sections and be indistinguishable from one that genuinely banked nothing,
+    # so fetch it individually rather than let it read as an empty backlog.
+    for pr in prs:
+        if not pr.get("body"):
+            full = fetch_pr(int(pr.get("number") or 0))
+            if full and full.get("body"):
+                pr["body"] = full["body"]
+
+    prs.sort(key=lambda p: int(p.get("number") or 0))
+    recovery["prs_found"] = len(prs)
+    if prs:
+        recovery["state"] = "recovered"
+    elif failed_heads == len(heads):
+        recovery["state"] = "gh_unavailable"
+    return prs, recovery
 
 
 def load_entry(ledger_dir: Path, slug: str) -> dict:
@@ -147,7 +277,8 @@ def banked_from_findings(record: dict | None) -> list[dict]:
 
 
 def build(article: dict, entry: dict, prs: list[dict],
-          findings_record: dict | None = None) -> dict:
+          findings_record: dict | None = None,
+          recovery: dict | None = None) -> dict:
     backlog = {
         "schema_version": SCHEMA_VERSION,
         "slug": article.get("slug"),
@@ -159,6 +290,9 @@ def build(article: dict, entry: dict, prs: list[dict],
         "source_prs": [],
         "banked": [],
         "notes": [],
+        # True when the ledger says findings were banked and none could be
+        # recovered. Always present so a consumer can rely on the key.
+        "degraded": False,
     }
     # Structured record first. The PR-body scrape still runs and is still
     # merged in: it is the only place the model's one-line REASON for deferring
@@ -175,28 +309,81 @@ def build(article: dict, entry: dict, prs: list[dict],
             "counts": (findings_record or {}).get("counts"),
         }
 
+    recovery = dict(recovery or {"heads_queried": [], "prs_found": len(prs),
+                                 "prs_unreachable": [], "prs_without_sections": [],
+                                 "state": "recovered" if prs else "no_prior_prs"})
+    recovery["prs_without_sections"] = []
+
     for pr in prs:
         number = int(pr.get("number") or 0)
-        backlog["source_prs"].append({"number": number, "url": pr.get("url")})
-        sections = extract_sections(pr.get("body") or "")
-        for section in BANKED_SECTIONS:
+        head = str(pr.get("headRefName") or "")
+        backlog["source_prs"].append({"number": number, "url": pr.get("url"),
+                                      "head": head})
+        wanted = sections_for(head)
+        sections = extract_sections(pr.get("body") or "", wanted)
+        before = len(backlog["banked"])
+        for section in wanted:
+            declined = section == "Backlog declined"
             for i, text in enumerate(sections.get(section, []), start=1):
-                backlog["banked"].append({
+                item = {
                     "id": f"pr{number}-{section.lower().split()[0]}-{i}",
                     "section": section,
                     "source_pr": number,
-                    "source": "pr-body",
+                    # A previously-declined item is re-banked, not dropped —
+                    # dropping it makes debt vanish silently, which is the bug
+                    # class this file exists to close — but it is tagged so the
+                    # model knows it was already turned down once and a human
+                    # can see a decline loop forming.
+                    "source": "glowup-declined" if declined else "pr-body",
                     "text": text,
-                })
-    if structured and not prs:
-        pass  # the record alone is a complete backlog; no degradation note
-    elif not prs:
-        backlog["notes"].append(
-            "no prior review PRs reachable; run the taxonomy-only sweep")
-    elif not backlog["banked"]:
-        backlog["notes"].append(
-            "prior PR bodies carried no banked findings; run the taxonomy-only sweep")
+                }
+                if declined:
+                    item["declined_by_pr"] = number
+                backlog["banked"].append(item)
+        if len(backlog["banked"]) == before:
+            recovery["prs_without_sections"].append(number)
+
+    if backlog["banked"]:
+        if recovery["state"] != "gh_unavailable":
+            recovery["state"] = "recovered"
+    elif prs:
+        recovery["state"] = "prs_carried_nothing"
+
+    backlog["recovery"] = recovery
+    if not backlog["banked"]:
+        backlog["notes"].append(_recovery_note(recovery))
+        # The ledger's counters ARE the selection criterion, so a page selected
+        # for 17 banked findings that recovers none is self-contradictory. It
+        # used to pass through three programs without a word, and the PR then
+        # announced a taxonomy-only glow-up as though the page were clean.
+        if backlog["skipped_findings"] > 0 or backlog["clarity_flag"]:
+            backlog["degraded"] = True
+            warn(f"ledger records {backlog['skipped_findings']} banked finding(s)"
+                 f"{' and a clarity flag' if backlog['clarity_flag'] else ''} for "
+                 f"{backlog['slug']}, but none could be recovered "
+                 f"({recovery['state']}) — this glow-up is taxonomy-only")
     return backlog
+
+
+def _recovery_note(recovery: dict) -> str:
+    """One sentence naming which recovery outcome happened.
+
+    Four states, four sentences. The single collapsed note these replace said
+    "no prior review PRs reachable" for all of them, including the case where
+    no lookup was attempted at all — sending anyone who read it looking for an
+    API failure instead of a missing pointer.
+    """
+    state = recovery.get("state")
+    heads = ", ".join(recovery.get("heads_queried") or []) or "none"
+    tail = "; run the taxonomy-only sweep"
+    if state == "gh_unavailable":
+        return (f"GitHub would not answer for any of {heads}, so prior review PRs "
+                f"could not be read{tail}")
+    if state == "prs_carried_nothing":
+        found = ", ".join(f"#{n}" for n in recovery.get("prs_without_sections") or [])
+        return (f"reviewed {recovery.get('prs_found', 0)} prior PR(s) ({found}); "
+                f"none carried banked sections{tail}")
+    return f"no review PR has ever used {heads}{tail}"
 
 
 def run(args) -> int:
@@ -211,8 +398,11 @@ def run(args) -> int:
     numbers: list[int] = []
     # Ledger entry when a cache is present (dispatcher-side runs); the queue
     # article's carried pointer otherwise (the worker has no ledger cache —
-    # select-glowup.py stamps source_pr_number for exactly this).
-    for n in (entry.get("pr_number"), article.get("source_pr_number")):
+    # select-glowup.py stamps source_pr_number for exactly this). `last_pr_number`
+    # is record-review.py's durable pointer, which survives a review that opened
+    # no PR; `pr_number` is only set when that review opened one.
+    for n in (entry.get("pr_number"), entry.get("last_pr_number"),
+              article.get("source_pr_number")):
         if n and int(n) not in numbers:
             numbers.append(int(n))
     for extra in args.pr or []:
@@ -220,12 +410,7 @@ def run(args) -> int:
         if n not in numbers:
             numbers.append(n)
 
-    if args.pr_json:
-        raw = sys.stdin.read() if args.pr_json == "-" else Path(args.pr_json).read_text()
-        fixtures = {int(p["number"]): p for p in json.loads(raw)}
-        prs = [fixtures[n] for n in numbers if n in fixtures]
-    else:
-        prs = [pr for n in numbers if (pr := fetch_pr(n))]
+    prs, recovery = discover_prs(article.get("slug") or "", numbers, args.pr_json)
 
     # The queue article carries the record when the dispatcher had S3 access
     # (select-glowup.py stamps it); --findings-dir covers a dispatcher-side or
@@ -242,11 +427,17 @@ def run(args) -> int:
             log(f"no findings record at {fr}; PR-body scrape only "
                 f"(expected for pages last reviewed before the record existed)")
 
-    backlog = build(article, entry, prs, findings_record)
+    backlog = build(article, entry, prs, findings_record, recovery)
     Path(args.out).write_text(json.dumps(backlog, indent=2) + "\n")
     log(f"{len(backlog['banked'])} banked finding(s) from "
-        f"{len(backlog['source_prs'])} PR(s) -> {args.out}")
-    return 0
+        f"{len(backlog['source_prs'])} PR(s) "
+        f"[{backlog['recovery']['state']}] -> {args.out}")
+    # Fail-open by default: the review job is unprivileged, a red X here reads
+    # as "the lane is broken" when the true state is "the evidence is out of
+    # reach", and record-review.py now preserves the backlog either way, so a
+    # degraded run costs a slot rather than the data. --strict exists so the
+    # workflow can be flipped fail-closed without another change here.
+    return 2 if (args.strict and backlog["degraded"]) else 0
 
 
 def self_test() -> int:
@@ -344,6 +535,116 @@ def self_test() -> int:
     check("PR without banked sections degrades with a note",
           blank["banked"] == [] and any("taxonomy-only" in n for n in blank["notes"]))
 
+    # --- lane-aware section vocabulary ---------------------------------
+    heads = heads_for("docs-x")
+    check("all three canonical heads are queried",
+          heads == ["content-review/docs-x", "content-review/retire-docs-x",
+                    "content-review/glowup-docs-x"])
+    check("the glow-up head selects the glow-up vocabulary",
+          sections_for("content-review/glowup-docs-x") == GLOWUP_BANKED_SECTIONS
+          and sections_for("content-review/docs-x") == FIX_BANKED_SECTIONS
+          and sections_for("content-review/retire-docs-x") == FIX_BANKED_SECTIONS)
+
+    glow_body = "\n".join([
+        "## Backlog executed",
+        "| already fixed | #1 | done |",
+        "",
+        "## Backlog declined",
+        "- **Claim (c9)** — needs an SME",
+        "- **Vale weasel (L472)** — accurate as written",
+        "",
+        "## Secondary sweep",
+        "- **Style improvements**: none",
+    ])
+    gpr = [{"number": 20984, "url": "u", "headRefName": "content-review/glowup-docs-x",
+            "body": glow_body}]
+    gback = build(article, entry, gpr)
+    check("a glow-up PR's declined items are banked",
+          len(gback["banked"]) == 2)
+    check("they are tagged so the model knows they were turned down once",
+          all(b["source"] == "glowup-declined" and b["declined_by_pr"] == 20984
+              for b in gback["banked"]))
+    check("a glow-up PR's EXECUTED items are never re-banked",
+          all("already fixed" not in b["text"] for b in gback["banked"]))
+    check("fix-lane sections are not read out of a glow-up PR",
+          build(article, entry, [{"number": 1, "url": "u",
+                                  "headRefName": "content-review/glowup-docs-x",
+                                  "body": "## Findings not applied\n- x\n"}])["banked"] == [])
+    check("glow-up sections are not read out of a fix PR",
+          build(article, entry, [{"number": 1, "url": "u",
+                                  "headRefName": "content-review/docs-x",
+                                  "body": "## Backlog declined\n- x\n"}])["banked"] == [])
+    check("a PR with no head ref falls back to the fix vocabulary",
+          len(build(article, entry, [{"number": 1, "url": "u",
+                                      "body": "## Findings not applied\n- x\n"}]
+                    )["banked"]) == 1)
+
+    # --- recovery states: four outcomes, four distinct notes ------------
+    def state_of(prs, rec=None, art=None):
+        return build(art or article, {}, prs, None, rec)
+
+    none_ever = state_of([], {"heads_queried": heads, "prs_found": 0,
+                              "prs_unreachable": [], "prs_without_sections": [],
+                              "state": "no_prior_prs"})
+    gh_down = state_of([], {"heads_queried": heads, "prs_found": 0,
+                            "prs_unreachable": heads, "prs_without_sections": [],
+                            "state": "gh_unavailable"})
+    carried_nothing = state_of([{"number": 5, "url": "u",
+                                 "headRefName": "content-review/docs-x",
+                                 "body": "## Why this page\nx"}])
+    states = [none_ever["recovery"]["state"], gh_down["recovery"]["state"],
+              carried_nothing["recovery"]["state"]]
+    check("the three empty outcomes are distinguished, not collapsed",
+          states == ["no_prior_prs", "gh_unavailable", "prs_carried_nothing"])
+    check("each carries its own note",
+          len({none_ever["notes"][0], gh_down["notes"][0],
+               carried_nothing["notes"][0]}) == 3)
+    check("the gh-failure note says GitHub would not answer",
+          "would not answer" in gh_down["notes"][0])
+    check("the never-reviewed note does not claim a lookup failed",
+          "no review PR has ever used" in none_ever["notes"][0]
+          and "unreachable" not in none_ever["notes"][0])
+    check("prs_carried_nothing names the PRs it read",
+          "#5" in carried_nothing["notes"][0])
+    check("a recovered backlog reports recovered",
+          gback["recovery"]["state"] == "recovered")
+
+    # --- the #20984 contradiction --------------------------------------
+    debt = {"skipped_findings": 17, "clarity_flag": True}
+    stranded = build(article, debt, [], None,
+                     {"heads_queried": heads, "prs_found": 0, "prs_unreachable": [],
+                      "prs_without_sections": [], "state": "no_prior_prs"})
+    check("#20984: debt with an empty backlog is flagged degraded",
+          stranded["degraded"] is True and stranded["banked"] == [])
+    check("#20984: the counters ride along so the composer can name them",
+          stranded["skipped_findings"] == 17 and stranded["clarity_flag"] is True)
+    check("no debt and no backlog is NOT degraded",
+          build(article, {"skipped_findings": 0}, [])["degraded"] is False)
+    check("a clarity flag alone is enough to count as debt",
+          build(article, {"skipped_findings": 0, "clarity_flag": True},
+                [])["degraded"] is True)
+    check("debt that DID recover is not degraded",
+          build(article, debt, gpr)["degraded"] is False)
+    check("degraded is always present, even on the happy path",
+          "degraded" in gback and "recovery" in gback)
+
+    # The property every test above depends on: fixtures mean zero gh calls.
+    import unittest.mock as _mock
+    with _mock.patch.object(subprocess, "run",
+                            side_effect=AssertionError("subprocess called")):
+        fx = Path(__file__).parent / ".selftest-prs.json"
+        fx.write_text(json.dumps(gpr))
+        try:
+            prs, rec = discover_prs("docs-x", [123], str(fx))
+            check("--pr-json performs zero subprocess calls",
+                  len(prs) == 1 and rec["state"] == "recovered")
+            fx.write_text("[]")
+            _, rec_empty = discover_prs("docs-x", [123], str(fx))
+            check("an empty fixture set reads as no_prior_prs, not a failure",
+                  rec_empty["state"] == "no_prior_prs")
+        finally:
+            fx.unlink(missing_ok=True)
+
     if failures:
         print(f"\n{len(failures)} failure(s)", file=sys.stderr)
         return 1
@@ -364,6 +665,9 @@ def main() -> int:
     p.add_argument("--findings-dir", default="",
                    help="synced findings/ prefix; the structured spine, "
                         "preferred over scraping PR bodies")
+    p.add_argument("--strict", action="store_true",
+                   help="exit 2 when the ledger says findings were banked and none "
+                        "could be recovered (default: warn and continue)")
     p.add_argument("--out", default=".glowup-backlog.json")
     p.add_argument("--self-test", action="store_true", help="run built-in smoke checks")
     args = p.parse_args()

--- a/scripts/content-review/build-glowup-backlog.py
+++ b/scripts/content-review/build-glowup-backlog.py
@@ -77,6 +77,24 @@ NOISE_LINES = {
     "no images.", "skipped.", "none.", "n/a", "-", "—",
 }
 
+# The same thing, matched as a PREFIX. Exact-line matching was enough while
+# nothing was ever recovered; the first live run against a real page showed why
+# it isn't — the composer's pre-fills and the model's nothing-here lines all
+# CONTINUE past the phrase ("No images. The page source references no
+# screenshots...", "None — the backlog was empty (...)", "Skipped — the page
+# source uses only render-safe chrome..."), so every one of them was banked as
+# a finding for the model to dutifully decline.
+NOISE_PREFIX_RE = re.compile(
+    r"^[-*+_\s|]*(no images|none|n/?a|skipped|"
+    r"nothing judgment-level was pre-found)\b", re.I)
+
+# The composer closes "Findings not applied" with a routing trailer telling a
+# human where the deferrals go. Its wording has changed over the lane's life
+# ("For the judgment-level items above, run ..." became "The items above are
+# banked ..."), so match the invariant rather than either phrasing: it is the
+# line that points at the /glow-up command instead of describing a finding.
+TRAILER_RE = re.compile(r"`?/glow-up\s+content/", re.I)
+
 
 def log(msg: str) -> None:
     print(f"build-glowup-backlog: {msg}", file=sys.stderr)
@@ -124,6 +142,8 @@ def extract_sections(body: str,
         if re.fullmatch(r"\|?[\s|:-]+\|?", line):
             continue
         if line.lower().rstrip("_* ").lstrip("_* ") in NOISE_LINES:
+            continue
+        if NOISE_PREFIX_RE.match(line) or TRAILER_RE.search(line):
             continue
         sections.setdefault(current, []).append(line)
     return sections
@@ -483,6 +503,53 @@ def self_test() -> int:
           not sections.get("Screenshot check") and not sections.get("Rendered content"))
     check("fixes/verification never banked",
           "Fixes applied" not in sections and "Verification" not in sections)
+
+    # --- boilerplate is not a finding ----------------------------------
+    # Exact-line noise matching was enough while nothing was ever recovered.
+    # The first live run against a real page (#19885) banked 5 boilerplate
+    # lines out of 13, each of which the model would have had to execute or
+    # decline in the PR body's tables.
+    real = "- **Vale cliché (L710): avoid clichés like 'a clean slate'.** — Stylistic."
+    noisy = "\n".join([
+        "## Findings not applied",
+        real,
+        "For the judgment-level items above, run "
+        "`/glow-up content/docs/iac/get-started/kubernetes/create-component.md`.",
+        "The items above are banked for the automated glow-up lane, which executes a "
+        "page's accumulated deferrals under human review — or run "
+        "`/glow-up content/docs/x.md` to work them now.",
+        "- _Nothing judgment-level was pre-found. Add any finding you chose not to apply._",
+        "",
+        "## Screenshot check",
+        "No images. The page source references no screenshots, diagrams, or other content "
+        "images (only the generic shared `meta_image` card, if any), so there is nothing "
+        "to verify. _(Determined from the source; the screenshot pass was skipped.)_",
+        "",
+        "## Rendered content",
+        "Skipped — the page source uses only render-safe chrome (`choosable`), so the "
+        "rendered HTML carries no content beyond the source prose. "
+        "_(Determined from the source.)_",
+    ])
+    noisy_sections = extract_sections(noisy)
+    check("the composer's /glow-up routing trailer is not a finding",
+          noisy_sections.get("Findings not applied") == [real])
+    check("both historical trailer phrasings are dropped",
+          not any("glow-up" in t for t in
+                  noisy_sections.get("Findings not applied", [])))
+    check("the empty-deferrals placeholder is not a finding",
+          not any("pre-found" in t for t in
+                  noisy_sections.get("Findings not applied", [])))
+    check("a pre-fill that continues past 'No images.' is still noise",
+          not noisy_sections.get("Screenshot check"))
+    check("a pre-fill that continues past 'Skipped' is still noise",
+          not noisy_sections.get("Rendered content"))
+    check("a glow-up's 'None — the backlog was empty' declines nothing",
+          not extract_sections(
+              "## Backlog declined\nNone — the backlog was empty (`banked: []`).",
+              GLOWUP_BANKED_SECTIONS).get("Backlog declined"))
+    check("a real finding starting with a normal word survives",
+          extract_sections("## Findings not applied\n- **Nonetheless the claim holds**"
+                           )["Findings not applied"] == ["- **Nonetheless the claim holds**"])
 
     article = {"slug": "docs-x", "path": "content/docs/x.md"}
     entry = {"skipped_findings": 2, "clarity_flag": True, "pr_number": 123}

--- a/scripts/content-review/build-glowup-backlog.py
+++ b/scripts/content-review/build-glowup-backlog.py
@@ -246,7 +246,12 @@ def discover_prs(slug: str, extra_numbers: list[int],
     recovery["prs_found"] = len(prs)
     if prs:
         recovery["state"] = "recovered"
-    elif failed_heads == len(heads):
+    elif failed_heads:
+        # ANY unanswered head, not just all three. Requiring total failure meant
+        # one dead query plus two empty ones reported "no review PR has ever
+        # used <all three heads>" — naming heads that were never successfully
+        # asked. That is the same collapse this block exists to prevent, just
+        # at partial rather than total failure.
         recovery["state"] = "gh_unavailable"
     return prs, recovery
 
@@ -359,7 +364,7 @@ def build(article: dict, entry: dict, prs: list[dict],
                 }
                 if declined:
                     item["declined_by_pr"] = number
-                backlog["banked"].append(item)
+                _bank(backlog["banked"], item)
         if len(backlog["banked"]) == before:
             recovery["prs_without_sections"].append(number)
 
@@ -385,6 +390,54 @@ def build(article: dict, entry: dict, prs: list[dict],
     return backlog
 
 
+def _dedupe_key(text: str) -> str:
+    """A banked line's finding identity, for cross-PR de-duplication.
+
+    Keyed on the LABEL, not the whole row. Every shape the lane produces is
+    "<label> — <reason>": the composer renders `- **<label>** — <why it was
+    deferred>`, and `banked_from_findings` writes `<label> — <detail>`. The
+    label is the finding; the reason is one reviewer's phrasing of why they
+    left it, and it differs between every review of the same page. Keying on
+    the whole row would therefore dedupe almost nothing.
+    """
+    head = re.split(r"\s+(?:—|–|--)\s+", str(text or ""), maxsplit=1)[0]
+    return re.sub(r"[^a-z0-9]+", " ", head.lower()).strip()
+
+
+def _bank(banked: list[dict], item: dict) -> None:
+    """Append `item` unless the same finding is already banked.
+
+    One unresolved finding is now discoverable from several PRs at once, which
+    it never was while only the latest PR was readable. A page reviewed three
+    times carries the same unactioned Vale nag in all three bodies (see
+    content-review/docs-iac-concepts-providers, #20953/#20927/#20503, each
+    deferring `'all of' is too wordy` in its own words), and a glow-up that
+    declines it adds a fourth. Undeduped, the model's execute-or-decline table
+    grows by a row per review for a single piece of debt — an expanding backlog
+    that reads as new findings when nothing new has been found.
+
+    Two preferences on collision. A `glowup-declined` variant always wins: it
+    carries decline history the plain row doesn't, the model needs to know this
+    was already turned down once, and a human needs to be able to see a decline
+    loop forming. Otherwise the later PR wins, so the reason shown is the most
+    recent reviewer's judgment rather than the oldest.
+    """
+    key = _dedupe_key(item.get("text"))
+    if not key:
+        banked.append(item)
+        return
+    for i, existing in enumerate(banked):
+        if _dedupe_key(existing.get("text")) != key:
+            continue
+        was_declined = existing.get("source") == "glowup-declined"
+        is_declined = item.get("source") == "glowup-declined"
+        newer = int(item.get("source_pr") or 0) > int(existing.get("source_pr") or 0)
+        if (is_declined and not was_declined) or (is_declined == was_declined and newer):
+            banked[i] = item
+        return
+    banked.append(item)
+
+
 def _recovery_note(recovery: dict) -> str:
     """One sentence naming which recovery outcome happened.
 
@@ -397,7 +450,11 @@ def _recovery_note(recovery: dict) -> str:
     heads = ", ".join(recovery.get("heads_queried") or []) or "none"
     tail = "; run the taxonomy-only sweep"
     if state == "gh_unavailable":
-        return (f"GitHub would not answer for any of {heads}, so prior review PRs "
+        # Name the heads that actually went unanswered, not every head queried:
+        # the failure can be partial, and a sentence listing branches that WERE
+        # successfully asked is the same untrue-by-collapse note this replaces.
+        unreachable = ", ".join(recovery.get("prs_unreachable") or []) or heads
+        return (f"GitHub would not answer for {unreachable}, so prior review PRs "
                 f"could not be read{tail}")
     if state == "prs_carried_nothing":
         found = ", ".join(f"#{n}" for n in recovery.get("prs_without_sections") or [])
@@ -694,6 +751,49 @@ def self_test() -> int:
           build(article, debt, gpr)["degraded"] is False)
     check("degraded is always present, even on the happy path",
           "degraded" in gback and "recovery" in gback)
+
+    # --- partial head-query failure is still a failure ------------------
+    part = {"heads_queried": heads, "prs_found": 0,
+            "prs_unreachable": ["content-review/glowup-docs-x"],
+            "prs_without_sections": [], "state": "gh_unavailable"}
+    part_note = build(article, {}, [], None, part)["notes"][0]
+    check("a partly-failed query never claims the page was never reviewed",
+          "has ever used" not in part_note)
+    check("the note names only the heads that actually went unanswered",
+          "glowup-docs-x" in part_note
+          and "content-review/retire-docs-x" not in part_note)
+
+    # --- one finding, one row, however many PRs carry it ----------------
+    # A page reviewed three times defers the same Vale nag in all three bodies,
+    # each in its own words; a glow-up declining it adds a fourth. Undeduped
+    # the model gets four rows for one piece of debt.
+    same = "Vale wordiness (L84): 'all of' is too wordy."
+    multi = [
+        {"number": 20503, "url": "u", "headRefName": "content-review/docs-x",
+         "body": f"## Findings not applied\n- **{same}** — Style nag; a prose judgment."},
+        {"number": 20927, "url": "u", "headRefName": "content-review/docs-x",
+         "body": f"## Findings not applied\n- **{same}** — `write-good` heuristic; a style call."},
+        {"number": 20953, "url": "u", "headRefName": "content-review/docs-x",
+         "body": f"## Findings not applied\n- **{same}** — Style nag; reads naturally here."},
+    ]
+    dd = build(article, {}, multi)
+    check("the same finding deferred by three reviews banks once",
+          len(dd["banked"]) == 1)
+    check("and it keeps the most recent reviewer's reason",
+          dd["banked"][0]["source_pr"] == 20953)
+    declined_too = build(article, {}, multi + [
+        {"number": 21000, "url": "u", "headRefName": "content-review/glowup-docs-x",
+         "body": f"## Backlog declined\n- **{same}** — declined: accurate as written."}])
+    check("a later decline replaces the plain row rather than adding one",
+          len(declined_too["banked"]) == 1
+          and declined_too["banked"][0]["source"] == "glowup-declined")
+    check("distinct findings are never collapsed",
+          len(build(article, {}, [{"number": 1, "url": "u",
+                                   "headRefName": "content-review/docs-x",
+                                   "body": "## Findings not applied\n"
+                                           "- **Vale wordiness (L84): 'all of'.** — a\n"
+                                           "- **Vale wordiness (L99): 'all of'.** — b"}]
+                    )["banked"]) == 2)
 
     # The property every test above depends on: fixtures mean zero gh calls.
     import unittest.mock as _mock

--- a/scripts/content-review/compose-pr-body.py
+++ b/scripts/content-review/compose-pr-body.py
@@ -506,9 +506,33 @@ def compose_glowup(queue: dict, backlog: dict | None, verified, vale,
         executed.append("| --- | --- | --- |")
         for b in banked:
             text = str(b.get("text", "")).replace("|", "\\|")
-            executed.append(f"| {text} | #{b.get('source_pr')} | <TODO> |")
+            src = f"#{b.get('source_pr')}" if b.get("source_pr") else "findings record"
+            # A previously-declined row is real debt, but the reviewer needs to
+            # see that a glow-up already turned it down once — otherwise a
+            # decline loop looks like fresh work every cycle.
+            if b.get("source") == "glowup-declined":
+                src += " (declined)"
+            executed.append(f"| {text} | {src} | <TODO> |")
+    elif backlog and backlog.get("degraded"):
+        # The counters that selected this page could not be backed by anything.
+        # Saying "taxonomy-only glow-up" here — as this did before — reads as
+        # "the page had nothing outstanding", which is the opposite of true.
+        n = int((backlog or {}).get("skipped_findings") or 0)
+        flag = " and a clarity flag" if (backlog or {}).get("clarity_flag") else ""
+        why = "; ".join(notes) if notes else "no prior review PR could be read"
+        executed.append("> [!WARNING]")
+        executed.append(f"> **Backlog recovery failed.** The ledger records {n} "
+                        f"deferred finding(s){flag} for this page, but none could be "
+                        f"recovered ({why}). This run is a taxonomy sweep only. The "
+                        "backlog is preserved and the page stays eligible for a "
+                        "later glow-up — do not treat this as a clean page.")
+        heads = (backlog.get("recovery") or {}).get("heads_queried") or []
+        if heads:
+            executed.append("")
+            executed.append("_Heads queried: "
+                            + ", ".join(f"`{h}`" for h in heads) + "._")
     else:
-        executed.append("_No banked findings reachable"
+        executed.append("_No banked backlog for this page"
                         + (f" ({'; '.join(notes)})" if notes else "")
                         + " — taxonomy-only glow-up._")
 

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -440,12 +440,11 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
         # `pr_number` keeps its original meaning — the PR THIS review opened, 0
         # when it opened none — so the versioned ledger's metrics stay
         # comparable across history. The durable pointer to the page's most
-        # recent review PR is separate, and is read by select-glowup.py, which
-        # folds it into the `source_pr_number` it stamps on the queue — the only
-        # form the unprivileged worker gets it in, and what
-        # build-glowup-backlog.py reads there. That file's own dispatcher-side
-        # ledger read still keys on `pr_number` alone; #21004 teaches it the
-        # same fallback.
+        # recent review PR is separate, and both consumers prefer `pr_number`
+        # and fall back to it: select-glowup.py folds it into the
+        # `source_pr_number` it stamps on the queue — the only form the
+        # unprivileged worker gets it in — and build-glowup-backlog.py takes the
+        # same fallback in its own dispatcher-side ledger read.
         "last_pr": last_pr_from(prior)[0],
         "last_pr_number": last_pr_from(prior)[1],
         "head_sha": "",

--- a/scripts/content-review/test_compose_pr_body.py
+++ b/scripts/content-review/test_compose_pr_body.py
@@ -245,9 +245,49 @@ check("banked findings pre-stubbed with source PR",
       "needs interpretation" in gout and "#123" in gout)
 check("taxonomy sweep stubbed per category",
       all(f"**{cat}**" in gout for cat in c.GLOWUP_TAXONOMY))
-gempty = c.compose_glowup(QUEUE, {"banked": [], "notes": ["no prior review PRs reachable; run the taxonomy-only sweep"]},
+gempty = c.compose_glowup(QUEUE, {"banked": [], "degraded": False,
+                                  "notes": ["no review PR has ever used "
+                                            "content-review/docs-x; run the "
+                                            "taxonomy-only sweep"]},
                           None, None, None, None)
-check("empty backlog degrades to taxonomy-only note", "taxonomy-only" in gempty)
+check("a genuinely empty backlog still reads as taxonomy-only",
+      "taxonomy-only" in gempty and "WARNING" not in gempty)
+
+# #20984 shipped "No banked findings reachable ... taxonomy-only glow-up" for a
+# page whose ledger recorded 17 deferred findings — which reads as "this page
+# had nothing outstanding", the opposite of true.
+gdeg = c.compose_glowup(QUEUE, {
+    "banked": [], "degraded": True, "skipped_findings": 17, "clarity_flag": True,
+    "recovery": {"state": "no_prior_prs",
+                 "heads_queried": ["content-review/docs-x",
+                                   "content-review/retire-docs-x",
+                                   "content-review/glowup-docs-x"]},
+    "notes": ["no review PR has ever used content-review/docs-x; "
+              "run the taxonomy-only sweep"]}, None, None, None, None)
+check("#20984: a failed recovery renders a warning, not 'nothing to do'",
+      "[!WARNING]" in gdeg and "Backlog recovery failed" in gdeg)
+check("#20984: the warning names the count the ledger recorded",
+      "17 deferred finding(s)" in gdeg and "clarity flag" in gdeg)
+check("#20984: it tells the reader not to read this as a clean page",
+      "do not treat this as a clean page" in gdeg)
+check("#20984: the old misleading sentence is gone",
+      "No banked findings reachable" not in gdeg)
+check("a failed recovery shows its work",
+      all(h in gdeg for h in ("content-review/docs-x",
+                              "content-review/glowup-docs-x")))
+
+gdecl = c.compose_glowup(QUEUE, {"banked": [
+    {"id": "pr20984-backlog-1", "section": "Backlog declined", "source_pr": 20984,
+     "source": "glowup-declined", "declined_by_pr": 20984,
+     "text": "**Claim (c9)** — needs an SME"}], "degraded": False, "notes": []},
+    None, None, None, None)
+check("previously-declined rows are visibly marked as such",
+      "#20984 (declined)" in gdecl and "needs an SME" in gdecl)
+check("a record-sourced row with no PR does not render '#None'",
+      "#None" not in c.compose_glowup(QUEUE, {"banked": [
+          {"id": "findings-f2", "section": "Findings not applied", "source_pr": None,
+           "source": "findings-record", "text": "Vale filler (L48)"}],
+          "degraded": False, "notes": []}, None, None, None, None))
 
 _rr_spec = importlib.util.spec_from_file_location(
     "record_review", Path(__file__).resolve().parent / "record-review.py")


### PR DESCRIPTION
### Proposed changes

Unit 3 of 3 from the #20984 investigation. **Stacked on #21003** (which is stacked on #21002); each retargets automatically as its parent merges.

**The false premise.** `build-glowup-backlog.py` asserted that reused branch names made older review PRs undiscoverable, so it read only whatever pointer the ledger happened to carry. That is not true. `gh pr list --head <branch> --state all` returns every PR a branch has ever carried, closed and merged included — `content-review/docs-iac-concepts-providers` returns #20953, #20927 **and** #20503, and the branch #20984 needed returns [#19885](https://github.com/pulumi/docs/pull/19885), whose "Findings not applied" section held the very items its taxonomy sweep then rediscovered by luck.

Discovery now queries all three canonical heads — fix, retire, glow-up — with the ledger/queue pointer kept only as defence in depth. The glow-up head earns its call on its own: a prior glow-up's "Backlog declined" rows are the debt `record-review.py` counts into `skipped_findings`, and the selector re-picks the page on that number, so the backlog has to be able to name it or the counter is unbacked. Per the approved decision those rows are **re-banked, tagged** `glowup-declined` and rendered `#20984 (declined)` — dropping them makes debt vanish silently, which is the bug class this file exists to close, while re-proposing them blind invites a decline loop nobody can see forming.

Section extraction is lane-aware, keyed off `headRefName` rather than guessed from the body: a glow-up body uses different headings, and reading fix-lane headings out of one recovers nothing.

**The collapsed message.** Four distinct outcomes were reported as one sentence, `no prior review PRs reachable` — which #20984 printed for the single case where *no lookup was attempted at all*, sending its reader after an API failure that never happened. There are now four states (`recovered` / `no_prior_prs` / `gh_unavailable` / `prs_carried_nothing`), each with its own note, all recorded in a `recovery` block naming the heads queried and the PRs read.

**The silent contradiction.** `skipped_findings: 17` with `banked: []` is impossible — those counters *are* the selection criterion — and it passed through three programs without a word. It now sets `degraded`, emits a `::warning::`, and the composer renders a `[!WARNING]` naming the count, replacing the sentence that read as "this page had nothing outstanding".

Fail-open by default (decision D5): the review job is unprivileged, a red X there reads as "the lane is broken" when the true state is "the evidence is out of reach", and #21002 now preserves the backlog either way, so a degraded run costs a slot rather than the data. `--strict` exists so the workflow can be flipped fail-closed without another change here.

`pull-requests: read` is added to the review job — read-only, and it still holds no push token. Worth knowing: that job has only ever had `contents: read` + `id-token: write`, so the pre-existing `gh pr view` path likely never succeeded; nothing surfaced it because the pointer was always empty by the time it was called.

**One thing I could not verify locally:** `gh` isn't installed in this sandbox, so `gh pr list --json body,headRefName` is unconfirmed end-to-end. `body` is a documented `pr list` field and a failure would be loud (non-zero exit → `gh_unavailable` → the new warning, not a silent empty backlog), and a PR arriving without a body is hydrated individually via the existing `fetch_pr`. Still worth a glance at the first glow-up run's logs.

The `--pr-json` fixture path still performs zero subprocess calls — now with a test that asserts it, since that property is what the whole self-test suite rests on.

Verification: `make test-review-pipeline` and `make lint` pass (1845 files parsed, 0 errors; Prettier clean). New self-tests cover the four recovery states, the lane-specific section split in both directions, declined-item tagging, and the #20984 regression in both the backlog builder and the composer.

### Unreleased product version (optional)

n/a — automation only, no user-facing content.

### Related issues (optional)

Stacked on #21003 and #21002. Fixes the root cause behind #20984; corrects a claim repeated in #20990's commit message.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx3iwUddA9pNZQ4ReDiadT)_