### PR TITLE
Mark compliance policy packs as Business Critical in docs and pricing

### DIFF
--- a/content/blog/iso-27001-policy-pack-for-aws/index.md
+++ b/content/blog/iso-27001-policy-pack-for-aws/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Enforce ISO 27001 Across Your AWS Infrastructure"
 date: 2026-06-30
+updated: 2026-08-25
 authors:
     - dan-biwer
 meta_desc: "Align your AWS infrastructure to ISO/IEC 27001:2022 with a pre-built Pulumi policy pack of 238 ready-to-run security policies."
@@ -78,7 +79,7 @@ Adopting any pack means you skip the authoring work entirely, inherit framework 
 
 ## Get started today
 
-The ISO 27001 pack is available now to every Pulumi Cloud user:
+The ISO 27001 pack is available now on the [Business Critical edition](/pricing/#pre-built-policy-packs) of Pulumi Cloud:
 
 1. Browse the [pack reference](/docs/reference/pre-built-policy-packs/iso-27001/aws/) to see all 238 policies and how they map to the standard's controls.
 1. Explore the full [pre-built packs index](/docs/insights/policy/policy-packs/pre-built-packs/).

--- a/content/docs/insights/policy/_index.md
+++ b/content/docs/insights/policy/_index.md
@@ -85,7 +85,7 @@ Pulumi Cloud extends policy capabilities with centralized management and additio
 **Preventative policies:**
 
 - Centralized management via [Policy Groups](/docs/insights/policy/policy-groups/)
-- Access to Pulumi-authored pre-built policy packs for common compliance frameworks
+- Access to Pulumi-authored [pre-built policy packs](/docs/insights/policy/policy-packs/pre-built-packs/) (Pulumi Best Practices on the Team edition and above; compliance-framework packs on the Business Critical edition)
 - Support for open source policy packs by publishing them to your organization's private registry
 - Automatic policy pack download to local cache
 - No need to specify `--policy-pack` flag for each command

--- a/content/docs/insights/policy/integrations/aws-organizations-tag-policies.md
+++ b/content/docs/insights/policy/integrations/aws-organizations-tag-policies.md
@@ -9,6 +9,7 @@ menu:
         name: AWS Organizations Tag Policies
         parent: integrations
         weight: 2
+pulumi_cloud_feature: pre-built-policy-packs
 ---
 
 ## Overview

--- a/content/docs/insights/policy/policy-packs/_index.md
+++ b/content/docs/insights/policy/policy-packs/_index.md
@@ -24,7 +24,7 @@ A pack does nothing on its own. To enforce it, add it to a [policy group](/docs/
 
 ## Types of policy packs
 
-- <a id="pre-built-policy-packs"></a>**[Pre-built policy packs](/docs/insights/policy/policy-packs/pre-built-packs/)** are written and maintained by Pulumi. They cover common compliance frameworks, including CIS, PCI DSS, HITRUST, and NIST, as well as security, cost, and operational best practices for AWS, Azure, and Google Cloud. You enable them from Pulumi Cloud without writing any code.
+- <a id="pre-built-policy-packs"></a>**[Pre-built policy packs](/docs/insights/policy/policy-packs/pre-built-packs/)** are written and maintained by Pulumi. They cover common compliance frameworks, including CIS, PCI DSS, HITRUST, NIST, and ISO 27001, as well as security, cost, and operational best practices for AWS, Azure, and Google Cloud. You enable them from Pulumi Cloud without writing any code. The Pulumi Best Practices and AWS Organizations Tag Policies packs are included in the Team edition and above; the compliance-framework packs require the [Business Critical edition](/pricing/#pre-built-policy-packs).
 
 - <a id="custom-policy-packs"></a>**[Custom policy packs](/docs/insights/policy/policy-packs/authoring/)** are the ones you write yourself, in TypeScript, Python, or [OPA (Rego)](/docs/insights/policy/policy-packs/authoring/#opa), to enforce requirements specific to your organization. You can test a custom pack locally with `pulumi preview --policy-pack` before publishing it to Pulumi Cloud.
 

--- a/content/docs/insights/policy/policy-packs/pre-built-packs.md
+++ b/content/docs/insights/policy/policy-packs/pre-built-packs.md
@@ -16,7 +16,6 @@ aliases:
   - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-aws
   - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-azure
   - /docs/iac/packages-and-automation/crossguard/compliance-ready-policies-gcp
-pulumi_cloud_feature: pre-built-policy-packs
 ---
 
 Pulumi Cloud comes with pre-built policy packs that codify best practices for common security and compliance frameworks. These packs allow you to quickly evaluate your organization's compliance posture and "shift left," embedding continuous compliance directly into your IaC workflow. Proactively enforce controls, reduce misconfiguration risks before deployment, and help your organization meet its regulatory obligations with confidence.
@@ -30,18 +29,22 @@ Pulumi Cloud comes with pre-built policy packs that codify best practices for co
 
 ### Available policy packs
 
+{{< pulumi-cloud "compliance-policy-packs" >}}
+That applies to every pack below except **Pulumi Best Practices** and **AWS Organizations Tag Policies**, which are available on the [Team edition and above](/pricing/#pre-built-policy-packs).
+{{< /pulumi-cloud >}}
+
 The following pre-built policy packs are available out of the box in Pulumi Cloud.
 
-| Framework | Supported Cloud Providers | Description |
-| ----- | ----- | ----- |
-| **CIS 8.1** | [AWS](/docs/reference/pre-built-policy-packs/cis/aws/), [Azure](/docs/reference/pre-built-policy-packs/cis/azure/), [Google Cloud](/docs/reference/pre-built-policy-packs/cis/google-cloud/) | Enforces CIS 8.1 controls to help organizations implement industry-recognized security best practices and benchmarks across multiple cloud providers. |
-| **CIS Kubernetes** | [AWS (EKS)](/docs/reference/pre-built-policy-packs/cis-kubernetes/aws/), [Azure (AKS)](/docs/reference/pre-built-policy-packs/cis-kubernetes/azure/), [Google Cloud (GKE)](/docs/reference/pre-built-policy-packs/cis-kubernetes/google-cloud/) | Enforces CIS Kubernetes Benchmark controls for managed Kubernetes services, helping organizations secure their container orchestration platforms with industry-recognized best practices. |
-| **HITRUST CSF 11.5** | [AWS](/docs/reference/pre-built-policy-packs/hitrust/aws/), [Azure](/docs/reference/pre-built-policy-packs/hitrust/azure/), [Google Cloud](/docs/reference/pre-built-policy-packs/hitrust/google-cloud/) | Provides predefined controls that align cloud resources with HITRUST CSF requirements, helping organizations enforce security and compliance baselines across multiple providers. |
-| **ISO/IEC 27001:2022** | [AWS](/docs/reference/pre-built-policy-packs/iso-27001/aws/) | Enforces ISO/IEC 27001:2022 Annex A controls for AWS resources, helping organizations align their cloud infrastructure with the international standard for information security management. |
-| **NIST SP 800-53** | [AWS](/docs/reference/pre-built-policy-packs/nist/aws/), [Google Cloud](/docs/reference/pre-built-policy-packs/nist/google-cloud/) | Enforces NIST SP 800-53 rev. 5 security and privacy controls for AWS and Google Cloud resources, helping federal agencies and organizations meet rigorous compliance requirements. |
-| **PCI DSS v4.0.1** | [AWS](/docs/reference/pre-built-policy-packs/pci-dss/aws/) | Enforces PCI DSS v4.0.1 compliance controls for AWS resources, ensuring payment card data security and helping organizations meet payment card industry standards. |
-| **Pulumi Best Practices** | [AWS](/docs/reference/pre-built-policy-packs/pulumi-best-practices/aws/), [Azure](/docs/reference/pre-built-policy-packs/pulumi-best-practices/azure/), [Google Cloud](/docs/reference/pre-built-policy-packs/pulumi-best-practices/google-cloud/) | Offers a foundational set of recommended governance and security controls, serving as a strong starting point for organizations seeking comprehensive security coverage. |
-| **AWS Organizations Tag Policies** | [AWS and AWS-Native](/docs/reference/pre-built-policy-packs/aws-organizations-tag-policies/aws/) | Integrates with AWS Organizations Tag Policies to validate that infrastructure as code resources have required tags before deployment. [Learn more](/docs/insights/policy/integrations/aws-organizations-tag-policies/). |
+| Framework | Supported Cloud Providers | Edition | Description |
+| ----- | ----- | ----- | ----- |
+| **CIS 8.1** | [AWS](/docs/reference/pre-built-policy-packs/cis/aws/), [Azure](/docs/reference/pre-built-policy-packs/cis/azure/), [Google Cloud](/docs/reference/pre-built-policy-packs/cis/google-cloud/) | Business Critical | Enforces CIS 8.1 controls to help organizations implement industry-recognized security best practices and benchmarks across multiple cloud providers. |
+| **CIS Kubernetes** | [AWS (EKS)](/docs/reference/pre-built-policy-packs/cis-kubernetes/aws/), [Azure (AKS)](/docs/reference/pre-built-policy-packs/cis-kubernetes/azure/), [Google Cloud (GKE)](/docs/reference/pre-built-policy-packs/cis-kubernetes/google-cloud/) | Business Critical | Enforces CIS Kubernetes Benchmark controls for managed Kubernetes services, helping organizations secure their container orchestration platforms with industry-recognized best practices. |
+| **HITRUST CSF 11.5** | [AWS](/docs/reference/pre-built-policy-packs/hitrust/aws/), [Azure](/docs/reference/pre-built-policy-packs/hitrust/azure/), [Google Cloud](/docs/reference/pre-built-policy-packs/hitrust/google-cloud/) | Business Critical | Provides predefined controls that align cloud resources with HITRUST CSF requirements, helping organizations enforce security and compliance baselines across multiple providers. |
+| **ISO/IEC 27001:2022** | [AWS](/docs/reference/pre-built-policy-packs/iso-27001/aws/) | Business Critical | Enforces ISO/IEC 27001:2022 Annex A controls for AWS resources, helping organizations align their cloud infrastructure with the international standard for information security management. |
+| **NIST SP 800-53** | [AWS](/docs/reference/pre-built-policy-packs/nist/aws/), [Google Cloud](/docs/reference/pre-built-policy-packs/nist/google-cloud/) | Business Critical | Enforces NIST SP 800-53 rev. 5 security and privacy controls for AWS and Google Cloud resources, helping federal agencies and organizations meet rigorous compliance requirements. |
+| **PCI DSS v4.0.1** | [AWS](/docs/reference/pre-built-policy-packs/pci-dss/aws/) | Business Critical | Enforces PCI DSS v4.0.1 compliance controls for AWS resources, ensuring payment card data security and helping organizations meet payment card industry standards. |
+| **Pulumi Best Practices** | [AWS](/docs/reference/pre-built-policy-packs/pulumi-best-practices/aws/), [Azure](/docs/reference/pre-built-policy-packs/pulumi-best-practices/azure/), [Google Cloud](/docs/reference/pre-built-policy-packs/pulumi-best-practices/google-cloud/) | Team and above | Offers a foundational set of recommended governance and security controls, serving as a strong starting point for organizations seeking comprehensive security coverage. |
+| **AWS Organizations Tag Policies** | [AWS and AWS-Native](/docs/reference/pre-built-policy-packs/aws-organizations-tag-policies/aws/) | Team and above | Integrates with AWS Organizations Tag Policies to validate that infrastructure as code resources have required tags before deployment. [Learn more](/docs/insights/policy/integrations/aws-organizations-tag-policies/). |
 
 ### A foundation for your governance strategy
 

--- a/content/docs/reference/pre-built-policy-packs/_content.gotmpl
+++ b/content/docs/reference/pre-built-policy-packs/_content.gotmpl
@@ -143,9 +143,13 @@
          mistaken for a real datePublished by the JSON-LD/OpenGraph
          partials -- see layouts/partials/schema/collectors/article-entity.html.
          ---------------------------------------------------------------- */}}
+    {{ if not $section.feature }}
+        {{ errorf "policy packs: section %q in data/policy_packs.yaml has no `feature:` — the generated pages need it to state which edition includes the pack." $section.id }}
+    {{ end }}
     {{ $pageParams := dict
         "h1" $entry.h1
         "meta_desc" $entry.metaDesc
+        "pulumi_cloud_feature" $section.feature
     }}
     {{ $dates := dict }}
     {{ with $lastmodData }}

--- a/content/docs/reference/pre-built-policy-packs/aws-organizations-tag-policies/aws.md
+++ b/content/docs/reference/pre-built-policy-packs/aws-organizations-tag-policies/aws.md
@@ -8,6 +8,7 @@ menu:
     parent: reference-pre-built-policy-packs
     identifier: reference-pre-built-policy-packs-aws-organizations-tag-policies
     weight: 6
+pulumi_cloud_feature: pre-built-policy-packs
 ---
 
 The **AWS Organizations Tag Policies** pack validates that your infrastructure as code resources comply with tag policies configured in AWS Organizations. Built in partnership with AWS, this pack proactively blocks non-compliant deployments when resources are missing required tags. For complete documentation including prerequisites, setup instructions, and supported resources, see the [AWS Organizations Tag Policies integration guide](/docs/insights/policy/integrations/aws-organizations-tag-policies/).

--- a/data/policy_packs.yaml
+++ b/data/policy_packs.yaml
@@ -31,12 +31,17 @@
 #     | sort
 #
 # Menu group headers (`menu:` below) are defined in config/_default/menus.yml.
+#
+# `feature:` is the data/pulumi_pricing.yaml feature id that decides which edition
+# the generated pages' Pulumi Cloud callout names. Pulumi Best Practices is the only
+# section here on Team and above; the compliance frameworks are Business Critical.
 
 org: pulumi
 
 sections:
   - id: cis
     menu: reference-pre-built-policy-packs-cis
+    feature: compliance-policy-packs
     # Bolded in the page intro: "...policies in the **CIS 8.1** pack for **AWS**."
     framework: CIS 8.1
     packs:
@@ -64,6 +69,7 @@ sections:
 
   - id: cis-kubernetes
     menu: reference-pre-built-policy-packs-cis-kubernetes
+    feature: compliance-policy-packs
     framework: CIS Kubernetes
     packs:
       - pack: cis-kubernetes-aws
@@ -93,6 +99,7 @@ sections:
 
   - id: cmmc
     menu: reference-pre-built-policy-packs-cmmc
+    feature: compliance-policy-packs
     framework: CMMC 2.0
     packs:
       - pack: cmmc-aws
@@ -105,6 +112,7 @@ sections:
 
   - id: hitrust
     menu: reference-pre-built-policy-packs-hitrust
+    feature: compliance-policy-packs
     framework: HITRUST CSF 11.5
     packs:
       - pack: hitrust-aws
@@ -141,6 +149,7 @@ sections:
 
   - id: iso-27001
     menu: reference-pre-built-policy-packs-iso-27001
+    feature: compliance-policy-packs
     framework: ISO/IEC 27001:2022
     packs:
       - pack: iso-27001-aws
@@ -167,6 +176,7 @@ sections:
 
   - id: nist
     menu: reference-pre-built-policy-packs-nist
+    feature: compliance-policy-packs
     framework: NIST SP 800-53
     packs:
       - pack: nist-aws
@@ -193,6 +203,7 @@ sections:
 
   - id: pci-dss
     menu: reference-pre-built-policy-packs-pci-dss
+    feature: compliance-policy-packs
     framework: PCI DSS v4.0.1
     packs:
       - pack: pci-dss-aws
@@ -219,6 +230,7 @@ sections:
 
   - id: pulumi-best-practices
     menu: reference-pre-built-policy-packs-pulumi-best-practices
+    feature: pre-built-policy-packs
     framework: Pulumi Best Practices
     packs:
       - pack: pulumi-best-practices-aws

--- a/data/pulumi_pricing.yaml
+++ b/data/pulumi_pricing.yaml
@@ -214,7 +214,7 @@ editions:
       features_intro: "Everything in **Enterprise**, plus:"
       features:
         - "[Self-hosting available](/product/self-hosted)"
-        - Built-in compliance (NIST, PCI, and more)
+        - Built-in compliance (NIST, PCI, ISO 27001, and more)
         - Automatic group & user sync (SCIM)
         - Audit logs export
         - Volume pricing and invoicing
@@ -599,9 +599,19 @@ categories:
         name: Pre-built policy packs
         link: /docs/insights/policy/policy-packs/pre-built-packs/
         availability:
-          team: Pulumi Best Practices
-          enterprise: Pulumi Best Practices
-          business-critical: Pulumi Best Practices, CIS, NIST, HITRUST, PCI DSS
+          team: Pulumi Best Practices, AWS Organizations Tag Policies
+          enterprise: Pulumi Best Practices, AWS Organizations Tag Policies
+          business-critical: Pulumi Best Practices, AWS Organizations Tag Policies, CIS, CIS Kubernetes, CMMC, NIST, HITRUST, PCI DSS, ISO 27001
+
+      # The compliance-framework packs (everything on the pre-built packs page
+      # except Pulumi Best Practices and AWS Organizations Tag Policies). Docs
+      # markers need a separate id because the pre-built-policy-packs row above
+      # resolves to Team.
+      - id: compliance-policy-packs
+        name: Compliance policy packs
+        link: /docs/insights/policy/policy-packs/pre-built-packs/
+        available_from: business-critical
+        hidden: true
 
       - id: custom-policy-packs
         name: Custom policy packs


### PR DESCRIPTION
All pre-built policy packs require the Business Critical edition except Pulumi Best Practices and AWS Organizations Tag Policies, which are available on Team and above. The pre-built packs page carried a page-level marker that resolved to Team, so it read as if every pack were included with every edition. Raised in [#product-policies](https://pulumi.slack.com/archives/C0AVDRQF71V/p1787653514444679?thread_ts=1782762015.503159&cid=C0AVDRQF71V).

## Changes
- `data/pulumi_pricing.yaml`: update the pre-built policy packs row (Business Critical now lists ISO 27001) and add a hidden `compliance-policy-packs` feature so docs markers can name Business Critical
- Pre-built packs page: replace the page-level Team marker with an explicit callout and an **Edition** column in the packs table
- Generated pack reference pages: per-section `feature:` in `data/policy_packs.yaml`, passed through `_content.gotmpl` as `pulumi_cloud_feature`, so every pack page carries an edition callout
- Policy overview pages and the AWS Organizations Tag Policies pages state the split
- ISO 27001 blog post: correct "every Pulumi Cloud user" to Business Critical, stamped `updated`

Not included: the packs table is still missing packs that already have reference pages (CMMC 2.0 AWS; ISO 27001 Azure/GCP; NIST Azure; PCI DSS Azure/GCP) — left for a separate confirmation that they're GA.