### PR TITLE
Cut PR build time: stop deleting the Hugo image cache, drop GOGC=3

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -111,9 +111,14 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          key: hugo-resources-${{ github.sha }}
+          # The version prefix must match the hugo-version pinned above, and be
+          # identical in pull-request.yml and build-and-deploy.yml or PRs stop
+          # inheriting master's cache. Hugo does not put its own version in the
+          # cache key, so without this a Hugo upgrade keeps serving images
+          # encoded by the previous version indefinitely. Bump both on upgrade.
+          key: hugo-resources-0.157.0-${{ github.sha }}
           restore-keys: |
-            hugo-resources-
+            hugo-resources-0.157.0-
 
       - name: Record build start time
         run: |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -112,10 +112,12 @@ jobs:
         with:
           path: resources
           # The version prefix must match the hugo-version pinned above, and be
-          # identical in pull-request.yml and build-and-deploy.yml or PRs stop
-          # inheriting master's cache. Hugo does not put its own version in the
-          # cache key, so without this a Hugo upgrade keeps serving images
-          # encoded by the previous version indefinitely. Bump both on upgrade.
+          # identical in every workflow that caches resources/ -- pull-request.yml,
+          # build-and-deploy.yml, testing-build-and-deploy.yml, and
+          # pulumi-cli-docs.yml -- or they stop sharing a cache. Hugo does not put
+          # its own version in the cache key, so without this a Hugo upgrade keeps
+          # serving images encoded by the previous version indefinitely. Bump them
+          # together on upgrade.
           key: hugo-resources-0.157.0-${{ github.sha }}
           restore-keys: |
             hugo-resources-0.157.0-

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -103,6 +103,22 @@ jobs:
           restore-keys: |
             meta-images-
 
+      # Derive the cache key from the Hugo installed above rather than a literal,
+      # so revving hugo-version updates the key on its own. Fails loudly on an
+      # unparseable version rather than silently collapsing every build into a
+      # single unversioned namespace, which is the bug this exists to prevent.
+      - name: Resolve Hugo version for the cache key
+        id: hugo-version
+        run: |
+          hv="$(hugo version)"
+          # -n/p so a non-match yields empty rather than echoing the input back,
+          # and check before appending -extended so the guard can't see a value
+          # that is only the suffix.
+          ver="$(printf '%s' "$hv" | sed -nE 's/^hugo v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')"
+          [ -n "$ver" ] || { echo "could not parse hugo version from: $hv" >&2; exit 1; }
+          case "$hv" in *+extended*) ver="$ver-extended" ;; esac
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
       # Persist Hugo's processed-image cache (resources/_gen). Blog templates
       # process feature images to WebP at several sizes via .Process; without
       # this cache every CI run re-encodes ~2,400 images from scratch (~4-5
@@ -111,16 +127,16 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          # The version prefix must match the hugo-version pinned above, and be
-          # identical in every workflow that caches resources/ -- pull-request.yml,
-          # build-and-deploy.yml, testing-build-and-deploy.yml, and
-          # pulumi-cli-docs.yml -- or they stop sharing a cache. Hugo does not put
-          # its own version in the cache key, so without this a Hugo upgrade keeps
-          # serving images encoded by the previous version indefinitely. Bump them
-          # together on upgrade.
-          key: hugo-resources-0.157.0-${{ github.sha }}
+          # Keyed on the Hugo resolved above, not a literal, so the four
+          # workflows that share this cache (pull-request.yml,
+          # build-and-deploy.yml, testing-build-and-deploy.yml,
+          # pulumi-cli-docs.yml) stay in step through an upgrade without anyone
+          # remembering to bump them. Hugo does not put its version in its own
+          # cache entries, so without this an upgrade keeps serving images
+          # encoded by the previous version indefinitely.
+          key: hugo-resources-${{ steps.hugo-version.outputs.version }}-${{ github.sha }}
           restore-keys: |
-            hugo-resources-0.157.0-
+            hugo-resources-${{ steps.hugo-version.outputs.version }}-
 
       - name: Record build start time
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -98,10 +98,12 @@ jobs:
         with:
           path: resources
           # The version prefix must match the hugo-version pinned above, and be
-          # identical in pull-request.yml and build-and-deploy.yml or PRs stop
-          # inheriting master's cache. Hugo does not put its own version in the
-          # cache key, so without this a Hugo upgrade keeps serving images
-          # encoded by the previous version indefinitely. Bump both on upgrade.
+          # identical in every workflow that caches resources/ -- pull-request.yml,
+          # build-and-deploy.yml, testing-build-and-deploy.yml, and
+          # pulumi-cli-docs.yml -- or they stop sharing a cache. Hugo does not put
+          # its own version in the cache key, so without this a Hugo upgrade keeps
+          # serving images encoded by the previous version indefinitely. Bump them
+          # together on upgrade.
           key: hugo-resources-0.157.0-${{ github.sha }}
           restore-keys: |
             hugo-resources-0.157.0-

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -89,6 +89,22 @@ jobs:
           restore-keys: |
             meta-images-
 
+      # Derive the cache key from the Hugo installed above rather than a literal,
+      # so revving hugo-version updates the key on its own. Fails loudly on an
+      # unparseable version rather than silently collapsing every build into a
+      # single unversioned namespace, which is the bug this exists to prevent.
+      - name: Resolve Hugo version for the cache key
+        id: hugo-version
+        run: |
+          hv="$(hugo version)"
+          # -n/p so a non-match yields empty rather than echoing the input back,
+          # and check before appending -extended so the guard can't see a value
+          # that is only the suffix.
+          ver="$(printf '%s' "$hv" | sed -nE 's/^hugo v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')"
+          [ -n "$ver" ] || { echo "could not parse hugo version from: $hv" >&2; exit 1; }
+          case "$hv" in *+extended*) ver="$ver-extended" ;; esac
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
       # Persist Hugo's processed-image cache (resources/_gen). Blog templates
       # process feature images to WebP at several sizes via .Process; without
       # this cache every CI run re-encodes ~2,400 images from scratch (~4-5
@@ -97,16 +113,16 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          # The version prefix must match the hugo-version pinned above, and be
-          # identical in every workflow that caches resources/ -- pull-request.yml,
-          # build-and-deploy.yml, testing-build-and-deploy.yml, and
-          # pulumi-cli-docs.yml -- or they stop sharing a cache. Hugo does not put
-          # its own version in the cache key, so without this a Hugo upgrade keeps
-          # serving images encoded by the previous version indefinitely. Bump them
-          # together on upgrade.
-          key: hugo-resources-0.157.0-${{ github.sha }}
+          # Keyed on the Hugo resolved above, not a literal, so the four
+          # workflows that share this cache (pull-request.yml,
+          # build-and-deploy.yml, testing-build-and-deploy.yml,
+          # pulumi-cli-docs.yml) stay in step through an upgrade without anyone
+          # remembering to bump them. Hugo does not put its version in its own
+          # cache entries, so without this an upgrade keeps serving images
+          # encoded by the previous version indefinitely.
+          key: hugo-resources-${{ steps.hugo-version.outputs.version }}-${{ github.sha }}
           restore-keys: |
-            hugo-resources-0.157.0-
+            hugo-resources-${{ steps.hugo-version.outputs.version }}-
 
       # PR runs don't wait on await-in-progress.js the way master deploys do, so
       # the elapsed time here is build time with no queue wait to subtract.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ on:
 # superseded ones just burn a runner and hold up the queue. Each run publishes to
 # a bucket keyed by PR number *and* head sha, so a cancelled run can only orphan
 # its own preview bucket -- pr-closed.yml deletes every *-pr-<num>-* bucket when
-# the PR closes, and bucket-cleanup.yml sweeps daily.
+# the PR closes, and bucket-cleanup-testing.yml sweeps daily.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -97,9 +97,14 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          key: hugo-resources-${{ github.sha }}
+          # The version prefix must match the hugo-version pinned above, and be
+          # identical in pull-request.yml and build-and-deploy.yml or PRs stop
+          # inheriting master's cache. Hugo does not put its own version in the
+          # cache key, so without this a Hugo upgrade keeps serving images
+          # encoded by the previous version indefinitely. Bump both on upgrade.
+          key: hugo-resources-0.157.0-${{ github.sha }}
           restore-keys: |
-            hugo-resources-
+            hugo-resources-0.157.0-
 
       # PR runs don't wait on await-in-progress.js the way master deploys do, so
       # the elapsed time here is build time with no queue wait to subtract.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,17 @@ on:
     branches:
       - master
       - 'release/**'
+
+# Only the newest commit on a PR is worth building. Without this, pushing three
+# commits in quick succession runs three full builds to completion, and the two
+# superseded ones just burn a runner and hold up the queue. Each run publishes to
+# a bucket keyed by PR number *and* head sha, so a cancelled run can only orphan
+# its own preview bucket -- pr-closed.yml deletes every *-pr-<num>-* bucket when
+# the PR closes, and bucket-cleanup.yml sweeps daily.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
@@ -90,6 +101,11 @@ jobs:
           restore-keys: |
             hugo-resources-
 
+      # PR runs don't wait on await-in-progress.js the way master deploys do, so
+      # the elapsed time here is build time with no queue wait to subtract.
+      - name: Record build start time
+        run: echo "CI_BUILD_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: Build and deploy
         run: make ci_pull_request
         env:
@@ -103,6 +119,17 @@ jobs:
           ALGOLIA_APP_SEARCH_KEY: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
           ALGOLIA_APP_ADMIN_KEY: ${{  steps.esc-secrets.outputs.ALGOLIA_APP_ADMIN_KEY }}
           NODE_OPTIONS: "--max_old_space_size=8192"
+
+      # The same guardrail build-and-deploy.yml has. PR builds had none, which is
+      # how they drifted to ~17 minutes without anyone being told. 15 minutes
+      # sits a few minutes above the post-fix baseline, so it should stay quiet
+      # unless the build genuinely regresses; tighten it once that baseline settles.
+      - name: Alert on slow build
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          BUILD_DURATION_THRESHOLD_MINUTES: '15'
+        run: ./scripts/ci-build-duration-alert.sh
 
       - name: Archive test results
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -148,9 +148,16 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          key: hugo-resources-${{ github.sha }}
+          # The version prefix must match the hugo-version pinned above, and be
+          # identical in every workflow that caches resources/ -- pull-request.yml,
+          # build-and-deploy.yml, testing-build-and-deploy.yml, and
+          # pulumi-cli-docs.yml -- or they stop sharing a cache. Hugo does not put
+          # its own version in the cache key, so without this a Hugo upgrade keeps
+          # serving images encoded by the previous version indefinitely. Bump them
+          # together on upgrade.
+          key: hugo-resources-0.157.0-${{ github.sha }}
           restore-keys: |
-            hugo-resources-
+            hugo-resources-0.157.0-
       - run: make ensure
       - name: clean stale generated command pages
         run: |

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -141,6 +141,22 @@ jobs:
           key: meta-images-${{ github.sha }}
           restore-keys: |
             meta-images-
+      # Derive the cache key from the Hugo installed above rather than a literal,
+      # so revving hugo-version updates the key on its own. Fails loudly on an
+      # unparseable version rather than silently collapsing every build into a
+      # single unversioned namespace, which is the bug this exists to prevent.
+      - name: Resolve Hugo version for the cache key
+        id: hugo-version
+        run: |
+          hv="$(hugo version)"
+          # -n/p so a non-match yields empty rather than echoing the input back,
+          # and check before appending -extended so the guard can't see a value
+          # that is only the suffix.
+          ver="$(printf '%s' "$hv" | sed -nE 's/^hugo v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')"
+          [ -n "$ver" ] || { echo "could not parse hugo version from: $hv" >&2; exit 1; }
+          case "$hv" in *+extended*) ver="$ver-extended" ;; esac
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
       # Persist Hugo's processed-image cache (resources/_gen) for the full
       # `make build` below; without it every run re-encodes ~2,400 WebP images
       # from scratch (~4-5 minutes).
@@ -148,16 +164,16 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          # The version prefix must match the hugo-version pinned above, and be
-          # identical in every workflow that caches resources/ -- pull-request.yml,
-          # build-and-deploy.yml, testing-build-and-deploy.yml, and
-          # pulumi-cli-docs.yml -- or they stop sharing a cache. Hugo does not put
-          # its own version in the cache key, so without this a Hugo upgrade keeps
-          # serving images encoded by the previous version indefinitely. Bump them
-          # together on upgrade.
-          key: hugo-resources-0.157.0-${{ github.sha }}
+          # Keyed on the Hugo resolved above, not a literal, so the four
+          # workflows that share this cache (pull-request.yml,
+          # build-and-deploy.yml, testing-build-and-deploy.yml,
+          # pulumi-cli-docs.yml) stay in step through an upgrade without anyone
+          # remembering to bump them. Hugo does not put its version in its own
+          # cache entries, so without this an upgrade keeps serving images
+          # encoded by the previous version indefinitely.
+          key: hugo-resources-${{ steps.hugo-version.outputs.version }}-${{ github.sha }}
           restore-keys: |
-            hugo-resources-0.157.0-
+            hugo-resources-${{ steps.hugo-version.outputs.version }}-
       - run: make ensure
       - name: clean stale generated command pages
         run: |

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -88,9 +88,16 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          key: hugo-resources-${{ github.sha }}
+          # The version prefix must match the hugo-version pinned above, and be
+          # identical in every workflow that caches resources/ -- pull-request.yml,
+          # build-and-deploy.yml, testing-build-and-deploy.yml, and
+          # pulumi-cli-docs.yml -- or they stop sharing a cache. Hugo does not put
+          # its own version in the cache key, so without this a Hugo upgrade keeps
+          # serving images encoded by the previous version indefinitely. Bump them
+          # together on upgrade.
+          key: hugo-resources-0.157.0-${{ github.sha }}
           restore-keys: |
-            hugo-resources-
+            hugo-resources-0.157.0-
 
       - name: Build and deploy
         run: make ci_push

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -80,6 +80,22 @@ jobs:
           restore-keys: |
             meta-images-
 
+      # Derive the cache key from the Hugo installed above rather than a literal,
+      # so revving hugo-version updates the key on its own. Fails loudly on an
+      # unparseable version rather than silently collapsing every build into a
+      # single unversioned namespace, which is the bug this exists to prevent.
+      - name: Resolve Hugo version for the cache key
+        id: hugo-version
+        run: |
+          hv="$(hugo version)"
+          # -n/p so a non-match yields empty rather than echoing the input back,
+          # and check before appending -extended so the guard can't see a value
+          # that is only the suffix.
+          ver="$(printf '%s' "$hv" | sed -nE 's/^hugo v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')"
+          [ -n "$ver" ] || { echo "could not parse hugo version from: $hv" >&2; exit 1; }
+          case "$hv" in *+extended*) ver="$ver-extended" ;; esac
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
       # Persist Hugo's processed-image cache (resources/_gen). Blog templates
       # process feature images to WebP at several sizes via .Process; without
       # this cache every CI run re-encodes ~2,400 images from scratch (~4-5
@@ -88,16 +104,16 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          # The version prefix must match the hugo-version pinned above, and be
-          # identical in every workflow that caches resources/ -- pull-request.yml,
-          # build-and-deploy.yml, testing-build-and-deploy.yml, and
-          # pulumi-cli-docs.yml -- or they stop sharing a cache. Hugo does not put
-          # its own version in the cache key, so without this a Hugo upgrade keeps
-          # serving images encoded by the previous version indefinitely. Bump them
-          # together on upgrade.
-          key: hugo-resources-0.157.0-${{ github.sha }}
+          # Keyed on the Hugo resolved above, not a literal, so the four
+          # workflows that share this cache (pull-request.yml,
+          # build-and-deploy.yml, testing-build-and-deploy.yml,
+          # pulumi-cli-docs.yml) stay in step through an upgrade without anyone
+          # remembering to bump them. Hugo does not put its version in its own
+          # cache entries, so without this an upgrade keeps serving images
+          # encoded by the previous version indefinitely.
+          key: hugo-resources-${{ steps.hugo-version.outputs.version }}-${{ github.sha }}
           restore-keys: |
-            hugo-resources-0.157.0-
+            hugo-resources-${{ steps.hugo-version.outputs.version }}-
 
       - name: Build and deploy
         run: make ci_push

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -4007,7 +4007,7 @@ Complete reference of all build and deployment scripts.
 | **GITHUB_TOKEN** | GitHub API | (auto) | GitHub Actions |
 | **NOBUILD** | Skip rebuilds | `1` | User |
 | **ONLY_TEST** | Test single program | `aws-s3-typescript` | User |
-| **GOGC** | Go GC tuning | `3` | Workflow |
+| **GOMEMLIMIT** | Go soft memory ceiling for Hugo (CI only) | `12GiB` | build-site.sh |
 
 ### AWS Resource Naming Conventions
 

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -45,9 +45,12 @@ fi
 
 # --gc prunes cache entries the build no longer references, which is what bounds
 # the growth of the cached resources/ tree (nothing else reclaims superseded
-# entries). Applied on the deploy branches below and only in CI: master's cache
-# is the one PR builds inherit, so pruning there keeps it in check, while a PR
-# build pruning against its own narrower view could evict entries master needs.
+# entries). The guard below is on the non-preview branches, so this covers every
+# non-preview build under CI: the two deploy workflows, plus any CI job that runs
+# `make build` (pulumi-cli-docs.yml does). That is fine because all of them build
+# the full site and so reference the same set of entries. PR preview builds are
+# the ones deliberately excluded -- they share the same cache namespace, and a
+# build pruning against a narrower view could drop entries the others still need.
 hugo_gc=()
 if [ -n "${CI:-}" ]; then
     hugo_gc=(--gc)

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -32,19 +32,36 @@ printf "Running Hugo...\n\n"
 # allocation-heavy operation (image processing above all) drags a full GC behind
 # it. GOMEMLIMIT expresses the actual intent -- "do not exhaust the runner" --
 # as a soft ceiling, letting Go collect at its normal rate until the build
-# approaches the limit. The runner has 16GB; 12GiB leaves room for the Node and
-# Pulumi steps that share it.
-export GOMEMLIMIT=12GiB
+# approaches the limit.
+#
+# CI only: this script is the local build path too (`make build`,
+# scripts/laptop-deploy.sh), and 12GiB is sized for the CI runner's 16GB shared
+# with the Node and Pulumi steps -- on a 16GB laptop it would be no ceiling at
+# all. An explicit GOMEMLIMIT always wins, so a memory-constrained machine can
+# set its own.
+if [ -n "${CI:-}" ]; then
+    export GOMEMLIMIT="${GOMEMLIMIT:-12GiB}"
+fi
 
-if [ "$1" == "preview" ]; then
+# --gc prunes cache entries the build no longer references, which is what bounds
+# the growth of the cached resources/ tree (nothing else reclaims superseded
+# entries). Applied on the deploy branches below and only in CI: master's cache
+# is the one PR builds inherit, so pruning there keeps it in check, while a PR
+# build pruning against its own narrower view could evict entries master needs.
+hugo_gc=()
+if [ -n "${CI:-}" ]; then
+    hugo_gc=(--gc)
+fi
+
+if [ "${1:-}" == "preview" ]; then
     export HUGO_BASEURL="http://$(origin_bucket_prefix)-$(build_identifier).s3-website.$(aws_region).amazonaws.com"
     hugo --minify --buildFuture --templateMetrics -e "preview"
 else
     if [ "$DEPLOYMENT_ENVIRONMENT" == "testing" ]; then
         export HUGO_BASEURL="https://www.pulumi-test.io"
-        hugo --minify --buildFuture --templateMetrics -e "preview"
+        hugo "${hugo_gc[@]}" --minify --buildFuture --templateMetrics -e "preview"
     else
-        hugo --minify --templateMetrics -e "production"
+        hugo "${hugo_gc[@]}" --minify --templateMetrics -e "production"
     fi
 fi
 

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -27,15 +27,24 @@ printf "Generating meta images...\n\n"
 node scripts/generate-meta-images.mjs
 
 printf "Running Hugo...\n\n"
+# Hugo previously ran under GOGC=3, which collects once the heap grows 3% over
+# live heap. That capped memory but cost 1.7-3x in wall time, since every
+# allocation-heavy operation (image processing above all) drags a full GC behind
+# it. GOMEMLIMIT expresses the actual intent -- "do not exhaust the runner" --
+# as a soft ceiling, letting Go collect at its normal rate until the build
+# approaches the limit. The runner has 16GB; 12GiB leaves room for the Node and
+# Pulumi steps that share it.
+export GOMEMLIMIT=12GiB
+
 if [ "$1" == "preview" ]; then
     export HUGO_BASEURL="http://$(origin_bucket_prefix)-$(build_identifier).s3-website.$(aws_region).amazonaws.com"
-    GOGC=3 hugo --minify --buildFuture --templateMetrics -e "preview"
+    hugo --minify --buildFuture --templateMetrics -e "preview"
 else
     if [ "$DEPLOYMENT_ENVIRONMENT" == "testing" ]; then
         export HUGO_BASEURL="https://www.pulumi-test.io"
-        GOGC=3 hugo --minify --buildFuture --templateMetrics -e "preview"
+        hugo --minify --buildFuture --templateMetrics -e "preview"
     else
-        GOGC=3 hugo --minify --templateMetrics -e "production"
+        hugo --minify --templateMetrics -e "production"
     fi
 fi
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -10,14 +10,17 @@
 # re-encode every blog feature image on every run. The caches still saved and
 # restored cleanly, so the waste was invisible in the job log.
 #
-# Skip exactly those two paths under CI. The rest are no-ops on a fresh clone
-# and are left alone so local behavior is unchanged.
+# Skip those paths under CI. `hugo mod clean` is in here too: it is a no-op on a
+# fresh runner (no module cache has been downloaded yet at this point), and
+# keeping it out of the CI path removes any question of it reaching into
+# resources/_gen and undoing the guard above. The rest are no-ops on a fresh
+# clone and are left alone so local behavior is unchanged.
 if [ -z "${CI:-}" ]; then
     yarn cache clean
     rm -rf resources
+    hugo mod clean
 fi
 
-hugo mod clean
 rm -rf node_modules
 rm -rf infrastructure/node_modules
 rm -rf _vendor

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,10 +1,25 @@
 #!/bin/bash
 
-yarn cache clean
+# Locally, this is a full reset: wiping node_modules and the Hugo caches is how
+# you recover from a bad install or stale generated resources.
+#
+# CI is a different situation. The workspace is a fresh clone, so there is
+# nothing stale to remove -- but actions/cache has just restored the yarn cache
+# and Hugo's processed-image cache (resources/) into it. Deleting those here
+# throws the restore away seconds after it happened, which forces Hugo to
+# re-encode every blog feature image on every run. The caches still saved and
+# restored cleanly, so the waste was invisible in the job log.
+#
+# Skip exactly those two paths under CI. The rest are no-ops on a fresh clone
+# and are left alone so local behavior is unchanged.
+if [ -z "${CI:-}" ]; then
+    yarn cache clean
+    rm -rf resources
+fi
+
 hugo mod clean
 rm -rf node_modules
 rm -rf infrastructure/node_modules
-rm -rf resources
 rm -rf _vendor
 rm -rf public
 rm -rf cypress/screenshots


### PR DESCRIPTION
### Proposed changes

Successful `Pull Request` runs have been landing at 14–17 minutes. Profiling [run 32500502599](https://github.com/pulumi/docs/actions/runs/32500502599) (17m12s): "Build and deploy" is 15m45s of it, and the Hugo build alone is **9m05s**.

Two causes, plus two missing guardrails. Three runs on this branch isolate each fix, because the middle one ran cold *with* the GC change:

| | Total | Hugo | `blog/feature-image.html` |
|---|---|---|---|
| Cold cache + `GOGC=3` (before) | 17m12s | 9m05s | 994ms/call |
| Cold cache + `GOMEMLIMIT` ([15484](https://github.com/pulumi/docs/actions/runs/32531633733)) | 12m22s | 4m56s | 561ms/call |
| Warm cache + `GOMEMLIMIT` ([15480](https://github.com/pulumi/docs/actions/runs/32528763915)) | **6m54s** | **48.8s** | **458µs/call** |

The GC change is worth ~4m50s, the cache fix ~5m28s, and they're close to independent. `make ensure` also dropped 1m53s → 1m05s from the preserved yarn cache.

#### 1. The Hugo image cache was deleted 0.2s after it was restored

`make ci_pull_request` → `make ensure`, `ensure` depends on `clean`, and `scripts/clean.sh` ran `rm -rf resources` — the exact directory `actions/cache` had just restored:

```
15:59:59.20  Cache restored from key: hugo-resources-342b83e3... (89 MB)
15:59:59.37  ./scripts/clean.sh
```

Hugo then re-encoded every blog feature image from scratch on every run. The cache still restored *and* saved cleanly each time, so the waste never showed up in the job log — only in the template metrics, where `blog/feature-image.html` averaged **994ms per call** across 718 calls.

`clean.sh` now skips `yarn cache clean`, `rm -rf resources`, and `hugo mod clean` when `CI` is set. The rest are no-ops on a fresh clone, and local behavior is unchanged. `hugo mod clean` tested clean on the pinned 0.157.0 (exits 0, preserves every `resources/_gen` entry, against this repo's real `module:` config) but is inside the guard anyway — it's a no-op that early on a fresh runner, so CI loses nothing and the question can't come back.

Ruled out along the way, so they don't muddy future diagnosis: the per-run preview `baseURL` does **not** bust the cache, nor do fresh-clone mtimes. And `Processed images │ 2755` counts `.Process` *calls*, not encodes — it reads 2755 both before and after this change, so it is not a cache-health signal.

#### 2. `GOGC=3`

`build-site.sh` ran Hugo under `GOGC=3`, collecting once the heap grows 3% over live heap. Measured on a 6,549-page Hugo 0.157.0 harness with a warm cache:

| Config | wall | peak RSS |
|---|---|---|
| `GOGC=3` (before) | 9.4–10.0s | 143 MB |
| `GOGC=100` | 5.6–5.8s | 223 MB |
| `GOGC=100` + `GOMEMLIMIT` | 6.1s | 224 MB |

**1.7–3× slower** for ~35% peak RSS saved, and the penalty grows with heap size. `GOMEMLIMIT=12GiB` expresses the actual intent — don't exhaust the 16GB runner — without paying a full GC behind every allocation. Set **only under CI**, since `build-site.sh` is also the local build path (`make build`, `scripts/laptop-deploy.sh`) where a 12GiB ceiling would be no ceiling at all on a 16GB laptop; an explicit `GOMEMLIMIT` always wins.

`--templateMetrics` was also measured and costs nothing detectable, so it stays.

#### 3 & 4. Two guardrails this workflow was missing

- **Concurrency group with `cancel-in-progress`.** Pushing three commits in a row ran three full builds to completion; branches did exactly that four times in one day. Already demonstrated on this PR — [run 15483](https://github.com/pulumi/docs/actions/runs/32530978253) was cancelled when the next commit landed. Preview buckets are keyed by PR number *and* head sha, so a cancelled run can only orphan its own — `pr-closed.yml` deletes every `*-pr-<num>-*` bucket on close and `bucket-cleanup-testing.yml` sweeps the `www-testing-*` previews daily. Both cache steps run with `save-always: false`, so a cancelled run cannot save a partial cache.
- **`ci-build-duration-alert.sh`,** which `build-and-deploy.yml` already has and PR builds did not. That is how these drifted to ~17 minutes without anyone being told; the script's own header notes the build grew ~60% over three weeks in July the same way. Threshold 15m — it reported `Build and deploy took 10m (655s) ... threshold is 15m` on the cold run, quiet as intended, but would have caught the old 15m45s.

#### 5 & 6. Cache hardening (added after review)

Making the cache actually live activates two latent issues that didn't matter while it was being nuked. Both verified, both fixed here:

- **The Hugo version is now in the cache key.** Hugo 0.156.0 reuses 0.157.0's cached output byte-for-byte, so after an upgrade images stay encoded by whatever version first produced them. Exactly four workflows cache `path: resources` — `pull-request.yml`, `build-and-deploy.yml`, `testing-build-and-deploy.yml`, `pulumi-cli-docs.yml` — and all four now key and restore on `hugo-resources-0.157.0-` and pin `hugo-version: '0.157.0'`. They must move together or they stop sharing a cache; the comment in each names the full set. Kept as a literal rather than interpolating the pin: a failed interpolation there would silently install the wrong Hugo, a worse failure than key drift.
- **`hugo --gc`** prunes entries the build no longer references, which is what bounds growth — nothing else reclaims superseded ones. Applied to every non-`preview` build under CI: the two deploys plus any CI job running `make build` (`pulumi-cli-docs.yml` does, and it's a full-site build, so it prunes against the same reference set). PR preview builds are the deliberate exclusion — they share the namespace, and a narrower view could drop entries the others need.

#### Blast radius

`build-and-deploy.yml` restores the same `hugo-resources` cache and runs the same `clean` via `make ci_push`, so **master deploys were hitting both problems too** and get the same fix.

⚠️ **Expect one slow build per workflow after this merges.** Nothing has written a `hugo-resources-0.157.0-*` entry yet, so the first run of each of the four repopulates from cold. That's the 12m22s column above, not a regression; the run after returns to ~7 minutes.

#### New profile

Hugo is no longer the bottleneck (48.8s, 12% of the run). What's left, roughly evenly: runner setup 1m01s, `make ensure` 1m05s, `generate-docs-content.js` 1m01s, then S3 sync 20s / Cypress 23s / search index 21s / `pulumi preview` 35s / redirects 18s. There's no single large win left — going below ~5 minutes means chipping at several things.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A