### PR TITLE
Fix onboarding skill installation

### DIFF
--- a/content/blog/pulumi-agent-skills/index.md
+++ b/content/blog/pulumi-agent-skills/index.md
@@ -101,10 +101,12 @@ You can install both plugin groups or choose only the ones you need.
 
 ### Universal installation
 
-For Cursor, GitHub Copilot, VS Code, Codex, Gemini and other platforms, use the universal [Agent Skills](https://agentskills.io) CLI:
+For Cursor, GitHub Copilot, VS Code, Codex, Gemini, and other platforms, use the universal [Agent Skills](https://agentskills.io) CLI. The universal installer does not read plugin marketplace manifests, so install each end-user skill group:
 
 ```bash
-npx skills add pulumi/agent-skills --skill '*'
+npx skills add pulumi/agent-skills/pulumi --skill '*'
+npx skills add pulumi/agent-skills/migration --skill '*'
+npx skills add pulumi/agent-skills/delegation --skill '*'
 ```
 
 This works across all platforms that support the Agent Skills specification.

--- a/content/docs/ai/skills/index.md
+++ b/content/docs/ai/skills/index.md
@@ -115,25 +115,25 @@ Once the marketplace is registered, run `codex`, open the plugin marketplace, an
 
 ### Universal Installation
 
-Install all skills for use with any AI coding assistant:
+The universal installer does not read plugin marketplace manifests. Install
+each end-user skill group for use with any AI coding assistant:
 
 ```bash
-npx skills add pulumi/agent-skills --skill '*'
+npx skills add pulumi/agent-skills/pulumi --skill '*'       # 8 Pulumi skills
+npx skills add pulumi/agent-skills/migration --skill '*'    # 5 migration skills
+npx skills add pulumi/agent-skills/delegation --skill '*'   # 1 Neo handoff skill
 ```
 
-Or install individual plugin groups:
+Provider authors can also install the separate package-maintenance group:
 
 ```bash
-npx skills add pulumi/agent-skills/migration --skill '*'             # 5 migration skills
-npx skills add pulumi/agent-skills/pulumi --skill '*'                # 8 pulumi skills (overview + specialized)
-npx skills add pulumi/agent-skills/delegation --skill '*'            # 1 delegation skill
-npx skills add pulumi/agent-skills/package-maintenance --skill '*'   # 2 package-maintenance skills
+npx skills add pulumi/agent-skills/package-maintenance --skill '*'
 ```
 
-This works with Claude Code, Cursor, Copilot, Codex, Junie, and other agent tools. To install for a specific agent, use the `--agent` flag:
+This works with Claude Code, Cursor, Copilot, Codex, Junie, and other agent tools. To install a group for a specific agent, use the `--agent` flag:
 
 ```bash
-npx skills add pulumi/agent-skills --skill '*' --agent junie
+npx skills add pulumi/agent-skills/pulumi --skill '*' --agent junie
 ```
 
 ## Usage Examples

--- a/content/docs/install/_index.md
+++ b/content/docs/install/_index.md
@@ -521,10 +521,12 @@ You can install all plugin groups or choose only the ones you need.
 
 ### Universal installation
 
-For Cursor, GitHub Copilot, VS Code, Codex, Gemini and other platforms, use the universal [Agent Skills](https://agentskills.io) CLI:
+For Cursor, GitHub Copilot, VS Code, Codex, Gemini, and other platforms, use the universal [Agent Skills](https://agentskills.io) CLI. The universal installer does not read plugin marketplace manifests, so install each end-user skill group:
 
 ```bash
-npx skills add pulumi/agent-skills --skill '*'
+npx skills add pulumi/agent-skills/pulumi --skill '*'
+npx skills add pulumi/agent-skills/migration --skill '*'
+npx skills add pulumi/agent-skills/delegation --skill '*'
 ```
 
 You can also connect your assistant to the [Pulumi MCP server](/docs/ai/mcp-server/) for live access to your Pulumi Cloud stacks, resources, and the Pulumi Registry.

--- a/static/onboard.md
+++ b/static/onboard.md
@@ -40,6 +40,13 @@ Azure, GCP, or another provider):
 
 Do not guess. The answer decides the path.
 
+If the user chooses migration, install the migration skills before continuing:
+
+    npx skills add pulumi/agent-skills/migration --skill '*'
+
+If the migration skill install does not succeed, continue with
+`pulumi-overview` and the Pulumi CLI rather than stopping.
+
 ## 4. Ask how to authenticate to the cloud
 
 Pulumi creates resources in the user's own cloud account, with credentials

--- a/static/onboard.md
+++ b/static/onboard.md
@@ -20,7 +20,7 @@ installer, then re-check. Do not continue until the version command succeeds.
 This prompt hands the real work to Pulumi's `pulumi-overview` skill.
 Install the Pulumi skills now so the steps below have them:
 
-    npx skills add pulumi/agent-skills --skill '*'
+    npx skills add pulumi/agent-skills/pulumi --skill '*'
 
 Follow the `pulumi-overview` skill for the work below, not any stub `pulumi`
 skill that shipped with the CLI. If the install does not succeed, do not stop


### PR DESCRIPTION
### Proposed changes

Update the hosted onboarding prompt to install from the Pulumi skill group path exposed by the new `agent-skills` repository structure. This makes `pulumi-overview` available without changing the Claude Code plugin marketplace layout.

If the user selects migration, install the migration skill group before continuing.

Replace the broken repository-root universal install command on the AI Skills page, the main installation page, and the Agent Skills launch blog with explicit Pulumi, migration, and delegation group commands.

I ran the documented end-user commands in a clean temporary directory. They installed all 14 end-user skills, including `pulumi-overview`, `pulumi-terraform-to-pulumi`, and `pulumi-neo-handoff`.