### PR TITLE
Mark the direct Terraform modules announcement as deprecated

### DIFF
--- a/content/blog/announcing-direct-tf-modules/index.md
+++ b/content/blog/announcing-direct-tf-modules/index.md
@@ -2,6 +2,7 @@
 title: "New: Use Terraform Modules in Pulumi Without Conversion"
 allow_long_title: true
 date: 2025-06-23
+updated: 2026-08-28
 draft: false
 meta_desc: "Pulumi can now execute Terraform modules directly, making migration from Terraform to Pulumi simpler than ever for complex infrastructure projects."
 authors:
@@ -28,6 +29,10 @@ social:
 
     This represents a significant step forward in making infrastructure migration accessible to teams of all sizes.
 ---
+
+{{% notes type="warning" %}}
+This post describes the deprecated [pulumi-terraform-module](https://github.com/pulumi/pulumi-terraform-module) provider and its `pulumi package add terraform-module` command. Terraform module support is now provided by [Pulumi HCL](https://github.com/pulumi/pulumi-hcl/) via `pulumi package add hcl module`. See [Use a Terraform Module in Pulumi](/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/) for current instructions.
+{{% /notes %}}
 
 Today, we're excited to announce a major advancement in Pulumi's mission to make modern infrastructure as code accessible to every developer: **direct support for executing Terraform modules**. This new capability addresses one of the most significant challenges our users face when migrating from Terraform to Pulumi—complex projects with extensive module dependencies.
 


### PR DESCRIPTION
The [June 2025 announcement post](https://www.pulumi.com/blog/announcing-direct-tf-modules/) still teaches the deprecated [pulumi-terraform-module](https://github.com/pulumi/pulumi-terraform-module) provider and its `pulumi package add terraform-module` command, replaced by [Pulumi HCL](https://github.com/pulumi/pulumi-hcl/) and `pulumi package add hcl module`.

Following the blog-is-historical convention, this adds the standard outdated-post warning banner (pointing at pulumi-hcl and the current [Use a Terraform Module guide](https://www.pulumi.com/docs/iac/guides/building-extending/using-existing-tools/use-terraform-module/)) plus `updated: 2026-08-28`, and leaves the historical body unchanged.

Precedent — other announcement posts carrying the same banner:

- [Announcing Per-User Pricing and Unlimited Stacks for Teams](https://www.pulumi.com/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/)
- [Building Your First Serverless App Using Only JavaScript](https://www.pulumi.com/blog/building-your-first-serverless-app-using-only-javascript/)
- [Announcing the Pulumi Azure Provider 2.0](https://www.pulumi.com/blog/pulumi-azure-2-0/)

This is the only remaining reference to the deprecated system in master: #20709 (merged) already renamed the command across the docs pages, and the getting-started page (`content/docs/iac/get-started/terraform/terraform-modules.md`) already teaches `pulumi package add hcl module` — its only `terraform-module` hits are generic example directory names. The open draft #20732 covers adjacent Terraform-facing pages and does not conflict.

## Test plan

- `node scripts/lint/lint-markdown.js`: 1856 files parsed, 0 errors.
- Grepped `content/` (excluding this post) for `package add terraform-module`, `source: terraform-module`, and `github.com/pulumi/pulumi-terraform-module`: no hits.