### PR TITLE
infrastructure: use the project no-cache policy for the support redirect

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -1512,6 +1512,7 @@ if (config.supportRedirectDomain) {
         domain: config.supportRedirectDomain,
         targetUrl: `https://${config.websiteDomain}/support/new/`,
         certificateArn: config.certificateArn,
+        cachePolicyId: noCacheKeyPolicy.id,
     });
 }
 

--- a/infrastructure/supportRedirect.ts
+++ b/infrastructure/supportRedirect.ts
@@ -21,6 +21,9 @@ export interface SupportRedirectArgs {
     targetUrl: string;
     // certificateArn is an ACM certificate (us-east-1) covering `domain` — the *.pulumi.com wildcard in production.
     certificateArn: pulumi.Input<string>;
+    // cachePolicyId is the CloudFront cache policy for the redirect behavior. Pass the project's no-cache policy —
+    // the viewer-request function generates every response, so nothing should be cached.
+    cachePolicyId: pulumi.Input<string>;
 }
 
 export class SupportRedirect extends pulumi.ComponentResource {
@@ -82,8 +85,8 @@ export class SupportRedirect extends pulumi.ComponentResource {
                     // only POST-capable set — anything narrower 403s non-GET requests instead of redirecting them.
                     allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
                     cachedMethods: ["GET", "HEAD"],
-                    // AWS-managed CachingDisabled policy — the function generates every response.
-                    cachePolicyId: "4135ea2d-6df8-44a3-b632-99711092ca9d",
+                    // Project no-cache policy — the function generates every response, so nothing is cached.
+                    cachePolicyId: args.cachePolicyId,
                     functionAssociations: [
                         {
                             eventType: "viewer-request",

--- a/infrastructure/supportRedirect.ts
+++ b/infrastructure/supportRedirect.ts
@@ -21,8 +21,6 @@ export interface SupportRedirectArgs {
     targetUrl: string;
     // certificateArn is an ACM certificate (us-east-1) covering `domain` — the *.pulumi.com wildcard in production.
     certificateArn: pulumi.Input<string>;
-    // cachePolicyId is the CloudFront cache policy for the redirect behavior. Pass the project's no-cache policy —
-    // the viewer-request function generates every response, so nothing should be cached.
     cachePolicyId: pulumi.Input<string>;
 }
 
@@ -85,7 +83,6 @@ export class SupportRedirect extends pulumi.ComponentResource {
                     // only POST-capable set — anything narrower 403s non-GET requests instead of redirecting them.
                     allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
                     cachedMethods: ["GET", "HEAD"],
-                    // Project no-cache policy — the function generates every response, so nothing is cached.
                     cachePolicyId: args.cachePolicyId,
                     functionAssociations: [
                         {


### PR DESCRIPTION
Follow-up to #21161, which unblocked the master deploy by resolving the AWS-managed `Managed-CachingDisabled` policy by name.

This switches the support-redirect distribution to the project's own `noCacheKeyPolicy` (`cacheKeyPolicy("no-cache", 0)`) instead, so it references an infrastructure-owned cache policy by `.id` — the same pattern every other CDN behavior in `index.ts` already uses — rather than reaching for a managed policy by name.