### PR TITLE
infrastructure: fix the cache policy ID that failed the www deploy

### DIFF
--- a/infrastructure/supportRedirect.ts
+++ b/infrastructure/supportRedirect.ts
@@ -82,8 +82,11 @@ export class SupportRedirect extends pulumi.ComponentResource {
                     // only POST-capable set — anything narrower 403s non-GET requests instead of redirecting them.
                     allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
                     cachedMethods: ["GET", "HEAD"],
-                    // AWS-managed CachingDisabled policy — the function generates every response.
-                    cachePolicyId: "4135ea2d-6df8-44a3-b632-99711092ca9d",
+                    // AWS-managed CachingDisabled policy, resolved by name rather than a hardcoded ID (a wrong
+                    // GUID here failed the first production deploy). Nothing caches: the function makes every response.
+                    cachePolicyId: aws.cloudfront
+                        .getCachePolicy({ name: "Managed-CachingDisabled" })
+                        .then((policy) => policy.id!),
                     functionAssociations: [
                         {
                             eventType: "viewer-request",


### PR DESCRIPTION
The first production deploy of the support redirect distribution (#21159) failed with NoSuchCachePolicy and blocked the master deploy pipeline: the hardcoded CachingDisabled GUID had the right prefix but a wrong tail. This resolves the [managed policy by name](https://github.com/pulumi/docs/blob/6489f0e48578e5ce1a29da0df878f6ae29dfccb2/infrastructure/supportRedirect.ts#L85-L89) at deploy time instead, so a stale or mistyped ID cannot recur. Verified against the live API: `aws cloudfront list-cache-policies --type managed` shows Managed-CachingDisabled as `4135ea2d-6df8-44a3-9df3-4b5a84be39ad`, which is what the by-name lookup returns.

The failed update (www-production update 19882) already created the redirect CloudFront Function; the next deploy resumes cleanly and creates the distribution.

## Testing

- [ ] Master deploy goes green after merge and `pulumi stack output supportRedirectDistributionDomain` appears on www-production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U27ANFtZAjDVNbDx6CUBz
