### PR TITLE
infrastructure: redirect support.pulumi.com to the support form

### DIFF
--- a/infrastructure/Pulumi.www-production.yaml
+++ b/infrastructure/Pulumi.www-production.yaml
@@ -19,6 +19,7 @@ config:
   www.pulumi.com:wafRateLimit: "500"
   www.pulumi.com:enableDataWarehouseAccess: "true"
   www.pulumi.com:enableSupportForm: "true"
+  www.pulumi.com:supportRedirectDomain: support.pulumi.com
   www.pulumi.com:intercomTicketTypeId: "3036244"
   www.pulumi.com:intercomApiKey:
     secure: AAABABqrMKEtK06xtI+MNA7niGyBS1pe7ns9Se96vKEXESNWcRn9RNX7E06uraYBygHF1PUifKZZemQCgnWUtwufpHxBn+wb4j0qKC/lCuB7fhn65DkgVaYaswY=

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -86,11 +86,9 @@ const config = {
     // config values — see SupportFormApiArgs in supportForm.ts.
     enableSupportForm: stackConfig.getBoolean("enableSupportForm") || false,
 
-    // supportRedirectDomain is a retired hostname (e.g. support.pulumi.com) to
-    // permanently redirect to the support-request form at /support/new/, via a
-    // small dedicated CloudFront distribution — see supportRedirect.ts. Unset
-    // = no redirect infrastructure is created. DNS for the hostname is managed
-    // by the pulumi-service repo, not here.
+    // supportRedirectDomain is a retired hostname (e.g. support.pulumi.com) permanently redirected to the
+    // support-request form at /support/new/ via a dedicated CloudFront distribution — see supportRedirect.ts.
+    // Unset means no redirect infrastructure. DNS for the hostname is managed by the pulumi-service repo, not here.
     supportRedirectDomain: stackConfig.get("supportRedirectDomain") || undefined,
 };
 
@@ -1505,11 +1503,9 @@ async function createAliasRecord(
 
 [...new Set(domainAliases)].map(alias => createAliasRecord(alias, cdn));
 
-// Redirect distribution for a retired support hostname (see supportRedirect.ts).
-// Deliberately not added to domainAliases: that list belongs to the website
-// distribution and drives Route 53 records in the www hosted zone, while this
-// hostname lives in the pulumi.com zone owned by the pulumi-service repo, which
-// CNAMEs it at the supportRedirectDistributionDomain output below.
+// Redirect distribution for a retired support hostname (see supportRedirect.ts). Deliberately not in domainAliases:
+// that list drives Route 53 records for the website distribution, while this hostname lives in the pulumi.com zone
+// owned by the pulumi-service repo, which CNAMEs it to the supportRedirectDistributionDomain output below.
 let supportRedirect: SupportRedirect | undefined;
 if (config.supportRedirectDomain) {
     supportRedirect = new SupportRedirect("support-redirect", {

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -7,6 +7,7 @@ import * as fs from "fs";
 import { getAIRedirectAndGoneAssociation, getEdgeRedirectAssociation } from "./cloudfrontLambdaAssociations";
 import { getMarkdownNegotiationFunctionAssociation, getMarketingMarkdownNegotiationFunctionAssociation, getApiCatalogContentTypeFunctionAssociation } from "./cloudfrontFunctions";
 import { SupportFormApi } from "./supportForm";
+import { SupportRedirect } from "./supportRedirect";
 
 const stackConfig = new pulumi.Config();
 
@@ -84,6 +85,13 @@ const config = {
     // tickets. Requires the intercomApiKey (secret) and intercomTicketTypeId stack
     // config values — see SupportFormApiArgs in supportForm.ts.
     enableSupportForm: stackConfig.getBoolean("enableSupportForm") || false,
+
+    // supportRedirectDomain is a retired hostname (e.g. support.pulumi.com) to
+    // permanently redirect to the support-request form at /support/new/, via a
+    // small dedicated CloudFront distribution — see supportRedirect.ts. Unset
+    // = no redirect infrastructure is created. DNS for the hostname is managed
+    // by the pulumi-service repo, not here.
+    supportRedirectDomain: stackConfig.get("supportRedirectDomain") || undefined,
 };
 
 // CloudFront Function to lowercase URIs for .NET SDK docs so that
@@ -1497,6 +1505,20 @@ async function createAliasRecord(
 
 [...new Set(domainAliases)].map(alias => createAliasRecord(alias, cdn));
 
+// Redirect distribution for a retired support hostname (see supportRedirect.ts).
+// Deliberately not added to domainAliases: that list belongs to the website
+// distribution and drives Route 53 records in the www hosted zone, while this
+// hostname lives in the pulumi.com zone owned by the pulumi-service repo, which
+// CNAMEs it at the supportRedirectDistributionDomain output below.
+let supportRedirect: SupportRedirect | undefined;
+if (config.supportRedirectDomain) {
+    supportRedirect = new SupportRedirect("support-redirect", {
+        domain: config.supportRedirectDomain,
+        targetUrl: `https://${config.websiteDomain}/support/new/`,
+        certificateArn: config.certificateArn,
+    });
+}
+
 export const uploadsBucketName = uploadsBucket.bucket;
 export const socialStateBucketName = socialStateBucket.bucket;
 export const contentReviewLedgerBucketName = contentReviewLedgerBucket.bucket;
@@ -1508,4 +1530,5 @@ export const websiteDomain = config.websiteDomain;
 export const originS3BucketName = originBucket.bucket;
 export const wafWebAclArn = webAcl?.arn;
 export const supportFormFunctionName = supportForm?.getFunctionName();
+export const supportRedirectDistributionDomain = supportRedirect?.getDistributionDomainName();
 export const readme = fs.readFileSync("./README.md").toString();

--- a/infrastructure/supportRedirect.ts
+++ b/infrastructure/supportRedirect.ts
@@ -1,0 +1,127 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+// SupportRedirect serves a permanent redirect from a retired hostname to the
+// support-request form at /support/new/. It exists for the Zendesk-to-Intercom
+// migration: support.pulumi.com is a CNAME to Zendesk's help center today, and
+// once the help center is retired the hostname needs to send visitors (and the
+// years of deep links into support.pulumi.com/hc/...) somewhere useful.
+//
+// It's a dedicated CloudFront distribution rather than an extra alias on the
+// main website distribution so that no host-based branching has to thread
+// through the website's per-behavior function and Lambda@Edge associations —
+// every request here gets the same answer, issued by a CloudFront Function at
+// viewer-request time. The origin below is required by CloudFront but is never
+// contacted, because the function responds before any origin request is made.
+//
+// DNS is NOT managed here: the pulumi.com hosted zone belongs to the
+// pulumi-service infrastructure (infrastructure/service/dns.ts in that repo),
+// which points the `support` CNAME at this distribution's domain name — the
+// `supportRedirectDistributionDomain` stack output.
+export interface SupportRedirectArgs {
+    // domain is the hostname to redirect from, e.g. support.pulumi.com.
+    domain: pulumi.Input<string>;
+    // targetUrl is the fully-qualified URL every request is redirected to.
+    targetUrl: string;
+    // certificateArn is an ACM certificate (us-east-1) covering `domain` —
+    // the website's *.pulumi.com wildcard certificate in production.
+    certificateArn: pulumi.Input<string>;
+}
+
+export class SupportRedirect extends pulumi.ComponentResource {
+    private readonly distribution: aws.cloudfront.Distribution;
+
+    constructor(name: string, args: SupportRedirectArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("www-pulumi:infrastructure:SupportRedirect", name, undefined, opts);
+
+        const redirectFunction = new aws.cloudfront.Function(
+            `${name}-function`,
+            {
+                runtime: "cloudfront-js-2.0",
+                comment: `Redirects all requests to ${args.targetUrl}`,
+                publish: true,
+                code: `function handler(event) {
+    return {
+        statusCode: 301,
+        statusDescription: "Moved Permanently",
+        headers: {
+            "location": { value: "${args.targetUrl}" },
+            "cache-control": { value: "max-age=604800" },
+        },
+    };
+}`,
+            },
+            { parent: this },
+        );
+
+        this.distribution = new aws.cloudfront.Distribution(
+            `${name}-distribution`,
+            {
+                enabled: true,
+                comment: pulumi.interpolate`Redirects ${args.domain} to ${args.targetUrl}`,
+                aliases: [args.domain],
+                // The cheapest price class is plenty: the only content served
+                // is a redirect, so an extra round trip to a farther POP for
+                // viewers outside North America and Europe is immaterial.
+                priceClass: "PriceClass_100",
+                httpVersion: "http2",
+                isIpv6Enabled: true,
+
+                // CloudFront requires at least one origin, but the redirect
+                // function answers every request at viewer-request time, so
+                // this origin never receives traffic.
+                origins: [
+                    {
+                        originId: "unused-placeholder",
+                        domainName: "www.pulumi.com",
+                        customOriginConfig: {
+                            originProtocolPolicy: "https-only",
+                            httpPort: 80,
+                            httpsPort: 443,
+                            originSslProtocols: ["TLSv1.2"],
+                        },
+                    },
+                ],
+
+                defaultCacheBehavior: {
+                    targetOriginId: "unused-placeholder",
+                    // allow-all so that plain-HTTP requests get one 301 straight
+                    // to the HTTPS target, rather than an https:// hop first.
+                    viewerProtocolPolicy: "allow-all",
+                    allowedMethods: ["GET", "HEAD", "OPTIONS"],
+                    cachedMethods: ["GET", "HEAD"],
+                    // AWS-managed CachingDisabled policy — there is nothing to
+                    // cache, since the function generates every response.
+                    cachePolicyId: "4135ea2d-6df8-44a3-b632-99711092ca9d",
+                    functionAssociations: [
+                        {
+                            eventType: "viewer-request",
+                            functionArn: redirectFunction.arn,
+                        },
+                    ],
+                },
+
+                restrictions: {
+                    geoRestriction: {
+                        restrictionType: "none",
+                    },
+                },
+
+                viewerCertificate: {
+                    acmCertificateArn: args.certificateArn,
+                    sslSupportMethod: "sni-only",
+                    minimumProtocolVersion: "TLSv1.2_2021",
+                },
+            },
+            { parent: this },
+        );
+
+        super.registerOutputs({});
+    }
+
+    public getDistributionDomainName(): pulumi.Output<string> {
+        return this.distribution.domainName;
+    }
+}

--- a/infrastructure/supportRedirect.ts
+++ b/infrastructure/supportRedirect.ts
@@ -104,7 +104,9 @@ export class SupportRedirect extends pulumi.ComponentResource {
                     minimumProtocolVersion: "TLSv1.2_2021",
                 },
             },
-            { parent: this },
+            // protect: the pulumi-service repo's CNAME depends on this distribution's generated domain name, which an
+            // accidental delete/replace would silently regenerate.
+            { parent: this, protect: true },
         );
 
         super.registerOutputs({});

--- a/infrastructure/supportRedirect.ts
+++ b/infrastructure/supportRedirect.ts
@@ -3,30 +3,23 @@
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
-// SupportRedirect serves a permanent redirect from a retired hostname to the
-// support-request form at /support/new/. It exists for the Zendesk-to-Intercom
-// migration: support.pulumi.com is a CNAME to Zendesk's help center today, and
-// once the help center is retired the hostname needs to send visitors (and the
-// years of deep links into support.pulumi.com/hc/...) somewhere useful.
+// SupportRedirect issues a permanent redirect from a retired hostname to the support-request form at /support/new/.
+// It exists for the Zendesk-to-Intercom migration: support.pulumi.com is a CNAME to Zendesk's help center today, and
+// once the help center retires, the hostname and years of deep links (support.pulumi.com/hc/...) still need to land
+// somewhere useful.
 //
-// It's a dedicated CloudFront distribution rather than an extra alias on the
-// main website distribution so that no host-based branching has to thread
-// through the website's per-behavior function and Lambda@Edge associations —
-// every request here gets the same answer, issued by a CloudFront Function at
-// viewer-request time. The origin below is required by CloudFront but is never
-// contacted, because the function responds before any origin request is made.
+// It is a dedicated CloudFront distribution, rather than an extra alias on the website distribution, so no host-based
+// branching has to thread through the website's per-behavior function and Lambda@Edge associations. A CloudFront
+// Function answers every request at viewer-request time, so the origin (required by CloudFront) is never contacted.
 //
-// DNS is NOT managed here: the pulumi.com hosted zone belongs to the
-// pulumi-service infrastructure (infrastructure/service/dns.ts in that repo),
-// which points the `support` CNAME at this distribution's domain name — the
-// `supportRedirectDistributionDomain` stack output.
+// DNS is not managed here: the pulumi.com hosted zone belongs to the pulumi-service repo, which CNAMEs the hostname
+// to this distribution's domain name — the supportRedirectDistributionDomain stack output.
 export interface SupportRedirectArgs {
     // domain is the hostname to redirect from, e.g. support.pulumi.com.
     domain: pulumi.Input<string>;
     // targetUrl is the fully-qualified URL every request is redirected to.
     targetUrl: string;
-    // certificateArn is an ACM certificate (us-east-1) covering `domain` —
-    // the website's *.pulumi.com wildcard certificate in production.
+    // certificateArn is an ACM certificate (us-east-1) covering `domain` — the *.pulumi.com wildcard in production.
     certificateArn: pulumi.Input<string>;
 }
 
@@ -62,16 +55,13 @@ export class SupportRedirect extends pulumi.ComponentResource {
                 enabled: true,
                 comment: pulumi.interpolate`Redirects ${args.domain} to ${args.targetUrl}`,
                 aliases: [args.domain],
-                // The cheapest price class is plenty: the only content served
-                // is a redirect, so an extra round trip to a farther POP for
-                // viewers outside North America and Europe is immaterial.
+                // The cheapest price class is plenty: the only content served is a redirect.
                 priceClass: "PriceClass_100",
                 httpVersion: "http2",
                 isIpv6Enabled: true,
 
-                // CloudFront requires at least one origin, but the redirect
-                // function answers every request at viewer-request time, so
-                // this origin never receives traffic.
+                // CloudFront requires an origin, but the redirect function answers every request, so it never
+                // receives traffic.
                 origins: [
                     {
                         originId: "unused-placeholder",
@@ -87,13 +77,11 @@ export class SupportRedirect extends pulumi.ComponentResource {
 
                 defaultCacheBehavior: {
                     targetOriginId: "unused-placeholder",
-                    // allow-all so that plain-HTTP requests get one 301 straight
-                    // to the HTTPS target, rather than an https:// hop first.
+                    // allow-all so plain-HTTP requests get one 301 to the HTTPS target, not an https:// hop first.
                     viewerProtocolPolicy: "allow-all",
                     allowedMethods: ["GET", "HEAD", "OPTIONS"],
                     cachedMethods: ["GET", "HEAD"],
-                    // AWS-managed CachingDisabled policy — there is nothing to
-                    // cache, since the function generates every response.
+                    // AWS-managed CachingDisabled policy — the function generates every response.
                     cachePolicyId: "4135ea2d-6df8-44a3-b632-99711092ca9d",
                     functionAssociations: [
                         {

--- a/infrastructure/supportRedirect.ts
+++ b/infrastructure/supportRedirect.ts
@@ -78,7 +78,9 @@ export class SupportRedirect extends pulumi.ComponentResource {
                     targetOriginId: "unused-placeholder",
                     // allow-all so plain-HTTP requests get one 301 to the HTTPS target, not an https:// hop first.
                     viewerProtocolPolicy: "allow-all",
-                    allowedMethods: ["GET", "HEAD", "OPTIONS"],
+                    // CloudFront enforces allowedMethods before the viewer-request function runs, and this is its
+                    // only POST-capable set — anything narrower 403s non-GET requests instead of redirecting them.
+                    allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
                     cachedMethods: ["GET", "HEAD"],
                     // AWS-managed CachingDisabled policy — the function generates every response.
                     cachePolicyId: "4135ea2d-6df8-44a3-b632-99711092ca9d",

--- a/infrastructure/supportRedirect.ts
+++ b/infrastructure/supportRedirect.ts
@@ -57,7 +57,6 @@ export class SupportRedirect extends pulumi.ComponentResource {
                 aliases: [args.domain],
                 // The cheapest price class is plenty: the only content served is a redirect.
                 priceClass: "PriceClass_100",
-                httpVersion: "http2",
                 isIpv6Enabled: true,
 
                 // CloudFront requires an origin, but the redirect function answers every request, so it never

--- a/infrastructure/tsconfig.json
+++ b/infrastructure/tsconfig.json
@@ -20,6 +20,7 @@
     "files": [
         "index.ts",
         "supportForm.ts",
+        "supportRedirect.ts",
         "support-form/validation.ts",
         "support-form/handler.ts",
         "support-form/intercom.ts",


### PR DESCRIPTION
support.pulumi.com hands traffic straight to Zendesk's help center today via a CNAME. With support moving to Intercom, the hostname and the existing deep links into support.pulumi.com/hc/... need to land on the support-request form instead. This adds a small dedicated CloudFront distribution that answers every request with a 301 to https://www.pulumi.com/support/new/, gated behind a new `supportRedirectDomain` stack config value and enabled only in www-production.

## Change Summary

- The new [redirect component](https://github.com/pulumi/docs/blob/ef79201ab3bea4dddb142d85c4603097af332a46/infrastructure/supportRedirect.ts) is a distribution plus a viewer-request CloudFront Function that 301s everything. It reuses the production *.pulumi.com wildcard certificate, so no new certificate or validation records are needed.
- A dedicated distribution, rather than another alias on the website distribution, keeps host-based branching out of the website's per-behavior function and Lambda@Edge associations.
- DNS does not change here. The pulumi.com hosted zone belongs to pulumi-service, which will repoint the support CNAME from pulumi.zendesk.com to the new `supportRedirectDistributionDomain` stack output in a follow-up PR. Until that lands, this deploy is inert: nothing points at the new distribution.

## Testing

- [ ] After deploy: `curl -sI https://<distribution domain>/hc/en-us -H "Host: support.pulumi.com"` returns a 301 to https://www.pulumi.com/support/new/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U27ANFtZAjDVNbDx6CUBz
