### PR TITLE
Explain the Terraform state `outputs` map before the samples use it

### DIFF
--- a/content/docs/iac/get-started/terraform/next-steps.md
+++ b/content/docs/iac/get-started/terraform/next-steps.md
@@ -62,7 +62,7 @@ Our goal is to empower you to use the right tool for the job while maintaining a
 
 The rest of this page is optional reading: patterns to reach for once a basic coexistence setup is working. They depend on your particular needs, so treat them as a general guide to strategies for managing more complex environments rather than as steps to follow in order.
 
-The samples below read Terraform state with `terraform.state.getS3ReferenceOutput` from the `@pulumi/terraform` package — the S3 counterpart of the `getLocalReference` and `getRemoteReference` functions covered in [Reference Terraform State](/docs/iac/get-started/terraform/reference-state/). Each returns an object whose `outputs` map holds the Terraform outputs.
+The samples below read Terraform state with `terraform.state.getS3ReferenceOutput` from the `@pulumi/terraform` package — the S3 counterpart of the `getLocalReference` and `getRemoteReference` functions covered in [Reference Terraform State](/docs/iac/get-started/terraform/reference-state/). Each returns an object with an `outputs` map holding the values the Terraform configuration exports through its `output` blocks, keyed by output name — the same `tfState.outputs["ecs_cluster_name"]` pattern used in that step. Those values arrive as Pulumi [outputs](/docs/iac/concepts/inputs-outputs/), so pass them straight into other resources rather than treating them as plain strings.
 
 ### Multi-stack architectures
 


### PR DESCRIPTION
### Proposed changes

Addresses @jkodroff's review comment on #21046 ("Need to make sure that outputs are linked as a concept or otherwise explained in this doc and that we're not just mentioning this concept out of the blue").

The orientation paragraph added ahead of "Advanced integration patterns" in `content/docs/iac/get-started/terraform/next-steps.md` ended with "Each returns an object whose `outputs` map holds the Terraform outputs" — which names the concept without saying what it is. This expands that sentence to explain the map (the values the Terraform configuration exports through its `output` blocks, keyed by output name), ties it back to the concrete `tfState.outputs["ecs_cluster_name"]` pattern the reader already saw in [Reference Terraform State](https://www.pulumi.com/docs/iac/get-started/terraform/reference-state/), and links [Inputs and outputs](https://www.pulumi.com/docs/iac/concepts/inputs-outputs/) for the Pulumi outputs the values come back as, so they get passed into other resources rather than treated as plain strings.

Based on the #21046 head branch so the diff is just this paragraph; merge into that branch (or cherry-pick the commit) before merging #21046. Note: I linked `/docs/iac/concepts/inputs-outputs/` rather than the `#outputs` anchor other pages use — that anchor doesn't exist on the page (its headings are `#what-are-inputs-and-outputs` and `#working-with-outputs`).

`make lint`: 1846 files parsed, 0 errors, Prettier clean.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Follows up on #21046

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxUijBpHVGxD3z4cQ6y8Lo)_