### PR TITLE
Suppress consent banner outside production

### DIFF
--- a/layouts/cjs26/list.html
+++ b/layouts/cjs26/list.html
@@ -218,7 +218,7 @@ open $(pulumi stack output url)
                 <a href="https://www.pulumi.com" class="hover:underline">pulumi.com</a>
             </div>
             <ul class="md:ml-auto md:text-right flex flex-wrap gap-x-3 gap-y-1 list-none m-0 p-0">
-                <li><a class="hover:underline cursor-pointer" data-track="footer-legal-privacy-preferences" onclick="window.consentManager.openConsentManager()">Your Privacy Preferences</a></li>
+                <li><a class="hover:underline cursor-pointer" data-track="footer-legal-privacy-preferences" onclick="window.consentManager && window.consentManager.openConsentManager()">Your Privacy Preferences</a></li>
                 <li><a class="hover:underline" data-track="footer-legal-trademark-usage" href="/trademark/">Trademark Usage</a></li>
                 <li><a class="hover:underline" data-track="footer-legal-acceptable-use-policy" href="/acceptable-use/">Acceptable Use Policy</a></li>
                 <li><a class="hover:underline" data-track="footer-legal-terms-conditions" href="/terms-and-conditions/">Terms &amp; Conditions</a></li>

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -75,7 +75,7 @@
             <li>
                 <a class="text-white opacity-70 hover:opacity-100 hover:underline cursor-pointer"
                    data-track="footer-legal-privacy-preferences"
-                   onclick="window.consentManager.openConsentManager();">Your Privacy Preferences</a>
+                   onclick="window.consentManager && window.consentManager.openConsentManager();">Your Privacy Preferences</a>
             </li>
             {{ range .Site.Menus.legal }}
                 <li>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -436,7 +436,9 @@
         })();
     </script>
 
-    <!-- Segment Consent Manager -->
+    <!-- Segment Consent Manager (production only - the banner and its analytics
+         gating are suppressed on local dev and PR preview builds). -->
+    {{- if eq hugo.Environment "production" }}
     <script>
         window.consentManagerConfig = {
             writeKey: segmentWriteKey,
@@ -459,6 +461,7 @@
             document.body.appendChild(s);
         });
     </script>
+    {{- end }}
 
     {{- if eq hugo.Environment "production" }}
         <!-- Facebook Domain Verification -->


### PR DESCRIPTION
Gates the Segment consent manager on `hugo.Environment == "production"`, so the cookie-consent banner no longer shows on local dev and PR preview builds. Footer "Your Privacy Preferences" links are made null-safe since `window.consentManager` is undefined outside production.