### PR TITLE
Roll back the "start with a coding agent" section on /docs/get-started/

### DIFF
--- a/content/docs/get-started/_index.md
+++ b/content/docs/get-started/_index.md
@@ -63,16 +63,6 @@ Pulumi IaC is free, [open source](https://github.com/pulumi/pulumi), and optiona
     </div>
 </section>
 
-## Or start with a coding agent
-
-Prefer to have your agent do the setup? Paste this prompt into Claude Code, Codex, Cursor, GitHub Copilot, or whichever agent you already use, and it will install the CLI, help you pick a cloud, and deploy your first stack with you.
-
-{{< copy-prompt track="docs-copy-onboarding-prompt" >}}
-Fetch https://www.pulumi.com/onboard.md and follow its instructions to get me started with Pulumi.
-{{< /copy-prompt >}}
-
-To go further with agents, see [Agent Skills](/docs/ai/skills/), the [Pulumi MCP server](/docs/ai/mcp-server/), and [Pulumi Neo](/docs/ai/neo/), Pulumi's purpose-built infrastructure agent.
-
 ## Learn more
 
 The following sections are also useful when first learning how to use Pulumi:


### PR DESCRIPTION
## Summary

Rolls back the **"Or start with a coding agent"** copy-prompt CTA that was added to `/docs/get-started/` in #20899. Per request, only the section on the get-started page is removed.

## What this changes

- Removes the `## Or start with a coding agent` section (heading, copy, `copy-prompt` shortcode, and the "To go further with agents" line) from `content/docs/get-started/_index.md`.

## What this intentionally leaves in place

- `static/onboard.md` — still actively maintained (#21006, #21023).
- The `copy-prompt` shortcode (`layouts/shortcodes/copy-prompt.*`) and `theme/src/ts/copy-text.ts` — shared infrastructure, not get-started-specific.
- The separate `## Choose a cloud provider` heading improvement from #20899.

A full `git revert` of #20899 was avoided on purpose: it conflicts on `onboard.md` (modified since) and would tear out infrastructure the team is still building on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)