### PR TITLE
Point crd2pulumi docs at provider extensions

### DIFF
--- a/content/docs/integrations/clouds/kubernetes/crd2pulumi.md
+++ b/content/docs/integrations/clouds/kubernetes/crd2pulumi.md
@@ -13,6 +13,8 @@ aliases:
 - /docs/iac/clouds/kubernetes/crd2pulumi/
 ---
 
+> **Prefer provider extensions for new programs.** As of pulumi-kubernetes v4.34.0, the Kubernetes provider can generate and serve typed CRD types itself via `pulumi package add kubernetes --extension`, without a separate code generation step. Extension-served resources alias their `kubernetes:` token, so state written by a `crd2pulumi`-generated SDK is adopted rather than replaced. See [Typed CustomResources with Provider Extensions](/registry/packages/kubernetes/how-to-guides/typed-customresources-with-provider-extensions/).
+
 `crd2pulumi` is a CLI tool that generates typed Pulumi SDK classes from Kubernetes [CustomResourceDefinition (CRD)](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/) YAML schemas. While Pulumi lets you manage Kubernetes [`CustomResources`](/registry/packages/kubernetes/api-docs/apiextensions/customresource/) directly, those resources are untyped by default because every CRD schema is different. `crd2pulumi` solves this by reading a CRD's OpenAPI schema and generating strongly typed classes for your language of choice, enabling IDE autocompletion and compile-time type checking.
 
 This is particularly useful for complex CRDs with large schemas, such as [cert-manager](https://cert-manager.io/) or [Istio](https://istio.io/), where manually constructing resource arguments is error-prone.


### PR DESCRIPTION
Adds a note at the top of the crd2pulumi page pointing at `pulumi package add kubernetes --extension`, which supersedes it for new programs as of pulumi-kubernetes v4.34.0. Without this the crd2pulumi page remains the only documented path to typed CustomResources.

Links to the new how-to guide in pulumi/registry#12251, which should merge first.

## Test plan

- Prose-only change to one page.
