### PR TITLE
Document organization-managed users and fix adjacent identity gaps

### DIFF
--- a/content/docs/administration/concepts/_index.md
+++ b/content/docs/administration/concepts/_index.md
@@ -19,6 +19,7 @@ How Pulumi Cloud models your organization and who can do what inside it. Read th
 
 - [Organizations](/docs/administration/concepts/organizations/) — the top-level container that owns your stacks, environments, and settings.
 - [Accounts](/docs/administration/concepts/accounts/) — individual user accounts, profiles, and identity providers.
+- [Organization-managed users](/docs/administration/concepts/org-managed-users/) — accounts an organization creates and controls through SAML or SCIM, and the restrictions that come with them.
 - [Agent accounts](/docs/administration/concepts/agent-accounts/) — accounts for AI agents and automation acting on your organization's behalf.
 - [Billing managers](/docs/administration/concepts/billing-managers/) — the role that delegates billing access without granting admin rights.
 - [Access tokens](/docs/administration/concepts/access-tokens/) — personal, team, and organization tokens for authenticating the CLI, CI/CD, and the REST API.

--- a/content/docs/administration/concepts/access-tokens.md
+++ b/content/docs/administration/concepts/access-tokens.md
@@ -7,7 +7,7 @@ menu:
   administration:
     name: Access tokens
     parent: administration-concepts
-    weight: 5
+    weight: 6
 aliases:
 - /docs/administration/access-identity/access-tokens/
 - /docs/intro/pulumi-service/organization-access-tokens/

--- a/content/docs/administration/concepts/accounts.md
+++ b/content/docs/administration/concepts/accounts.md
@@ -68,6 +68,15 @@ Connecting these additional identities will enable you to join Pulumi organizati
 
 In order to be invited as a member of a Pulumi organization, you must connect your account with the organization's backing identity provider. Once your account is linked to your third-party identity, you will then show up on the list of users that the organization admin can invite.
 
+Connecting an identity doesn't add you to the organizations that identity backs. An organization admin still has to invite or add you. See [Backing membership doesn't grant Pulumi membership](/docs/administration/concepts/organizations/#backing-membership).
+
+#### If the identity options aren't there {#identity-options-missing}
+
+The controls for connecting identities aren't available to every account. Two things remove them:
+
+* **Your account is organization-managed.** An account that an organization created through SAML or SCIM can't connect additional identity providers. See [Organization-managed users](/docs/administration/concepts/org-managed-users/).
+* **The provider isn't configured for your deployment.** In [self-hosted Pulumi Cloud](/docs/administration/self-hosting/), a provider only appears if the deployment has been configured with OAuth credentials for it. Ask whoever administers your deployment.
+
 ## Password Reset
 
 For users who signed up with email, you may change your password by:

--- a/content/docs/administration/concepts/agent-accounts.md
+++ b/content/docs/administration/concepts/agent-accounts.md
@@ -7,7 +7,7 @@ menu:
     administration:
         name: Agent Accounts
         parent: administration-concepts
-        weight: 3
+        weight: 4
 aliases:
   - /docs/administration/organizations-teams/agent-accounts/
 ---

--- a/content/docs/administration/concepts/audit-logs.md
+++ b/content/docs/administration/concepts/audit-logs.md
@@ -7,7 +7,7 @@ menu:
   administration:
         name: Audit Logs
         parent: administration-concepts
-        weight: 7
+        weight: 8
         identifier: administration-concepts-audit-logs
 aliases:
 - /docs/administration/security-compliance/audit-logs/

--- a/content/docs/administration/concepts/billing-managers.md
+++ b/content/docs/administration/concepts/billing-managers.md
@@ -7,7 +7,7 @@ menu:
   administration:
     name: Billing managers
     parent: administration-concepts
-    weight: 4
+    weight: 5
 aliases:
 - /docs/pulumi-cloud/access-management/billing-managers/
 - /docs/intro/pulumi-service/billing-managers/

--- a/content/docs/administration/concepts/customer-managed-keys.md
+++ b/content/docs/administration/concepts/customer-managed-keys.md
@@ -6,7 +6,7 @@ h1: Customer Managed Keys
 menu:
   administration:
     parent: administration-concepts
-    weight: 8
+    weight: 9
     identifier: administration-concepts-customer-managed-keys
 aliases:
   - /docs/pulumi-cloud/customer-managed-keys/

--- a/content/docs/administration/concepts/org-managed-users.md
+++ b/content/docs/administration/concepts/org-managed-users.md
@@ -52,7 +52,7 @@ Migrating an ordinary account to an organization-managed one is permanent and de
 Migrating an account deletes your personal organization, removes you from every organization other than the one taking it over, and deletes every linked identity except the managing organization's SAML identity. Any authentication method that depended on a deleted identity, such as GitHub or Google, stops working. Single sign-on through the managing organization becomes the account's only authentication method.
 {{% /notes %}}
 
-Pulumi rejects the migration unless all of the following are true:
+Pulumi rejects the migration unless all the following are true:
 
 1. Your personal organization has no stacks. [Transfer](/docs/administration/concepts/organizations/#transferring-stacks) or delete them first.
 1. Your personal organization has no environments. Environments can't be transferred, so delete them first.

--- a/content/docs/administration/concepts/org-managed-users.md
+++ b/content/docs/administration/concepts/org-managed-users.md
@@ -1,0 +1,71 @@
+---
+title_tag: "Organization-Managed Users | Pulumi Cloud"
+meta_desc: What an organization-managed Pulumi Cloud account is, how SAML and SCIM create one, and the restrictions that apply to it.
+title: Organization-Managed Users
+h1: Organization-Managed Users
+menu:
+    administration:
+        name: Organization-Managed Users
+        parent: administration-concepts
+        weight: 3
+pulumi_cloud_feature: saml-sso
+---
+
+An organization-managed user is a Pulumi Cloud account that belongs to an organization rather than to an individual. The organization's identity provider creates the account and remains the source of truth for it.
+
+For an administrator, this is what makes your Pulumi organization a closed system. Accounts are created, updated, and deactivated from your identity provider, so your Pulumi roster matches your directory and deprovisioning a user in the identity provider revokes their Pulumi access. An account you provision can't be carried into unrelated Pulumi organizations, can't accumulate login methods you don't control, and can't be used to create organizations outside your billing and governance.
+
+## How an account becomes organization-managed
+
+An account becomes organization-managed in one of three ways:
+
+- **Signing in to a SAML organization for the first time.** If you have no Pulumi account and you authenticate through an organization's [SAML single sign-on](/docs/administration/guides/saml/), Pulumi creates one for you. That account is managed by the organization from the moment it exists.
+- **SCIM provisioning.** An organization that uses [SCIM](/docs/administration/guides/scim/) provisions accounts from its identity provider. Every account SCIM creates is organization-managed.
+- **Migrating an existing account.** If you already have an ordinary Pulumi account, you can hand it over to an organization yourself with the **Migrate to Org-Managed Account** control in **Account settings**. The migration is opt-in, and it's [destructive](#migrating-an-existing-account).
+
+## Organization-managed is not the same as SAML membership
+
+Belonging to a SAML-backed organization does not make an account organization-managed. Members of either kind sign in through the same identity provider, so what distinguishes them is where the account came from:
+
+| How the account came to be | Organization-managed |
+|---|---|
+| The organization created it: the user signed in through its SAML SSO with no prior Pulumi account, or SCIM provisioned them | Yes |
+| The user created it, and later joined the organization by [connecting its SAML identity](/docs/administration/guides/saml/#connect-saml-sso-to-an-existing-account) or accepting an invitation | No |
+
+An ordinary account that joins a SAML organization keeps everything an ordinary account has. It gains a SAML identity, and nothing else changes: it can still belong to other organizations, connect other identity providers, and create organizations.
+
+## Restrictions
+
+An organization-managed user is subject to three restrictions that an ordinary Pulumi account isn't:
+
+- **Organization membership.** The account can belong to the organization that manages it, and to organizations related to that one as part of a multi-organization arrangement. Invitations to any other organization are rejected. A user who needs access to an unrelated Pulumi organization has to create a separate Pulumi account that isn't organization-managed.
+- **Additional identities.** The account can't connect the identity providers described in [Adding new identities](/docs/administration/concepts/accounts/#adding-new-identities). GitHub, GitLab, Atlassian, and Google identities are unavailable. A user managed by a multi-organization is the one exception, and a narrow one: they can connect the SAML identities of related organizations.
+- **Creating organizations.** The account can't [create an organization](/docs/administration/concepts/organizations/#creating-an-organization).
+
+## Migrating an existing account
+
+Migrating an ordinary account to an organization-managed one is permanent and destructive, and it takes effect immediately.
+
+{{% notes type="warning" %}}
+Migrating an account removes it from every organization other than the one taking it over and that organization's related organizations, and deletes every linked identity except the managing organization's SAML identity. Any authentication method that depended on a deleted identity, such as GitHub or Google, stops working. Single sign-on through the managing organization becomes the account's only authentication method.
+{{% /notes %}}
+
+Before you migrate:
+
+1. [Transfer any stacks](/docs/administration/concepts/organizations/#transferring-stacks) you want to keep out of the organizations you're about to leave.
+1. Confirm that you don't hold an admin role that another organization depends on.
+1. Make sure you can sign in through the managing organization's identity provider.
+
+To migrate the account:
+
+1. Navigate to **Account settings**.
+1. Under your email address, select **Migrate to Org-Managed Account**.
+
+The [SAML admin](/docs/administration/guides/saml/saml-admin/) role is the exception to the single-authentication-method rule. It exists so that at least one person can still sign in if the SAML configuration breaks, so a SAML admin keeps an alternative login method for as long as they hold the role, and loses it when the role passes to someone else.
+
+## Learn more
+
+- [Accounts](/docs/administration/concepts/accounts/)
+- [Organizations](/docs/administration/concepts/organizations/)
+- [SAML single sign-on](/docs/administration/guides/saml/)
+- [SCIM](/docs/administration/guides/scim/)

--- a/content/docs/administration/concepts/org-managed-users.md
+++ b/content/docs/administration/concepts/org-managed-users.md
@@ -34,32 +34,36 @@ Belonging to a SAML-backed organization does not make an account organization-ma
 
 An ordinary account that joins a SAML organization keeps everything an ordinary account has. It gains a SAML identity, and nothing else changes: it can still belong to other organizations, connect other identity providers, and create organizations.
 
+An organization that uses SCIM is the exception. SCIM can convert an account that already existed, without the user opting in, the next time the identity provider activates or deactivates them. See [Provisioned users are managed by your organization](/docs/administration/guides/scim/#provisioned-users-are-managed-by-your-organization).
+
 ## Restrictions
 
 An organization-managed user is subject to three restrictions that an ordinary Pulumi account isn't:
 
-- **Organization membership.** The account can belong to the organization that manages it, and to organizations related to that one as part of a multi-organization arrangement. Invitations to any other organization are rejected. A user who needs access to an unrelated Pulumi organization has to create a separate Pulumi account that isn't organization-managed.
-- **Additional identities.** The account can't connect the identity providers described in [Adding new identities](/docs/administration/concepts/accounts/#adding-new-identities). GitHub, GitLab, Atlassian, and Google identities are unavailable. A user managed by a multi-organization is the one exception, and a narrow one: they can connect the SAML identities of related organizations.
+- **Organization membership.** The account can belong only to the organization that manages it. Invitations to any other organization are rejected. A user who needs access to an unrelated Pulumi organization has to create a separate Pulumi account that isn't organization-managed.
+- **Additional identities.** The account can't connect the identity providers described in [Adding new identities](/docs/administration/concepts/accounts/#adding-new-identities). GitHub, GitLab, Atlassian, and Google identities are unavailable.
 - **Creating organizations.** The account can't [create an organization](/docs/administration/concepts/organizations/#creating-an-organization).
 
 ## Migrating an existing account
 
-Migrating an ordinary account to an organization-managed one is permanent and destructive, and it takes effect immediately.
+Migrating an ordinary account to an organization-managed one is permanent and destructive, and it takes effect as soon as you confirm it.
 
 {{% notes type="warning" %}}
-Migrating an account removes it from every organization other than the one taking it over and that organization's related organizations, and deletes every linked identity except the managing organization's SAML identity. Any authentication method that depended on a deleted identity, such as GitHub or Google, stops working. Single sign-on through the managing organization becomes the account's only authentication method.
+Migrating an account deletes your personal organization, removes you from every organization other than the one taking it over, and deletes every linked identity except the managing organization's SAML identity. Any authentication method that depended on a deleted identity, such as GitHub or Google, stops working. Single sign-on through the managing organization becomes the account's only authentication method.
 {{% /notes %}}
 
-Before you migrate:
+Pulumi rejects the migration unless all of the following are true:
 
-1. [Transfer any stacks](/docs/administration/concepts/organizations/#transferring-stacks) you want to keep out of the organizations you're about to leave.
-1. Confirm that you don't hold an admin role that another organization depends on.
-1. Make sure you can sign in through the managing organization's identity provider.
+1. Your personal organization has no stacks. [Transfer](/docs/administration/concepts/organizations/#transferring-stacks) or delete them first.
+1. Your personal organization has no environments. Environments can't be transferred, so delete them first.
+1. You aren't an admin of any organization other than the one taking the account over. Change your role there or leave that organization first.
+1. You have a SAML identity for exactly one organization.
 
 To migrate the account:
 
 1. Navigate to **Account settings**.
 1. Under your email address, select **Migrate to Org-Managed Account**.
+1. Review the changes in the confirmation dialog, then select **Migrate**.
 
 The [SAML admin](/docs/administration/guides/saml/saml-admin/) role is the exception to the single-authentication-method rule. It exists so that at least one person can still sign in if the SAML configuration breaks, so a SAML admin keeps an alternative login method for as long as they hold the role, and loses it when the role passes to someone else.
 

--- a/content/docs/administration/concepts/organizations.md
+++ b/content/docs/administration/concepts/organizations.md
@@ -41,6 +41,10 @@ Creating an organization will start a free trial that has access to all features
 At the end of the trial, you can choose the Team, Enterprise, or Business Critical edition.
 Learn more about what each one includes on the [pricing page](/pricing/).
 
+{{% notes type="info" %}}
+[Organization-managed users](/docs/administration/concepts/org-managed-users/) can't create organizations. If an organization created your account through SAML or SCIM, the option isn't available to you.
+{{% /notes %}}
+
 To create an organization:
 
 1. Select the create organization button at the top of the navigation.
@@ -58,6 +62,14 @@ you must associate a GitLab identity with your Pulumi account, and also
 be a member of that GitLab group.
 
 For more information, see [How do I link an existing Pulumi account to my company's organization?](/docs/support/faq/pulumi-cloud/#how-do-i-link-an-existing-pulumi-account-to-my-companys-organization)
+
+### Backing membership doesn't grant Pulumi membership {#backing-membership}
+
+Being in the backing GitHub organization, GitLab group, or Bitbucket workspace doesn't put you in the Pulumi organization. It only makes you someone an admin can add.
+
+Once you connect the matching identity to your Pulumi account, you appear on the list of people a Pulumi organization admin can invite or add. Until an admin does that, you have no access.
+
+If you're in the GitHub organization but don't see anything in Pulumi, this is why. Ask an organization admin to add you.
 
 ## Inviting members to an organization
 
@@ -84,11 +96,7 @@ To switch to a different organization:
 
 ## Organization roles
 
-| Role | Description |
-|--------|--------|
-| Admin | Administrators have full access to the organization including: inviting members, creating teams and policies, managing stack permissions and role-based access control, adjusting billing information, and controlling the organization settings. |
-| Member | Members are able to view and edit stacks they have access to and view members and teams. |
-| Billing Manager | Billing Managers are able to adjust billing information and view other Billing Managers. They do not have read or write access to stacks, teams, or policies. |
+Every member of an organization has a role: the built-in Admin, Member, or Billing Manager, or a custom role. For what each one grants, see [Roles](/docs/administration/concepts/rbac/roles/#pulumi-defined-roles). For delegating billing access without admin rights, see [Billing Managers](/docs/administration/concepts/billing-managers/).
 
 ## Updating billing information
 
@@ -181,6 +189,8 @@ Pulumi organization.
 
 A Pulumi organization can also be backed by a [SAML 2.0 identity provider](/docs/administration/guides/saml/).
 
+This setting goes by more than one name. The docs and the console call it the organization's **identity provider**, and you configure it under **Membership Requirements**; the console also refers to it as the organization backend, which is the name the REST API uses. They all mean the same thing.
+
 ### Changing identity providers
 
 Every organization is backed by an identity that governs the membership to your organization.
@@ -189,6 +199,8 @@ By default, when you create a new Pulumi organization, it uses the Pulumi identi
 Only organization admins can change the organization identity provider.
 
 Organization members must first add the new identity provider to their individual accounts before changing the organization identity provider, or members will be locked out of the organization.
+
+Switching an organization to SAML has one further prerequisite: the admin making the change can't belong to other, unrelated Pulumi organizations. Pulumi rejects the change otherwise. Either hand the change to an admin who belongs only to this organization, or leave the other organizations first.
 
 To change an organization's identity provider:
 
@@ -199,6 +211,10 @@ To change an organization's identity provider:
 ### Disconnecting identity providers
 
 In order to disconnect an identity provider you need to select another identity provider. This is also true for SAML SSO. To remove SAML SSO configuration, select a new identity provider.
+
+{{% notes type="warning" %}}
+Switching away from SAML discards the organization's SAML configuration and everything derived from it: its SAML identities, its SAML member roster, and its SCIM access token. If you switch back to SAML later, you have to reconfigure [SCIM](/docs/administration/guides/scim/) with a newly issued token and re-provision your users.
+{{% /notes %}}
 
 Organization members must first add the new identity provider to their individual accounts before changing the organization identity provider, or members will be locked out of the organization.
 
@@ -230,15 +246,22 @@ those users will lose access to Pulumi organization.
 
 ### Bitbucket identity provider
 
-[BitBucket Workspaces](https://support.atlassian.com/bitbucket-cloud/docs/what-is-a-workspace/)
+[Bitbucket workspaces](https://support.atlassian.com/bitbucket-cloud/docs/what-is-a-workspace/)
 
 To add a Bitbucket-backed organization to Pulumi, an admin of the Atlassian
 Bitbucket workspace
-must first grant the Pulumi Oauth app [read access](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Scopes)
+must first grant the Pulumi OAuth app [read access](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Scopes)
 to their Bitbucket account and workspace membership information.
 
+Two further requirements apply, and neither is obvious from the console:
+
+* **You need admin or owner rights in the Bitbucket workspace.** Granting the OAuth app read access isn't enough by itself. The person making the change in Pulumi must be an admin or owner of the workspace; a contributor or plain member gets an error.
+* **A personal Bitbucket account with no workspace won't work.** Pulumi backs the organization with a workspace, so the account has to have one.
+
 Once the Pulumi organization has been created, the admin can see a list of Bitbucket workspace
-members that they can add or invite to the Pulumi organization.
+members that they can add or invite to the Pulumi organization. Adding them is a separate step from their workspace membership. See [Backing membership doesn't grant Pulumi membership](#backing-membership).
+
+Bitbucket is an Atlassian product, and Pulumi labels the identity after Atlassian rather than Bitbucket. The control in your account settings is **Connect Atlassian**, and a connected Bitbucket identity is listed as **Atlassian**.
 
 ### SAML Single Sign-on (SSO)
 

--- a/content/docs/administration/concepts/organizations.md
+++ b/content/docs/administration/concepts/organizations.md
@@ -200,7 +200,7 @@ Only organization admins can change the organization identity provider.
 
 Organization members must first add the new identity provider to their individual accounts before changing the organization identity provider, or members will be locked out of the organization.
 
-Switching an organization to SAML has one further prerequisite: the admin making the change can't belong to other, unrelated Pulumi organizations. Pulumi rejects the change otherwise. Either hand the change to an admin who belongs only to this organization, or leave the other organizations first.
+Switching an organization to SAML has one further prerequisite. {{< saml-conversion-prereq >}}
 
 To change an organization's identity provider:
 

--- a/content/docs/administration/concepts/rbac/_index.md
+++ b/content/docs/administration/concepts/rbac/_index.md
@@ -11,7 +11,7 @@ aliases:
 menu:
   administration:
     parent: administration-concepts
-    weight: 6
+    weight: 7
     identifier: administration-concepts-rbac
 ---
 

--- a/content/docs/administration/guides/saml/_index.md
+++ b/content/docs/administration/guides/saml/_index.md
@@ -33,6 +33,8 @@ If you're a member of a SAML-based Pulumi organization, you can sign in to [your
 {{< sso-scim-limits-info >}}
 {{% /notes %}}
 
+Signing in through SSO without an existing Pulumi account creates one, and the organization manages that account: it can't join unrelated organizations, connect other identity providers, or create organizations of its own. An account that already existed and later connects a SAML identity keeps those abilities. See [Organization-managed users](/docs/administration/concepts/org-managed-users/).
+
 ## Connect SAML SSO to an existing account
 
 If you already have a Pulumi account and need to access a SAML-based organization, connect that organization's SAML SSO identity to your existing account rather than signing in to the organization directly. Signing in directly can produce an "Email already in use" error when your email already belongs to an account, and that screen cannot resolve the conflict on its own.
@@ -46,6 +48,14 @@ To connect a SAML SSO identity to your existing account:
 After your identity provider confirms your identity, Pulumi adds the organization's SAML identity to your existing account and grants you access to the organization.
 
 If the connection fails, confirm with your organization administrator that your identity provider assigns you to the Pulumi application for that organization and that the SAML `NameID` it sends is stable. An unstable `NameID` can create duplicate identities and repeat the conflict.
+
+## Before you configure SAML
+
+{{% notes type="info" %}}
+{{< saml-conversion-prereq >}}
+{{% /notes %}}
+
+Switching an organization to SAML is reversible, but not cleanly. Selecting a different identity provider later discards the organization's SAML identities, its SAML member roster, and its SCIM access token. See [Disconnecting identity providers](/docs/administration/concepts/organizations/#disconnecting-identity-providers).
 
 ## Integration Guides
 

--- a/content/docs/administration/guides/saml/auth0.md
+++ b/content/docs/administration/guides/saml/auth0.md
@@ -48,6 +48,10 @@ the same URL.
 
 ## Configuring your Pulumi organization
 
+{{% notes type="info" %}}
+{{< saml-conversion-prereq >}}
+{{% /notes %}}
+
 To configure Pulumi with the SAML metadata:
 
 1. Sign in to Pulumi Cloud and navigate to your organization.

--- a/content/docs/administration/guides/saml/entra.md
+++ b/content/docs/administration/guides/saml/entra.md
@@ -89,6 +89,10 @@ Entra ID application.
 
 ## Configuring your Pulumi organization
 
+{{% notes type="info" %}}
+{{< saml-conversion-prereq >}}
+{{% /notes %}}
+
 To configure your Pulumi organization to accept SAML SSO requests from Entra ID, you will need to
 download the SAML application's configuration data and then pass that to Pulumi.
 

--- a/content/docs/administration/guides/saml/gsuite.md
+++ b/content/docs/administration/guides/saml/gsuite.md
@@ -82,6 +82,10 @@ domain users by selecting the down arrow in the **User access** panel:
 
 ## Configuring your Pulumi organization
 
+{{% notes type="info" %}}
+{{< saml-conversion-prereq >}}
+{{% /notes %}}
+
 1. Sign in to Pulumi Cloud and navigate to your organization.
 1. Select **Settings** > **Access Management**.
 1. Select the **Other** tab.

--- a/content/docs/administration/guides/saml/jumpcloud.md
+++ b/content/docs/administration/guides/saml/jumpcloud.md
@@ -79,6 +79,10 @@ Pulumi requires the IdP metadata XML from JumpCloud to complete SSO configuratio
 
 ## Configuring your Pulumi organization
 
+{{% notes type="info" %}}
+{{< saml-conversion-prereq >}}
+{{% /notes %}}
+
 1. Sign in to [Pulumi Cloud](https://app.pulumi.com) and navigate to your organization.
 1. Select the **Settings** tab, then **Access Management**.
 1. Under **Membership Requirements**, select **Change requirements**.

--- a/content/docs/administration/guides/saml/okta.md
+++ b/content/docs/administration/guides/saml/okta.md
@@ -82,6 +82,10 @@ page.
 
 ## Configuring your Pulumi organization
 
+{{% notes type="info" %}}
+{{< saml-conversion-prereq >}}
+{{% /notes %}}
+
 To configure Pulumi Cloud with details on your new Okta-based SAML application, you need to
 obtain the IdP metadata document from Okta and then provide it to Pulumi.
 

--- a/content/docs/administration/guides/saml/onelogin.md
+++ b/content/docs/administration/guides/saml/onelogin.md
@@ -86,6 +86,10 @@ To assign users or groups to the application, navigate to the **Users** tab in t
 
 ## Configuring your Pulumi organization
 
+{{% notes type="info" %}}
+{{< saml-conversion-prereq >}}
+{{% /notes %}}
+
 To configure Pulumi Cloud with details on your new OneLogin-based SAML application, you need to obtain
 the IdP metadata document from OneLogin and then provide it to Pulumi.
 

--- a/content/docs/administration/guides/saml/saml-admin.md
+++ b/content/docs/administration/guides/saml/saml-admin.md
@@ -31,4 +31,6 @@ Only organization admins can be SAML admins. If you want to designate a member o
 When a user stops being a SAML admin, they will automatically lose all other login methods.
 {{% /notes %}}
 
+Losing every login method other than single sign-on is the same thing that happens to an [organization-managed user](/docs/administration/concepts/org-managed-users/).
+
 Only one SAML admin per organization is supported at this time.

--- a/content/docs/administration/guides/scim/_index.md
+++ b/content/docs/administration/guides/scim/_index.md
@@ -78,7 +78,9 @@ These apply to every identity provider, regardless of which guide you follow.
 
 An account SCIM creates belongs to your organization, not to the person using it. Such an account can't join unrelated Pulumi organizations, connect additional identity providers, or create organizations of its own. See [Organization-managed users](/docs/administration/concepts/org-managed-users/) for the full set of restrictions.
 
-This does not apply retroactively. Someone who already had a Pulumi account and joined your organization by invitation keeps an ordinary account, even after SCIM starts managing their membership.
+This mostly doesn't apply retroactively. Someone who already had a Pulumi account and joined your organization by invitation keeps an ordinary account when SCIM starts managing their membership.
+
+One case converts them. The next time your identity provider activates or deactivates such a user, Pulumi checks whether the account can be converted cleanly, and converts it if so. Clean means the user's personal organization holds no stacks and no environments, and they belong to no Pulumi organization other than yours. An account that fails any of those checks stays ordinary, and the activation change applies as normal. Unlike the [migration a user performs themselves](/docs/administration/concepts/org-managed-users/#migrating-an-existing-account), this conversion isn't opt-in.
 
 ### Deprovisioning never deletes a user
 

--- a/content/docs/administration/guides/scim/_index.md
+++ b/content/docs/administration/guides/scim/_index.md
@@ -78,9 +78,9 @@ These apply to every identity provider, regardless of which guide you follow.
 
 An account SCIM creates belongs to your organization, not to the person using it. Such an account can't join unrelated Pulumi organizations, connect additional identity providers, or create organizations of its own. See [Organization-managed users](/docs/administration/concepts/org-managed-users/) for the full set of restrictions.
 
-This mostly doesn't apply retroactively. Someone who already had a Pulumi account and joined your organization by invitation keeps an ordinary account when SCIM starts managing their membership.
+Existing accounts convert in one case only. Someone who already had a Pulumi account and joined your organization by invitation keeps an ordinary account when SCIM starts managing their membership. But the next time your identity provider activates or deactivates such a user, Pulumi checks whether the account can be converted cleanly, and converts it if so. Clean means the user's personal organization holds no stacks and no environments, and they belong to no Pulumi organization other than yours. An account that fails any of those checks stays ordinary, and the activation change applies as normal.
 
-One case converts them. The next time your identity provider activates or deactivates such a user, Pulumi checks whether the account can be converted cleanly, and converts it if so. Clean means the user's personal organization holds no stacks and no environments, and they belong to no Pulumi organization other than yours. An account that fails any of those checks stays ordinary, and the activation change applies as normal. Unlike the [migration a user performs themselves](/docs/administration/concepts/org-managed-users/#migrating-an-existing-account), this conversion isn't opt-in.
+The conversion is the same operation the user would perform themselves, minus the confirmation: it deletes their personal organization and every login method except your organization's single sign-on. Someone who signed in with GitHub or Google signs in through your identity provider from then on. See [Migrating an existing account](/docs/administration/concepts/org-managed-users/#migrating-an-existing-account).
 
 ### Deprovisioning never deletes a user
 

--- a/content/docs/administration/guides/scim/_index.md
+++ b/content/docs/administration/guides/scim/_index.md
@@ -74,6 +74,12 @@ For groups:
 
 These apply to every identity provider, regardless of which guide you follow.
 
+### Provisioned users are managed by your organization
+
+An account SCIM creates belongs to your organization, not to the person using it. Such an account can't join unrelated Pulumi organizations, connect additional identity providers, or create organizations of its own. See [Organization-managed users](/docs/administration/concepts/org-managed-users/) for the full set of restrictions.
+
+This does not apply retroactively. Someone who already had a Pulumi account and joined your organization by invitation keeps an ordinary account, even after SCIM starts managing their membership.
+
 ### Deprovisioning never deletes a user
 
 Pulumi has no endpoint for deleting a user through SCIM. Deprovisioning sets `active` to `false`, which removes the user's access to the organization while preserving their account and its history, so the change is reversible by reactivating the user in your IdP. Configure your IdP to suspend or deactivate users rather than delete them.
@@ -106,6 +112,12 @@ A group search returns every team in your organization whose display name matche
 
 This matters because an identity provider that reconciles group state may treat a team it does not own as one to remove, and a delete request succeeds against any team in the organization. Scope reconciliation to the groups your identity provider provisions, or give SCIM-managed teams a distinct naming convention so the others are easy to exclude.
 {{% /notes %}}
+
+### Changing the identity provider revokes the SCIM token
+
+Your organization's SCIM access token is tied to its SAML configuration. If an admin switches the organization to a different [identity provider](/docs/administration/concepts/organizations/#changing-identity-providers), that configuration is discarded along with the SCIM token, the organization's SAML identities, and its SAML member roster.
+
+Switching back to SAML doesn't restore any of it. You have to issue a new SCIM token, point your identity provider at it, and re-provision your users.
 
 ## Next steps
 

--- a/content/docs/support/faq/pulumi-cloud.md
+++ b/content/docs/support/faq/pulumi-cloud.md
@@ -111,15 +111,15 @@ For detailed steps, see [Deleting an organization](/docs/administration/concepts
 
 ### How do I link an existing Pulumi account to my company's organization?
 
-To join your company's organization, you must sign in with the identity provider that organization is backed by (for example, GitHub, GitLab, SAML/SSO, or email).
+Your account needs the identity that backs your company's organization. How you get it depends on the kind of identity provider the organization uses.
 
-If you already have a Pulumi account, navigate to your profile in [Pulumi Cloud](https://app.pulumi.com/signin) and connect that identity provider, then accept the organization invite.
+For **GitHub, GitLab, and Atlassian (Bitbucket)**, connect the identity to your existing account: navigate to your profile in [Pulumi Cloud](https://app.pulumi.com/signin), connect that identity provider, then accept the organization invite.
 
-If this fails, delete your account, then accept the organization invite.
+You don't have to sign in to Pulumi Cloud with that provider. Signing in with email is fine. What matters is that the identity is connected to your account, and that it belongs to the GitHub organization, GitLab group, or Bitbucket workspace backing the Pulumi organization.
 
-{{% notes type="warning" %}}
-Note that deleting your account will remove access to any stacks and environments still under the account. Transfer any stacks you want to keep before proceeding.
-{{% /notes %}}
+For **SAML/SSO**, authenticating through the identity provider is what establishes the identity, so you do have to complete a single sign-on. Start it from your existing account rather than signing in to the organization directly, which can produce an "Email already in use" error. See [Connect SAML SSO to an existing account](/docs/administration/guides/saml/#connect-saml-sso-to-an-existing-account).
+
+If your account offers no way to connect an identity provider, see [If the identity options aren't there](/docs/administration/concepts/accounts/#identity-options-missing).
 
 For more about joining organizations, see [Joining an organization](/docs/administration/concepts/organizations/#joining-an-organization).
 

--- a/layouts/shortcodes/saml-conversion-prereq.html
+++ b/layouts/shortcodes/saml-conversion-prereq.html
@@ -1,0 +1,1 @@
+The admin who makes this change can't belong to other, unrelated Pulumi organizations. Pulumi rejects the switch to SAML otherwise, and the error surfaces at the last step of setup. Either have an admin who belongs only to this organization make the change, or leave the other organizations first.


### PR DESCRIPTION
Adds a concepts page for organization-managed Pulumi Cloud accounts — accounts an organization creates and controls through SAML JIT provisioning or SCIM — and closes the seven adjacent documentation gaps found in the same investigation.

## Changes

**New page** — `concepts/org-managed-users.md`: how an account becomes org-managed, why an administrator wants it, how it differs from SAML organization membership, the three restrictions, and the destructive **Migrate to Org-Managed Account** migration. Cross-linked from Accounts, SAML, SCIM, and SAML admin.

**Adjacent fixes**

- FAQ: the answer on linking an existing account conflated *linking* an OAuth identity with *signing in* through it — now split by provider kind
- Accounts: new "If the identity options aren't there" section
- Organizations: Bitbucket workspace admin requirement; backing membership vs. Pulumi membership; destructive SAML disconnect; multi-org prerequisite for SAML conversion; Atlassian/Bitbucket naming; trimmed the roles table that duplicated RBAC
- SCIM: provisioned users are org-managed; identity-provider change revokes the SCIM token
- New `saml-conversion-prereq` shortcode, used in all six SAML guides

Concepts nav weights shifted to seat the new page after Accounts.

Fixes #21103