### PR TITLE
Update homepage hero and supporting copy

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -10,12 +10,12 @@ sections:
     layout: split
     cta_secondary_text: Download open source
     cta_secondary_link: /docs/install/
-    badge_highlight_text: "Latest release:"
-    badge_text: "Full support for Terraform and HCL"
+    badge_highlight_text: "New:"
+    badge_text: "Native support for Terraform and HCL"
     badge_link: /releases/terraform-state-backend-modules-hcl/
-    title: "*Next-level*<br>infrastructure as code for humans and agents."
+    title: "*Unleash agents*<br>on your infrastructure."
     description: |
-      Ship cloud infrastructure at the speed of AI with languages and tools that stay out of your way.
+      Ship infrastructure faster with tools that let agents do what they do best — without letting them go off the rails.
     anchor: hero
     code_overlay_image: /images/home/home-hero-code-overlay.svg
     code_aspect_ratio: "666/513"
@@ -117,6 +117,7 @@ sections:
                   ).ToList()
               );
           });
+
       - language: java
         label: Java
         title: "App.java"
@@ -152,6 +153,35 @@ sections:
                   });
               }
           }
+
+      - language: hcl
+        label: HCL
+        title: "main.tf"
+        code: |
+          terraform {
+            required_providers {
+              aws = {
+                source  = "pulumi/aws"
+              }
+              awsx = {
+                source  = "pulumi/awsx"
+              }
+            }
+          }
+
+          resource "awsx_ec2_vpc" "vpc" {}
+
+          data "aws_availability_zones" "available" {
+            state = "available"
+          }
+
+          resource "aws_subnet" "subnet" {
+            count             = length(data.aws_availability_zones.available.names)
+            vpc_id            = awsx_ec2_vpc.vpc.vpc_id
+            cidr_block        = "10.0.${count.index}.0/24"
+            availability_zone = data.aws_availability_zones.available.names[count.index]
+          }
+
       - language: yaml
         label: YAML
         title: "Pulumi.yaml"
@@ -253,26 +283,26 @@ sections:
     anchor: logos
 
   - type: feature_split
-    heading: The **complete platform** for infrastructure teams
+    heading: The **infrastructure platform** for humans and agents
     description: |
-      **From open source IaC to AI-driven workflows, Pulumi gives platform teams all they need to build and scale cloud infrastructure.**
+      Coding agents have reset the pace at which we build software. Pulumi brings that same agent-driven velocity to infrastructure.
 
-      A unified platform built on real programming languages that covers the full infrastructure stack, so your team can focus on shipping.
+      Open source and powered by languages agents know well, Pulumi is **software-driven infrastructure** that gives humans and agents the tools they need to build and scale infrastructure — safely.
     cta_text: Explore the platform
     cta_link: /product/
     cards:
       - image: /images/home/languages-card-image.svg
         image_alt: Programming language logos
-        title: Real languages
-        description: Write infrastructure code in TypeScript, Python, Go, C#, or Java — the same languages your team already uses to build software.
+        title: Use your language of choice
+        description: Build infrastructure with modern languages like TypeScript, Python, Go, C#, and more — or config languages like YAML and HCL.
       - image: /images/home/secure-card-image.svg
         image_alt: Security shield illustration
-        title: Secure by default
-        description: Meet compliance requirements with encrypted secrets, dynamic credentials, and full audit trails. Pulumi is SOC 2 Type II certified.
+        title: Keep it secure at every step
+        description: Meet compliance requirements with encrypted secrets, dynamic credentials, policy as code, and full audit trails. Pulumi is SOC 2 Type II certified.
       - image: /images/home/ai-card-image.svg
         image_alt: AI for infrastructure illustration
-        title: AI for infrastructure
-        description: Bring your own coding agent — or use Pulumi Neo — to generate, debug, and refactor infrastructure code with built-in best practices and full organizational context.
+        title: Bring full context to agents
+        description: Use our open-source skills with any coding agent — or use Pulumi Neo — to automate workflows with best practices and full organizational context.
     anchor: platform
 
   - type: testimonial
@@ -287,7 +317,7 @@ sections:
     large_cards:
       - title: Don't just write IaC — compose it
         description: |
-          Take advantage of your language of choice to build reusable components and share them with package managers like npm, PyPI, and NuGet. Get all of the benefits of your IDE, including type checking, code navigation, inline docs, testing, and more.
+          Take full advantage of your preferred language to build reusable components and share them with package managers like npm, PyPI, and NuGet. Get all of the benefits of your IDE, including type checking, code navigation, inline docs, testing, and more.
 
         image: /images/home/iac-card-image.svg
         image_alt: Pulumi infrastructure as code editor
@@ -295,7 +325,7 @@ sections:
         cta_link: /product/infrastructure-as-code/
       - title: Meet Neo, your AI platform engineer
         description: |
-          The first AI agent built for infrastructure. Pulumi Neo understands your code and organizational context, respects your policies, and executes complex tasks end-to-end — with or without a human in the loop. It works alongside the coding agents you already use.
+          The first AI agent built for infrastructure, Pulumi Neo understands your code and organizational context, respects your policies, and executes complex tasks end-to-end — with or without a human in the loop. And it works alongside the coding agents you already use.
         image: /images/home/neo-card-image.svg
         image_alt: Pulumi Neo AI platform engineer
         cta_text: Learn more about Neo


### PR DESCRIPTION
Makes a few adjustments to the home-page copy to align with updated messaging. 

Also adds an HCL version to the example in the hero visual. (We're currently working on a much more substantial update to this one; this just adds HCL to cover it in the meantime.)