### PR TITLE
Triage: route theme/ to domain:infra, add a domain:other fallback

### DIFF
--- a/.claude/commands/docs-review/references/domain-routing.md
+++ b/.claude/commands/docs-review/references/domain-routing.md
@@ -9,13 +9,15 @@ Each changed file routes to **exactly one** domain by path. Apply the rules in o
 
 | Order | Domain | Applies when the file path matches |
 |---|---|---|
-| 1 | `docs-review:references:programs` | `static/programs/**` (includes every nested file in a program directory: `Pulumi.yaml`, `package.json`, `requirements.txt`, source files) |
+| 1 | `docs-review:references:programs` | `static/programs/**` (includes every nested file in a program directory: `Pulumi.yaml`, `package.json`, `requirements.txt`, source files) and `scripts/programs/**` |
 | 2 | `docs-review:references:blog` | `content/blog/**`, `content/case-studies/**` |
 | 3 | `docs-review:references:docs` | `content/docs/**`, `content/tutorials/**`, `content/what-is/**` |
 | 4 | `docs-review:references:website` | Any other `content/**.md` (pricing, legal, `vs/`, `why-pulumi/`, `about/`, `careers/`, etc.) |
-| 5 | `docs-review:references:infra` | `.github/workflows/**`, `scripts/**` except `scripts/programs/**`, `infrastructure/**`, `Makefile` (repo root), `package.json` (repo root only), `webpack.config.js`, `webpack.*.js` |
-| 6 | `docs-review:references:shared-criteria` only | Anything else (`layouts/`, `assets/`, `data/`, etc.) |
+| 5 | `docs-review:references:infra` | Two groups, same criteria. **Tooling and CI:** `.github/workflows/**`, `scripts/**` except `scripts/programs/**`, `infrastructure/**`, `Makefile` (repo root), `package.json` (repo root only), `webpack.config.js`, `webpack.*.js`. **Site build pipeline:** `layouts/**`, `assets/**`, `theme/**` (SCSS and TypeScript sources compiled into the site bundles), `static/**` except `static/programs/**` |
+| 6 | `docs-review:references:shared-criteria` only | Anything else (`data/`, `styles/`, `archetypes/`, repo-root dotfiles, etc.). Triage labels such a PR `domain:other` |
 
 `docs-review:references:shared-criteria` applies to every file regardless of domain.
 
-**Ordering matters.** A per-program `package.json` under `static/programs/<name>/package.json` is programs, not infra. `scripts/programs/**` (e.g., `scripts/programs/ignore.txt`) is programs tooling, not site infra. Only the repo-root `package.json` and `Makefile` count as infra.
+**Every changed file routes somewhere.** Rules 1–5 name a criteria file; rule 6 is the catch-all, and files landing there get `docs-review:references:shared-criteria` and nothing more. When *no* file in a PR matches rules 1–5, `triage-classify.py` labels the PR `domain:other` so that an unlabeled PR always means triage didn't run, never that it ran and found nothing to say. `domain:other` is not itself a review lane — it is the label form of rule 6.
+
+**Ordering matters.** A per-program `package.json` under `static/programs/<name>/package.json` is programs, not infra. `scripts/programs/**` (e.g., `scripts/programs/ignore.txt`) is programs tooling, not site infra. Only the repo-root `package.json` and `Makefile` count as infra. Rule 5's two groups are one domain, not two: `theme/src/scss/` and `.github/workflows/` both review under `docs-review:references:infra`.

--- a/.claude/commands/docs-review/references/domain-routing.md
+++ b/.claude/commands/docs-review/references/domain-routing.md
@@ -14,7 +14,7 @@ Each changed file routes to **exactly one** domain by path. Apply the rules in o
 | 3 | `docs-review:references:docs` | `content/docs/**`, `content/tutorials/**`, `content/what-is/**` |
 | 4 | `docs-review:references:website` | Any other `content/**.md` (pricing, legal, `vs/`, `why-pulumi/`, `about/`, `careers/`, etc.) |
 | 5 | `docs-review:references:infra` | Two groups, same criteria. **Tooling and CI:** `.github/workflows/**`, `scripts/**` except `scripts/programs/**`, `infrastructure/**`, `Makefile` (repo root), `package.json` (repo root only), `webpack.config.js`, `webpack.*.js`. **Site build pipeline:** `layouts/**`, `assets/**`, `theme/**` (SCSS and TypeScript sources compiled into the site bundles), `static/**` except `static/programs/**` |
-| 6 | `docs-review:references:shared-criteria` only | Anything else (`data/`, `styles/`, `archetypes/`, repo-root dotfiles, etc.). Triage labels such a PR `domain:other` |
+| 6 | `docs-review:references:shared-criteria` only | Anything else (`data/`, `styles/`, `archetypes/`, `.claude/`, non-workflow `.github/` files, repo-root dotfiles, etc.). Triage labels such a PR `domain:other` |
 
 `docs-review:references:shared-criteria` applies to every file regardless of domain.
 

--- a/.claude/commands/docs-review/scripts/test_triage_classify.py
+++ b/.claude/commands/docs-review/scripts/test_triage_classify.py
@@ -21,8 +21,8 @@ _failures: list[str] = []
 _passes = 0
 
 
-def assert_clean(name: str) -> None:
-    """Fail the *test function* on any recorded check failure.
+def assert_clean(name: str, before: int) -> None:
+    """Fail the *test function* on the check failures it recorded itself.
 
     This file is run two ways: standalone (`python3 test_triage_classify.py`,
     where main() reads the _failures list) and under pytest via
@@ -30,9 +30,17 @@ def assert_clean(name: str) -> None:
     directly. pytest only sees a failure if the function raises, so without
     this call a broken routing rule would record FAILs and still report a
     green suite in CI.
+
+    `before` is `len(_failures)` captured on entry to the test function.
+    _failures is module-level and never reset, so without that baseline a
+    failure recorded by an earlier test would also fail every later one and
+    be counted in *its* message — pointing the reader at the wrong test.
+    It is required rather than defaulted so a future test can't silently
+    reintroduce that.
     """
-    if _failures:
-        raise AssertionError(f"{name}: {len(_failures)} check(s) failed (see FAIL lines above)")
+    new = _failures[before:]
+    if new:
+        raise AssertionError(f"{name}: {len(new)} check(s) failed (see FAIL lines above)")
 
 
 def check(cond: bool, msg: str) -> None:
@@ -66,6 +74,7 @@ def _pr(additions: int, deletions: int, paths: list[str]) -> dict:
 
 def test_oversized_threshold() -> None:
     print("test_oversized_threshold")
+    before = len(_failures)
     # A generated-corpus monster (the PR #20274 shape) is oversized.
     big = run_classify(_pr(99_664, 1_759, ["data/policy_pack_policies/cis.yaml",
                                            "content/docs/reference/x/_index.md",
@@ -91,11 +100,12 @@ def test_oversized_threshold() -> None:
     check(many["oversized"] is True, f"155-file PR classifies oversized; got {many['oversized']}")
     at_files = run_classify(_pr(2_000, 1_000, [f"content/docs/p{i}/_index.md" for i in range(150)]))
     check(at_files["oversized"] is False, f"exactly 150 files is NOT oversized (strict >); got {at_files['oversized']}")
-    assert_clean("test_oversized_threshold")
+    assert_clean("test_oversized_threshold", before)
 
 
 def test_domain_routing() -> None:
     print("test_domain_routing")
+    before = len(_failures)
 
     def domains(paths: list[str]) -> list[str]:
         return run_classify(_pr(10, 0, paths))["target_domains"]
@@ -155,7 +165,7 @@ def test_domain_routing() -> None:
     check(themed["trivial"] is False, "a one-line theme/ change is not trivial")
     other = run_classify(_pr(1, 0, ["data/a.yaml"]), "")
     check(other["trivial"] is False, "a one-line unmatched change is not trivial")
-    assert_clean("test_domain_routing")
+    assert_clean("test_domain_routing", before)
 
 
 def main() -> int:

--- a/.claude/commands/docs-review/scripts/test_triage_classify.py
+++ b/.claude/commands/docs-review/scripts/test_triage_classify.py
@@ -21,6 +21,20 @@ _failures: list[str] = []
 _passes = 0
 
 
+def assert_clean(name: str) -> None:
+    """Fail the *test function* on any recorded check failure.
+
+    This file is run two ways: standalone (`python3 test_triage_classify.py`,
+    where main() reads the _failures list) and under pytest via
+    `make test-review-pipeline`, which collects the `test_*` functions
+    directly. pytest only sees a failure if the function raises, so without
+    this call a broken routing rule would record FAILs and still report a
+    green suite in CI.
+    """
+    if _failures:
+        raise AssertionError(f"{name}: {len(_failures)} check(s) failed (see FAIL lines above)")
+
+
 def check(cond: bool, msg: str) -> None:
     global _passes
     if cond:
@@ -77,10 +91,75 @@ def test_oversized_threshold() -> None:
     check(many["oversized"] is True, f"155-file PR classifies oversized; got {many['oversized']}")
     at_files = run_classify(_pr(2_000, 1_000, [f"content/docs/p{i}/_index.md" for i in range(150)]))
     check(at_files["oversized"] is False, f"exactly 150 files is NOT oversized (strict >); got {at_files['oversized']}")
+    assert_clean("test_oversized_threshold")
+
+
+def test_domain_routing() -> None:
+    print("test_domain_routing")
+
+    def domains(paths: list[str]) -> list[str]:
+        return run_classify(_pr(10, 0, paths))["target_domains"]
+
+    # theme/ is asset-pipeline source (SCSS + TypeScript compiled into the
+    # site bundles) and routes to infra like layouts/ and assets/. The gap
+    # this closes: PR #21164 touched only theme/src/{scss,ts} and came out
+    # of triage with no domain label at all.
+    check(domains(["theme/src/ts/consent-manager/index.ts"]) == ["domain:infra"],
+          f"theme/src/ts routes to infra; got {domains(['theme/src/ts/consent-manager/index.ts'])}")
+    check(domains(["theme/src/scss/_consent-banner.scss"]) == ["domain:infra"],
+          "theme/src/scss routes to infra")
+    check(domains(["theme/scripts/build-color-theme.mjs"]) == ["domain:infra"],
+          "theme/scripts routes to infra")
+
+    # Existing precedence is unchanged by the theme/ rule and the fallback.
+    check(domains(["static/programs/aws-ts-s3/index.ts"]) == ["domain:programs"],
+          "static/programs beats the static/ infra rule")
+    check(domains(["scripts/programs/ignore.txt"]) == ["domain:programs"],
+          "scripts/programs beats the scripts/ infra rule")
+    check(domains(["content/blog/post/index.md"]) == ["domain:blog"], "blog routes to blog")
+    check(domains(["content/docs/a.md"]) == ["domain:docs"], "docs routes to docs")
+    check(domains(["content/pricing/_index.md"]) == ["domain:website"],
+          "non-docs content markdown routes to website")
+    check(domains(["layouts/index.html"]) == ["domain:infra"], "layouts routes to infra")
+
+    # Fallback: a PR where nothing matches still carries one domain signal,
+    # so "no domain label" unambiguously means triage never ran.
+    check(domains(["data/blog_tags.yaml"]) == ["domain:other"],
+          f"unmatched paths fall back to domain:other; got {domains(['data/blog_tags.yaml'])}")
+    check(domains(["data/a.yaml", "styles/Pulumi/Terms.yml"]) == ["domain:other"],
+          "several unmatched paths still collapse to a single domain:other")
+    check(run_classify(_pr(10, 0, ["data/a.yaml"]))["mixed"] is False,
+          "the fallback never sets mixed")
+
+    # ...but never alongside a real domain: the unmatched file adds no review
+    # lane, so it must not flip `mixed` on a single-domain PR.
+    mixed_with_unmatched = run_classify(_pr(10, 0, ["content/docs/a.md", "data/b.yaml"]))
+    check(mixed_with_unmatched["target_domains"] == ["domain:docs"],
+          f"an unmatched file alongside docs stays docs-only; got {mixed_with_unmatched['target_domains']}")
+    check(mixed_with_unmatched["mixed"] is False,
+          "docs + an unmatched file is NOT mixed")
+
+    # A genuinely multi-domain PR is still mixed, and never picks up the fallback.
+    real_mix = run_classify(_pr(10, 0, ["content/docs/a.md", "theme/src/ts/x.ts"]))
+    check(real_mix["target_domains"] == ["domain:docs", "domain:infra"],
+          f"docs + theme is a real two-domain PR; got {real_mix['target_domains']}")
+    check(real_mix["mixed"] is True, "docs + theme sets mixed")
+
+    # An empty file list yields no domain at all (nothing to label).
+    check(run_classify(_pr(0, 0, []))["target_domains"] == [],
+          "a PR with no files gets no domain label")
+
+    # The fallback must not open the trivial / frontmatter-only short-circuit
+    # to non-content files.
+    themed = run_classify(_pr(1, 0, ["theme/src/ts/x.ts"]), "")
+    check(themed["trivial"] is False, "a one-line theme/ change is not trivial")
+    other = run_classify(_pr(1, 0, ["data/a.yaml"]), "")
+    check(other["trivial"] is False, "a one-line unmatched change is not trivial")
+    assert_clean("test_domain_routing")
 
 
 def main() -> int:
-    tests = [test_oversized_threshold]
+    tests = [test_oversized_threshold, test_domain_routing]
     for t in tests:
         try:
             t()

--- a/.claude/commands/docs-review/scripts/triage-classify.py
+++ b/.claude/commands/docs-review/scripts/triage-classify.py
@@ -21,6 +21,17 @@ from collections.abc import Iterable
 
 WEBPACK_RE = re.compile(r"^webpack\.[^/]+\.js$")
 
+# Applied at the PR level when no file matched a domain rule, so that every
+# triaged PR carries exactly one domain signal and "no domain label" always
+# means "triage didn't run" rather than "triage ran and had nothing to say".
+# Deliberately NOT domain:mixed: mixed is derived from len(domains) > 1 and
+# asserts "touches more than one domain, each file reviewed under its own" —
+# the opposite of what's true here — and overloading it would destroy its
+# filter value for the multi-domain PRs it exists to mark. domain:other is
+# an honest "no specific domain"; those files review under shared-criteria
+# only, per docs-review:references:domain-routing rule 6.
+FALLBACK_DOMAIN = "domain:other"
+
 # Above this many changed lines (additions + deletions), the PR is `oversized`:
 # too big for the review pipeline to finish inside its time budget, and at this
 # scale the bulk is invariably generated output that an LLM line-review adds no
@@ -62,7 +73,13 @@ def classify_path(path: str) -> str | None:
     # infrastructure that affects how content renders. static/programs/ is
     # already routed at the top of this function (programs check returns
     # first); the explicit exclusion below documents intent for readers.
-    if path.startswith("layouts/") or path.startswith("assets/"):
+    # theme/ is the same kind of thing one level down: the SCSS and TypeScript
+    # sources compiled into the site's CSS/JS bundles. Its omission is why
+    # PR #21164 (a consent-manager change under theme/src/ts/) carried no
+    # domain label and was reviewed under shared-criteria only.
+    if (path.startswith("layouts/")
+            or path.startswith("assets/")
+            or path.startswith("theme/")):
         return "domain:infra"
     if path.startswith("static/") and not path.startswith("static/programs/"):
         return "domain:infra"
@@ -264,6 +281,13 @@ def classify_pr(pr_data: dict, file_flags: list[dict]) -> dict:
         d = classify_path(f.get("path", ""))
         if d:
             domains.add(d)
+    # Fallback fires only for a PR where NOTHING classified — never
+    # alongside a real domain. A PR touching content/docs/ plus data/ is
+    # domain:docs, not docs+other+mixed: the unmatched file adds no review
+    # lane, so surfacing it as a second domain would flip `mixed` on
+    # PRs that aren't. Placed before the mixed computation for that reason.
+    if not domains and files:
+        domains.add(FALLBACK_DOMAIN)
 
     has_any_frontmatter = any(f["has_frontmatter_change"] for f in file_flags)
     has_any_body = any(f["has_body_change"] for f in file_flags)

--- a/.github/labels-pr-review.md
+++ b/.github/labels-pr-review.md
@@ -8,13 +8,17 @@ This document lists the labels that the PR review pipeline (`claude-triage.yml`,
 
 Informational signal labels — surfaced for human filterability. Routing in CI is path-based (`docs-review:references:domain-routing`); these labels do not gate workflow logic.
 
+Every triaged PR carries exactly one of these, `domain:other` included, so **the absence of a `domain:` label means triage never ran** — the PR was opened as a draft and hasn't been marked ready, the author lacks write access, or the classifier errored. It never means "triage ran and had nothing to say."
+
 | Label | Color | Description |
 |---|---|---|
 | `domain:docs` | `0e8a16` | PR touches technical docs (`content/docs/`, `content/tutorials/`, `content/what-is/`). |
 | `domain:blog` | `a2eeef` | PR touches blog posts or customer stories (`content/blog/`, `content/case-studies/`). |
-| `domain:infra` | `d4c5f9` | PR touches workflows, scripts, infrastructure code, Makefile, or build/bundling config. |
+| `domain:infra` | `d4c5f9` | PR touches workflows, scripts, infrastructure code, Makefile, build/bundling config, or the site build pipeline (`layouts/`, `assets/`, `theme/`, `static/`). |
 | `domain:programs` | `fbca04` | PR touches example programs under `static/programs/`. |
+| `domain:website` | `c5def5` | PR touches marketing, pricing, legal, or competitive landing pages (any other `content/**.md`). |
 | `domain:mixed` | `bfd4f2` | PR touches more than one domain. Each file is reviewed under its domain. |
+| `domain:other` | `ededed` | PR touches no domain-specific path (`data/`, `styles/`, `archetypes/`, repo-root dotfiles). Reviewed under shared criteria only. Applied only when nothing else matched, so it never appears beside another `domain:` label. |
 
 ## Workflow-state labels
 
@@ -36,6 +40,8 @@ Load-bearing — these gate workflow execution.
 
 The six `review:*` state labels are **mutually exclusive**. Setting one removes the others. `set-review-label.sh` (under `.claude/commands/docs-review/scripts/`) enforces this atomically and supports a `--clear` mode that strips any state label without adding a new one (used by claude-triage.yml's `if: always()` cleanup).
 
+> **Before merging a change that introduces a new label:** create it first. Triage applies its whole ADD set in a single `gh pr edit --add-label a,b,c` call, and `gh` rejects the entire call if any one name doesn't exist in the repo — the workflow's `|| true` then swallows it, so the other labels in that batch go missing too, silently. As of this writing `domain:other` is the one label in this document that does not yet exist in `pulumi/docs`.
+
 ## Create them all (`gh` one-liner)
 
 Run from a clone of `pulumi/docs` with `gh` authenticated as a user with write access:
@@ -43,9 +49,11 @@ Run from a clone of `pulumi/docs` with `gh` authenticated as a user with write a
 ```bash
 gh label create "domain:docs"            --color 0e8a16 --description "PR touches technical docs"
 gh label create "domain:blog"            --color a2eeef --description "PR touches blog posts or customer stories"
-gh label create "domain:infra"           --color d4c5f9 --description "PR touches workflows, scripts, infra, Makefile, or build config"
+gh label create "domain:infra"           --color d4c5f9 --description "PR touches workflows, scripts, infra, Makefile, build config, or the site build pipeline"
 gh label create "domain:programs"        --color fbca04 --description "PR touches static/programs/"
+gh label create "domain:website"         --color c5def5 --description "PR touches marketing, pricing, legal, or competitive landing pages"
 gh label create "domain:mixed"           --color bfd4f2 --description "PR touches more than one domain"
+gh label create "domain:other"           --color ededed --description "PR touches no domain-specific path; reviewed under shared criteria only"
 gh label create "review:trivial"         --color c2e0c6 --description "Tiny prose-only change; skips Claude review"
 gh label create "review:frontmatter-only" --color e0f5d8 --description "Frontmatter-only Hugo content edit; skips Claude review"
 gh label create "review:oversized"       --color f9d0c4 --description "Diff too large for automated review (generated corpora); skips Claude review"

--- a/.github/labels-pr-review.md
+++ b/.github/labels-pr-review.md
@@ -18,7 +18,7 @@ Every triaged PR carries exactly one of these, `domain:other` included, so **the
 | `domain:programs` | `fbca04` | PR touches example programs under `static/programs/`. |
 | `domain:website` | `c5def5` | PR touches marketing, pricing, legal, or competitive landing pages (any other `content/**.md`). |
 | `domain:mixed` | `bfd4f2` | PR touches more than one domain. Each file is reviewed under its domain. |
-| `domain:other` | `ededed` | PR touches no domain-specific path (`data/`, `styles/`, `archetypes/`, repo-root dotfiles). Reviewed under shared criteria only. Applied only when nothing else matched, so it never appears beside another `domain:` label. |
+| `domain:other` | `ededed` | PR touches no domain-specific path (`data/`, `styles/`, `archetypes/`, `.claude/`, non-workflow `.github/` files, repo-root dotfiles). Reviewed under shared criteria only. Applied only when nothing else matched, so it never appears beside another `domain:` label. |
 
 ## Workflow-state labels
 

--- a/.github/labels-pr-review.md
+++ b/.github/labels-pr-review.md
@@ -40,7 +40,7 @@ Load-bearing — these gate workflow execution.
 
 The six `review:*` state labels are **mutually exclusive**. Setting one removes the others. `set-review-label.sh` (under `.claude/commands/docs-review/scripts/`) enforces this atomically and supports a `--clear` mode that strips any state label without adding a new one (used by claude-triage.yml's `if: always()` cleanup).
 
-> **Before merging a change that introduces a new label:** create it first. Triage applies its whole ADD set in a single `gh pr edit --add-label a,b,c` call, and `gh` rejects the entire call if any one name doesn't exist in the repo — the workflow's `|| true` then swallows it, so the other labels in that batch go missing too, silently. As of this writing `domain:other` is the one label in this document that does not yet exist in `pulumi/docs`.
+> **Before merging a change that introduces a new label:** create it first. Triage applies its whole ADD set in a single `gh pr edit --add-label a,b,c` call, and `gh` rejects the entire call if any one name doesn't exist in the repo — the workflow's `|| true` then swallows it, so the other labels in that batch go missing too, silently.
 
 ## Create them all (`gh` one-liner)
 


### PR DESCRIPTION
### Proposed changes

Two gaps in triage's path map, both surfaced by [#21164](https://github.com/pulumi/docs/pull/21164) — a change touching only `theme/src/scss` and `theme/src/ts` that came out of triage with no `domain:` label. Triage ran fine ([run](https://github.com/pulumi/docs/actions/runs/33036291604)); it just had nothing to say.

1. **`theme/` now routes to `domain:infra`.** It matched no rule in `classify_path()` and fell through to `None`. It's the same kind of path as `layouts/` and `assets/`, which already route to infra. This also gives those files the infra *review criteria*, which they weren't getting — the review lane is path-based off `domain-routing.md`, and `theme/` was landing in its catch-all.
1. **A PR where nothing matches now gets `domain:other`**, so an unlabeled PR unambiguously means triage never ran. It fires only when nothing else matched, so it can't flip `mixed` on a PR that isn't.

`domain:mixed` is the tempting reuse for that fallback, but it's derived from `len(domains) > 1` and means "touches more than one domain" — pointing it at a single unmatched file asserts the opposite of what's true and collapses the label's filter value. Swapping the two is one string in `FALLBACK_DOMAIN` if the tradeoff reads differently to you.

Also: `domain-routing.md` now matches the classifier (its table sent `layouts/`, `assets/`, and `static/` to the shared-criteria catch-all while the code labeled them infra); `labels-pr-review.md` gains `domain:other` and `domain:website` (the latter has been applied by triage all along, just never listed); routing tests added, 8 checks → 26. Both test functions now assert on recorded failures so they fail under pytest, not just standalone — previously a broken rule printed `FAIL` lines and still reported a green suite.

### Before merging

`domain:other` doesn't exist in the repo yet and needs creating, or it silently won't apply — triage batches its whole ADD set into one `gh pr edit --add-label a,b,c`, which `gh` rejects entirely on an unknown name, and the workflow's `|| true` swallows the error.

```bash
gh label create "domain:other" --color ededed --description "PR touches no domain-specific path; reviewed under shared criteria only"
```

### Testing

- `make test-review-pipeline` green. Replaying #21164's file set through the fixed classifier gives `domain:infra`.
- `make lint` doesn't cover this diff — markdownlint scans only `content/`, and `.prettierignore` excludes `*.md` and `scripts`. It was not run locally: `make ensure` needs hugo and Node 24.

### Related issues

Follows from [#21164](https://github.com/pulumi/docs/pull/21164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALUobedhegnGSPKD1W24zb