### PR TITLE
Author hero headlines as a single markdown string

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -13,8 +13,7 @@ sections:
     badge_highlight_text: "Latest release:"
     badge_text: "Full support for Terraform and HCL"
     badge_link: /releases/terraform-state-backend-modules-hcl/
-    title_primary: "Next-level"
-    title_secondary: "infrastructure as code \n for humans and agents."
+    title: "*Next-level*<br>infrastructure as code for humans and agents."
     description: |
       Ship cloud infrastructure at the speed of AI with languages and tools that stay out of your way.
     anchor: hero

--- a/content/_index.md
+++ b/content/_index.md
@@ -13,7 +13,7 @@ sections:
     badge_highlight_text: "Latest release:"
     badge_text: "Full support for Terraform and HCL"
     badge_link: /releases/terraform-state-backend-modules-hcl/
-    title: "*Next-level*<br>infrastructure as code for humans and agents."
+    title: "*Next-level*<br>infrastructure as code for humans and agents."
     description: |
       Ship cloud infrastructure at the speed of AI with languages and tools that stay out of your way.
     anchor: hero

--- a/content/product/_index.md
+++ b/content/product/_index.md
@@ -21,8 +21,7 @@ aliases:
 
 sections:
   - type: hero
-    title_primary: The unified platform
-    title_secondary: for infrastructure teams.
+    title: "*The unified platform*<br>for infrastructure teams."
     description: |
       Infrastructure as code with modern languages, centralized secrets and governance, and AI built for infrastructure — all in one platform. Everything teams need to move fast and scale with confidence.
     image: /images/product/overview/overview-diagram.svg

--- a/content/product/infrastructure-as-code.md
+++ b/content/product/infrastructure-as-code.md
@@ -11,8 +11,7 @@ aliases:
 
 sections:
   - type: hero
-    title_primary: Infrastructure as code
-    title_secondary: in any language.
+    title: "*Infrastructure as code*<br>in any language."
     description: |
       Use the programming languages you already know to build infrastructure on AWS, Azure, Google Cloud, Kubernetes, and hundreds more providers.
     anchor: hero

--- a/content/product/insights-governance.md
+++ b/content/product/insights-governance.md
@@ -15,8 +15,7 @@ aliases:
 
 sections:
   - type: hero
-    title_primary: "Continuous compliance,"
-    title_secondary: "by construction."
+    title: "*Continuous compliance,*<br>by construction."
     description: Audit, remediate, and enforce compliance policies across all your cloud infrastructure automatically.
     image: /images/product/insights-governance/ig-hero.svg
     image_alt: Pulumi Discovery & Governance dashboard showing cloud resource compliance

--- a/content/product/internal-developer-platforms.md
+++ b/content/product/internal-developer-platforms.md
@@ -13,8 +13,7 @@ aliases:
 
 sections:
   - type: hero
-    title_primary: Self-service infrastructure
-    title_secondary: at any scale.
+    title: "*Self-service infrastructure*<br>at any scale."
     description: Build golden paths with reusable components and templates. Enable self-service provisioning through code, YAML, or developer portals — with governance built in.
     image: /images/product/internal-developer-platforms/idp-hero-image.svg
     image_alt: Pulumi internal developer platform services dashboard

--- a/content/product/neo.md
+++ b/content/product/neo.md
@@ -20,9 +20,7 @@ include_floqer: true
 
 sections:
   - type: hero
-    title_primary: "AI infrastructure agent."
-    title_secondary: "Meet Neo, your new"
-    title_reversed: true
+    title: "Meet Neo, your new<br>*AI infrastructure agent.*"
     description: Neo provisions, governs, and optimizes your cloud infrastructure — with enterprise controls built in.
     image: /images/product/neo/neo-hero.svg
     image_alt: Neo AI infrastructure agent diagram showing Kubernetes cluster upgrade automation

--- a/content/product/secrets-management.md
+++ b/content/product/secrets-management.md
@@ -12,9 +12,7 @@ aliases:
 
 sections:
   - type: hero
-    title_primary: Centralized configuration,
-    title_secondary: "zero sprawl."
-    title_reversed: false
+    title: "*Centralized configuration,*<br>zero sprawl."
     description: Compose, manage, and share configuration and secrets across environments with Pulumi ESC.
     image: /images/product/secrets-management/esc-hero.svg
     image_alt: Pulumi ESC secrets management — connect any secrets store

--- a/layouts/partials/markdown/sections.md
+++ b/layouts/partials/markdown/sections.md
@@ -24,19 +24,10 @@
 > — {{ delimit . ", " }}
 {{- end }}
 {{ else -}}
-{{- /* Heroes split the heading across title_primary/title_secondary;
-       title_reversed renders secondary before primary. */ -}}
 {{- $heading := or .heading .title "" -}}
 {{- with .title_line_2 }}{{ $heading = printf "%s %s" $heading . }}{{ end -}}
-{{- $primary := trim (or .title_primary "") " \n" -}}
-{{- $secondary := trim (or .title_secondary "") " \n" -}}
-{{- if or $primary $secondary -}}
-{{- if .title_reversed -}}
-{{- $heading = trim (printf "%s %s" $secondary $primary) " " -}}
-{{- else -}}
-{{- $heading = trim (printf "%s %s" $primary $secondary) " " -}}
-{{- end -}}
-{{- end -}}
+{{- /* Hero headlines carry <br> to force a line break; markdown wraps on its own. */ -}}
+{{- $heading = replaceRE `<br\s*/?>` " " $heading -}}
 {{- with replaceRE `\s+` " " $heading }}
 
 ## {{ . }}

--- a/layouts/partials/template-partials/template-hero.html
+++ b/layouts/partials/template-partials/template-hero.html
@@ -6,10 +6,10 @@
     or a static image in the right/below slot.
 
     Parameters — hero:
-    - title: Hero title (used when title_primary/title_secondary not set)
-    - title_primary: First part of heading, purple/larger
-    - title_secondary: Second part of heading, black/smaller
-    - title_reversed: Optional bool. When true, renders secondary above primary.
+    - title: Hero headline, authored as a single markdown string. *Emphasis* (or
+             **strong**) renders the enclosed run in violet — same color, same
+             weight, no italics — and <br> forces a line break, e.g.
+             "*Infrastructure as code*<br>in any language."
     - description: Hero description
     - cta_primary_text: Primary CTA button text (defaults to site.Params.cta.primary.label)
     - cta_primary_link: Primary CTA button link (defaults to site.Params.cta.primary.href)
@@ -19,7 +19,6 @@
     - image_alt: Alt text for image (optional)
     - image_max_width: Optional max width for the image (e.g. "800px", "60rem"). Defaults to full width.
     - image_min_width: Optional min width for the image (e.g. "400px", "30rem").
-    - title_reversed: Optional boolean. When true, renders title_secondary (black) above title_primary (purple).
     - layout: Optional string. "split" renders text left / visual right; default is centered.
     - badge_highlight_text: Optional badge text highlighted in purple (split layout only).
     - badge_text: Optional pill badge text displayed above the heading (split layout only).
@@ -52,9 +51,7 @@
 */}}
 
 {{ $title := .title }}
-{{ $titlePrimary := .title_primary }}
-{{ $titleSecondary := .title_secondary }}
-{{ $titleReversed := .title_reversed | default false }}
+{{ $titlePlain := $title | replaceRE `<br\s*/?>` " " | markdownify | plainify | htmlUnescape }}
 {{ $description := .description }}
 {{ $ctaPrimaryText := .cta_primary_text | default site.Params.cta.primary.label }}
 {{ $ctaPrimaryLink := .cta_primary_link | default site.Params.cta.primary.href }}
@@ -65,7 +62,7 @@
 {{ $videoYouTubeId := .video_youtube_id }}
 {{ $videoTitle := .video_title | default "Watch video" }}
 {{ $image := .image }}
-{{ $imageAlt := .image_alt | default $title | default (printf "%s %s" $titlePrimary $titleSecondary) }}
+{{ $imageAlt := .image_alt | default $titlePlain }}
 {{ $imageMaxWidth := .image_max_width }}
 {{ $imageMinWidth := .image_min_width }}
 {{ $imageStyle := "" }}{{ if $imageMaxWidth }}{{ $imageStyle = printf "%smax-width: %s;" $imageStyle $imageMaxWidth }}{{ end }}{{ if $imageMinWidth }}{{ $imageStyle = printf "%smin-width: %s;" $imageStyle $imageMinWidth }}{{ end }}
@@ -114,22 +111,8 @@
                 <span class="hero-tag-line">{{ $tagLine }}</span>
             </div>
             {{ end }}
-            {{ if or $titlePrimary $title }}
-            <h1 class="product-hero-heading text-left">
-                {{ if and $titlePrimary $titleSecondary }}
-                {{ if $titleReversed }}
-                <span class="product-hero-title-secondary">{{ $titleSecondary }}</span>
-                <span class="product-hero-title-primary">{{ $titlePrimary }}</span>
-                {{ else }}
-                <span class="product-hero-title-primary">{{ $titlePrimary }}</span>
-                <span class="product-hero-title-secondary">{{ $titleSecondary }}</span>
-                {{ end }}
-                {{ else if $titlePrimary }}
-                <span class="product-hero-title-primary">{{ $titlePrimary }}</span>
-                {{ else }}
-                <span class="product-hero-title">{{ $title }}</span>
-                {{ end }}
-            </h1>
+            {{ with $title }}
+            <h1 class="product-hero-heading text-left">{{ . | markdownify }}</h1>
             {{ end }}
             {{ if or $dateAndLocation $booth }}
             <p class="hero-event-details mb-8">
@@ -212,22 +195,8 @@
 <section class="template-hero"{{ if $anchor }} id="{{ $anchor }}"{{ end }}>
     <div class="flex flex-col items-center gap-12">
         <div class="flex flex-col items-center text-center w-full max-w-4xl mx-auto">
-            {{ if or $titlePrimary $title }}
-            <h1 class="product-hero-heading">
-                {{ if and $titlePrimary $titleSecondary }}
-                {{ if $titleReversed }}
-                <span class="product-hero-title-secondary">{{ $titleSecondary }}</span>
-                <span class="product-hero-title-primary">{{ $titlePrimary }}</span>
-                {{ else }}
-                <span class="product-hero-title-primary">{{ $titlePrimary }}</span>
-                <span class="product-hero-title-secondary">{{ $titleSecondary }}</span>
-                {{ end }}
-                {{ else if $titlePrimary }}
-                <span class="product-hero-title-primary">{{ $titlePrimary }}</span>
-                {{ else }}
-                <span class="product-hero-title">{{ $title }}</span>
-                {{ end }}
-            </h1>
+            {{ with $title }}
+            <h1 class="product-hero-heading">{{ . | markdownify }}</h1>
             {{ end }}
             {{ if $description }}
             <p class="product-hero-description mb-10">{{ $description | markdownify }}</p>

--- a/theme/src/scss/_templates.scss
+++ b/theme/src/scss/_templates.scss
@@ -114,20 +114,19 @@
     }
 
     // Product page widgets
+    //
+    // The headline is a single markdown string in frontmatter: *emphasis* (or
+    // **strong**) marks the run that renders in violet. Color is the only
+    // change — the run keeps the heading's own weight and stays upright.
     .product-hero-heading {
         @include product-hero-heading();
-    }
 
-    .product-hero-title-primary {
-        @apply block text-violet-primary;
-    }
-
-    .product-hero-title-secondary {
-        @apply block text-black;
-    }
-
-    .product-hero-title {
-        @include product-hero-heading();
+        em,
+        strong {
+            @apply text-violet-primary;
+            font-style: inherit;
+            font-weight: inherit;
+        }
     }
 
     .product-hero-description {


### PR DESCRIPTION
### Proposed changes

* Hero headline is now one markdown string in `title:`. `*emphasis*` renders the enclosed run in violet - color only, no italics and no weight change - and `<br>` forces a line break.
* `title_primary`, `title_secondary`, and `title_reversed` are gone from the hero partial and the seven pages using them, along with the `.product-hero-title-primary` / `-secondary` / `.product-hero-title` classes.
* `**strong**` marks the violet run too, matching the `section-header` mixin that already does this for `heading:` on other section types.
* Migrated headlines keep their existing line breaks, including `neo.md`, where `title_reversed: true` becomes `"Meet Neo, your new<br>*AI infrastructure agent.*"`.
* Non-breaking spaces in the homepage headline are preserved after "for" and "and" (invisible in the diff). The literal `\n` it also carried is dropped, since HTML collapsed it and it never rendered.
* `<br>` is stripped from headings in the `text/markdown` output; the `*` passes through, same as `**` in other headings today.
