### PR TITLE
Document passkey sign-in for Pulumi Cloud accounts

### DIFF
--- a/content/docs/administration/concepts/accounts.md
+++ b/content/docs/administration/concepts/accounts.md
@@ -168,9 +168,9 @@ To disable multi-factor authentication, select **Reset authentication method** i
 
 ### Signing in with a passkey
 
-A passkey lets you sign in with Touch ID, Face ID, Windows Hello, or a hardware security key instead of typing a password. It is a public-key credential: the private key stays on your device or in your password manager, and Pulumi Cloud stores only the public half. Passkeys are built on the [WebAuthn](https://www.w3.org/TR/webauthn-3/) standard, which every major browser and operating system supports.
+A passkey is a public-key credential that lets you sign in with Touch ID, Face ID, Windows Hello, or a hardware security key instead of typing a password. The private key stays on your device or in your password manager, and Pulumi Cloud stores only the public half. Passkeys are built on the [WebAuthn](https://www.w3.org/TR/webauthn-3/) standard, which current versions of every major browser and operating system support.
 
-Any Pulumi account can register a passkey. Passkeys are available in every edition at no additional cost.
+Passkeys are available in every Pulumi Cloud edition at no additional cost.
 
 To register one:
 
@@ -179,11 +179,11 @@ To register one:
 1. In the Passkeys section, select **Register a passkey**.
 1. Complete your device's prompt: Touch ID, Face ID, Windows Hello, or your hardware key.
 
-Pulumi Cloud names the passkey after the authenticator it recognizes, such as "Windows Hello" or "Chrome on Mac". Select **Rename** to give it a name of your own, or **Remove** to delete it. Removal takes effect immediately, and a deleted passkey can no longer sign you in.
+Pulumi Cloud names the passkey after the authenticator it recognizes, such as "Windows Hello" or "Chrome on Mac". Select **Rename** to give it a name of your own, or **Remove** to delete it. Removal takes effect immediately, and a deleted passkey can no longer sign you in. It does not end sessions that are already signed in, so sign out of those separately if you have lost the device.
 
 You can register as many passkeys as you want. One per device is common, as is one synced credential plus a hardware key as a backup.
 
-To use one, select **Sign in with a passkey** on the sign-in page. If your browser supports passkey autofill, the email field also offers your registered passkeys as suggestions.
+To use one, select the passkey option on the sign-in page. If your browser supports passkey autofill, the email field also offers your registered passkeys as suggestions.
 
 Registering a passkey does not disable any other way of signing in. Your password, if you have one, keeps working, so losing every registered passkey does not lock you out of your account.
 
@@ -191,7 +191,7 @@ Registering a passkey does not disable any other way of signing in. Your passwor
 A passkey sign-in does not prompt for a one-time password, even when you have [MFA](#setting-up-mfa) enrolled. Pulumi Cloud requires user verification, a biometric or a PIN, on every passkey ceremony, so the passkey already proves both possession of the device and the factor that unlocks it. Signing in with your password still prompts for your second factor.
 {{% /notes %}}
 
-In [self-hosted Pulumi Cloud](/docs/administration/self-hosting/), the Passkeys section appears only if the deployment has been configured for passkeys. Ask whoever administers your deployment.
+In [self-hosted Pulumi Cloud](/docs/administration/self-hosting/), the Passkeys section appears only if an administrator has set `PULUMI_PASSKEY_CEREMONY_KEY` on the API service to a base64-encoded 32-byte random value.
 
 ## Deleting your account
 

--- a/content/docs/administration/concepts/accounts.md
+++ b/content/docs/administration/concepts/accounts.md
@@ -83,6 +83,7 @@ You can sign in to Pulumi Cloud with any of the following:
 - Atlassian
 - An email address and password
 - Single sign-on through a SAML 2.0 identity provider
+- A [passkey](#signing-in-with-a-passkey) registered on your device
 
 SAML single sign-on is configured by an organization admin, not by individual users. If your company uses it, your admin sets up the [SAML integration](/docs/administration/guides/saml/) and tells you which organization name to sign in with. Note that Pulumi supports only one Pulumi Cloud organization per SCIM application, so an admin managing several organizations configures each one separately.
 
@@ -164,6 +165,33 @@ Your recovery key works once. After you use it to sign in, Pulumi issues a new o
 {{% notes type="info" %}}
 To disable multi-factor authentication, select **Reset authentication method** in the MFA section of your account settings.
 {{% /notes %}}
+
+### Signing in with a passkey
+
+A passkey lets you sign in with Touch ID, Face ID, Windows Hello, or a hardware security key instead of typing a password. It is a public-key credential: the private key stays on your device or in your password manager, and Pulumi Cloud stores only the public half. Passkeys are built on the [WebAuthn](https://www.w3.org/TR/webauthn-3/) standard, which every major browser and operating system supports.
+
+Any Pulumi account can register a passkey. Passkeys are available in every edition at no additional cost.
+
+To register one:
+
+1. Select your account avatar in the top right corner.
+1. Navigate to **Account settings**.
+1. In the Passkeys section, select **Register a passkey**.
+1. Complete your device's prompt: Touch ID, Face ID, Windows Hello, or your hardware key.
+
+Pulumi Cloud names the passkey after the authenticator it recognizes, such as "Windows Hello" or "Chrome on Mac". Select **Rename** to give it a name of your own, or **Remove** to delete it. Removal takes effect immediately, and a deleted passkey can no longer sign you in.
+
+You can register as many passkeys as you want. One per device is common, as is one synced credential plus a hardware key as a backup.
+
+To use one, select **Sign in with a passkey** on the sign-in page. If your browser supports passkey autofill, the email field also offers your registered passkeys as suggestions.
+
+Registering a passkey does not disable any other way of signing in. Your password, if you have one, keeps working, so losing every registered passkey does not lock you out of your account.
+
+{{% notes type="info" %}}
+A passkey sign-in does not prompt for a one-time password, even when you have [MFA](#setting-up-mfa) enrolled. Pulumi Cloud requires user verification, a biometric or a PIN, on every passkey ceremony, so the passkey already proves both possession of the device and the factor that unlocks it. Signing in with your password still prompts for your second factor.
+{{% /notes %}}
+
+In [self-hosted Pulumi Cloud](/docs/administration/self-hosting/), the Passkeys section appears only if the deployment has been configured for passkeys. Ask whoever administers your deployment.
 
 ## Deleting your account
 

--- a/content/docs/administration/concepts/agent-accounts.md
+++ b/content/docs/administration/concepts/agent-accounts.md
@@ -45,7 +45,7 @@ The provisioned account is a Pulumi Cloud individual account. Agents can:
 
 ## Claiming an account
 
-The user clicks the claim link and signs in with any supported identity (GitHub, GitLab, Google, Atlassian, email/password, or SAML SSO). The claim replaces the placeholder identity with the user's real identity. All state, history, and resources transfer automatically.
+The user clicks the claim link and signs in with any supported identity (GitHub, GitLab, Google, Atlassian, email/password, SAML SSO, or a passkey). The claim replaces the placeholder identity with the user's real identity. All state, history, and resources transfer automatically.
 Claiming never reduces capability. Everything available before the claim is still available after. Once the account is claimed and email is verified, you get access to various Pulumi Cloud features, including [Neo](/product/neo/), our AI infrastructure agent.
 
 ## Lifecycle

--- a/content/docs/administration/concepts/agent-accounts.md
+++ b/content/docs/administration/concepts/agent-accounts.md
@@ -46,6 +46,7 @@ The provisioned account is a Pulumi Cloud individual account. Agents can:
 ## Claiming an account
 
 The user clicks the claim link and signs in with any supported identity (GitHub, GitLab, Google, Atlassian, email/password, SAML SSO, or a passkey). The claim replaces the placeholder identity with the user's real identity. All state, history, and resources transfer automatically.
+
 Claiming never reduces capability. Everything available before the claim is still available after. Once the account is claimed and email is verified, you get access to various Pulumi Cloud features, including [Neo](/product/neo/), our AI infrastructure agent.
 
 ## Lifecycle


### PR DESCRIPTION
Passkeys shipped in July 2026 but have no coverage under `content/docs/`. This adds a **Signing in with a passkey** section to the accounts concept page, beside the existing MFA and password sections.

Fixes #21108

## Changes

`content/docs/administration/concepts/accounts.md`:

- Lists passkeys among the supported sign-in methods, linking to the new section.
- New `### Signing in with a passkey` subsection: what a passkey is, who can register one, the registration procedure, rename/remove behavior, signing in, and that a passkey does not replace password sign-in.
- Info callout on the passkey/MFA interaction.
- Note that self-hosted deployments only show the section when configured for passkeys.

No frontmatter, nav, or pricing-marker changes. Prose only.

## Ground truth

Written against `pulumi/pulumi-service` at `7446d9882f` rather than from the announcement post, because two blog claims no longer match the code.

**1. TOTP MFA does not prompt on a passkey sign-in.** `finalizePasskeyLogin` (`cmd/service/api/passkey.go:328`) mints a login token directly; `PerformSecondFactorAuthentication` is called only from the two password paths (`cmd/service/api/login.go:690`, `:1396`). This looks deliberate — `services/passkey/passkey.go:44-52` requires user verification on every ceremony so a passkey is possession + biometric/PIN on its own. The [blog post](https://github.com/pulumi/docs/blob/master/content/blog/passkey-support-in-pulumi-cloud/index.md) says the opposite at line 77 ("will still prompt for your second factor").

**2. Any account can register a passkey**, not just email/password accounts. `PasskeyRegisterBeginHandler` (`passkey.go:136`) checks only for a session, and `<app-passkey-settings />` renders unconditionally (`user-settings.component.html:29`). The blog scopes the feature to password users at line 45.

The docs describe the code. **The blog post is untouched here** — worth a Cloud team confirmation of intent before anyone edits it.

## Answering the issue's org-restriction question

The issue asks whether an admin can require or disallow passkeys. **No such control exists.** The only gates are a global LaunchDarkly flag (`passkeys-enabled`, evaluated with a no-org context, `services/featureflag/flags.go:35-42`) and the `PULUMI_PASSKEY_CEREMONY_KEY` env var, which self-hosted deployments must set or the routes 404 (`config/env.go:80-86`). `model/auth_policies.go` governs OIDC token exchange, not human sign-in. Per review discussion this is recorded here rather than stated on the page.

## Worth a second opinion

A SAML- or SCIM-managed account can register a passkey and then sign in with it, bypassing the organization's identity provider. That reads like a policy gap rather than a docs gap, so it is not documented as intended behavior.

## Testing

- `make lint` — 1859 files, 0 errors; Prettier clean.
- `make lint-prose` — nags only.
- Rendered locally: both anchors resolve, callout renders, left nav unchanged.
