### PR TITLE
Revert Zendesk portal → support@pulumi.com link swap (#20868)

### DIFF
--- a/content/docs/administration/onboarding-guide/choose-edition.md
+++ b/content/docs/administration/onboarding-guide/choose-edition.md
@@ -38,7 +38,7 @@ Designed for larger organizations with mission-critical workloads. These edition
 - **Priority access**: Prioritized bugs and feature requests, plus product roadmap reviews
 - **Custom training**: Tailored onboarding and ongoing training for your team
 
-Contact Pulumi support at [support@pulumi.com](mailto:support@pulumi.com) if you're on the Enterprise or Business Critical edition.
+Access your support through the [support portal](https://support.pulumi.com/hc/en-us) if you're on the Enterprise or Business Critical edition.
 
 {{% notes type="info" %}}
 Learn more about the differences between [the editions](/pricing/).

--- a/content/docs/support/getting-support.md
+++ b/content/docs/support/getting-support.md
@@ -28,7 +28,7 @@ Pulumi staff are active in both the community Slack and on GitHub, but response 
 Customers on a paid support plan have access to direct support channels with response-time commitments:
 
 - **Private chat channel** — A dedicated chat channel with Pulumi support staff for your organization.
-- **Direct email support** — Contact Pulumi support directly via [support@pulumi.com](mailto:support@pulumi.com).
+- **Direct email support** — Contact Pulumi support directly via the [Pulumi support portal](https://support.pulumi.com/).
 
 If you are on a paid plan and aren't sure how to reach your support channel, contact your Pulumi account team.
 

--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -13,7 +13,7 @@ For more details, see our [security whitepaper](/security/pulumi-cloud-security-
 
 ## Vulnerability Reporting
 
-If you believe you’ve discovered a potential vulnerability in Pulumi’s security, please contact us at [security@pulumi.com](mailto:security@pulumi.com). For non-critical matters please contact Pulumi support at [support@pulumi.com](mailto:support@pulumi.com).
+If you believe you’ve discovered a potential vulnerability in Pulumi’s security, please contact us at [security@pulumi.com](mailto:security@pulumi.com). For non-critical matters please file an issue with [Pulumi support](https://support.pulumi.com/).
 
 When reporting a potential vulnerability, please include as much of the following information as possible.
 


### PR DESCRIPTION
### Proposed changes

Reverts #20868, restoring the Pulumi support portal links on all three pages it touched:

- `/docs/support/getting-support/` — the "Direct email support" bullet points back at the [Pulumi support portal](https://support.pulumi.com/) instead of `support@pulumi.com`.
- `/docs/administration/onboarding-guide/choose-edition/` — back to "Access your support through the support portal…".
- `/security/` — back to "For non-critical matters please file an issue with Pulumi support".

Requested by Kelsey Dirks: the reworded bullet reads as though email is the only support channel we offer. A wider rework of the getting-support page is expected in the next week or so, so this puts the page back to its prior state in the meantime.

This is a clean `git revert` of 118e981 — no other content changed.

### Related issues (optional)

Revert requested in Slack: https://pulumi.slack.com/archives/C85BS3LJZ/p1787322371229689?thread_ts=1786642291.773499&cid=C85BS3LJZ

Reverts #20868


---
_Generated by [Claude Code](https://claude.ai/code/session_01FBjGHW2RfjgGQerERTWo6n)_