### PR TITLE
Put the AWS KMS customer managed key setup on one page

### DIFF
--- a/content/docs/administration/concepts/customer-managed-keys.md
+++ b/content/docs/administration/concepts/customer-managed-keys.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Pulumi Cloud: Customer Managed Keys"
+title_tag: "Pulumi Cloud: Customer managed keys"
 meta_desc: Bring your own encryption keys to protect data within Pulumi Cloud for enhanced security and compliance.
-title: "Customer Managed Keys"
-h1: Customer Managed Keys
+title: "Customer managed keys"
+h1: Customer managed keys
 menu:
   administration:
     parent: administration-concepts
@@ -17,7 +17,7 @@ pulumi_cloud_feature: customer-managed-keys
 
 ## Overview
 
-Pulumi Cloud supports Customer Managed Keys (CMKs) to improve the security and compliance of your data. CMKs allow you
+Pulumi Cloud supports customer managed keys (CMKs) to improve the security and compliance of your data. CMKs allow you
 to use your own encryption keys to protect sensitive data in Pulumi Cloud through an external
 Key Management System (KMS).
 
@@ -28,15 +28,15 @@ encrypted data itself does not change.
 Only organization admins can manage CMKs.
 
 {{% notes type="info" %}}
-Currently, Customer Managed Keys are only used to encrypt data in Pulumi ESC, and only AWS KMS is
+Currently, customer managed keys are only used to encrypt data in Pulumi ESC, and only AWS KMS is
 supported.
 We are working on adding support for more KMS providers and expanding encryption to additional Pulumi products. If you
 have specific requirements, please [contact us](/contact/).
 {{% /notes %}}
 
-## Viewing Customer Managed Keys
+## Viewing customer managed keys
 
-To view Customer Managed Keys:
+To view customer managed keys:
 
 1. As an admin, expand the organization’s **Settings** menu.
 1. Select **Organization**.
@@ -53,33 +53,25 @@ The Customer Managed Keys page displays the following details for each key:
 - **Disable**: A button to disable the key. This option is unavailable for default keys or keys undergoing
   re-encryption.
 
-## Adding a Customer Managed Key
+## Adding a customer managed key
 
-Adding a Customer Managed Key enables you to use your own encryption key to protect sensitive data in Pulumi Cloud.
+Adding a customer managed key means preparing a key in your key management system and then registering it with Pulumi
+Cloud, so that your own key protects sensitive data. For the full procedure, see
+[AWS KMS](/docs/administration/guides/customer-managed-keys/aws-kms/).
 
 {{% notes type="info" %}}
-When the first Customer Managed Key is added, all data keys encrypted with the Pulumi-managed key will be automatically
-re-encrypted with the new Customer Managed Key. The encrypted data itself does not change.
+When the first customer managed key is added, all data keys encrypted with the Pulumi-managed key will be automatically
+re-encrypted with the new customer managed key. The encrypted data itself does not change.
 {{% /notes %}}
 
-### AWS KMS
-
-1. Set up a role in AWS IAM and a key in AWS KMS as
-   described in [Configure AWS KMS](/docs/administration/guides/customer-managed-keys/aws-kms/).
-2. Go to the **Customer Managed Keys** settings page in Pulumi Cloud.
-3. Click **Add Customer Managed Key**.
-4. Enter a unique name for the key.
-5. Provide the **Role ARN** with access to the AWS KMS key.
-6. Provide the **Key ARN** of the AWS KMS key. Alias ARNs are also supported.
-
-## Disabling a Customer Managed Key
+## Disabling a customer managed key
 
 Disabling a key prevents it from being used to create new data keys, but existing data keys remain encrypted with the
 key until they are re-encrypted. You must specify a re-encryption key to re-encrypt existing data keys.
 
 Disabling a key is not available for default keys or keys undergoing re-encryption.
 
-To disable a Customer Managed Key:
+To disable a customer managed key:
 
 1. Click the three-dot menu next to the key you want to disable.
 2. Select **Disable**.
@@ -87,12 +79,12 @@ To disable a Customer Managed Key:
 4. Click **Disable** to confirm.
 5. A banner will appear, showing the re-encryption process status. It disappears once the process is complete.
 
-## Disabling All Customer Managed Keys
+## Disabling all customer managed keys
 
 Disabling all keys prevents them from being used to create new data keys, but existing data keys remain encrypted with
 the keys until they are re-encrypted. All data keys will be re-encrypted with the Pulumi-managed key.
 
-To disable all Customer Managed Keys:
+To disable all customer managed keys:
 
 1. Click on the wheel button in the top right corner.
 2. Click **Disable all Customer Managed Keys**.

--- a/content/docs/administration/guides/customer-managed-keys/_index.md
+++ b/content/docs/administration/guides/customer-managed-keys/_index.md
@@ -1,11 +1,11 @@
 ---
-title: Customer Managed Keys
-title_tag: Configure Customer Managed Keys for Pulumi Cloud
+title: Customer managed keys
+title_tag: Configure customer managed keys for Pulumi Cloud
 h1: Configure customer managed keys
 meta_desc: Configure an external key management system so Pulumi Cloud encrypts your data with a key you control.
 menu:
   administration:
-    name: Customer Managed Keys
+    name: Customer managed keys
     parent: administration-guides
     identifier: administration-guides-customer-managed-keys
     weight: 5

--- a/content/docs/administration/guides/customer-managed-keys/aws-kms.md
+++ b/content/docs/administration/guides/customer-managed-keys/aws-kms.md
@@ -1,6 +1,6 @@
 ---
 title_tag: "AWS KMS"
-meta_desc: "Learn how to configure AWS KMS for Pulumi Cloud Customer Managed Keys to enhance security and compliance."
+meta_desc: "Configure AWS KMS and add the key in Pulumi Cloud to encrypt your organization's data with a customer managed key."
 title: "AWS KMS"
 h1: "AWS KMS"
 menu:
@@ -16,10 +16,9 @@ aliases:
 pulumi_cloud_feature: customer-managed-keys
 ---
 
-This guide provides step-by-step instructions for configuring AWS Key Management Service (KMS) to use [Customer Managed
-Keys (CMKs) with Pulumi Cloud](/docs/administration/concepts/customer-managed-keys/). It covers setting up the necessary AWS
-IAM roles, trust policies, and KMS key permissions
-to enhance the security and compliance of your Pulumi Cloud environment.
+This guide walks through configuring AWS Key Management Service (KMS) so that Pulumi Cloud encrypts your organization's
+data with a [customer managed key](/docs/administration/concepts/customer-managed-keys/) you own. You set up an identity
+provider, IAM role, and trust policy in AWS, create the KMS key, and then add the key in Pulumi Cloud.
 
 ## Prerequisites
 
@@ -81,7 +80,7 @@ and subject are configured as shown below:
 ```
 
 Before you log out of the AWS console, make sure to make a note of your role’s ARN value as you will need it to set up
-the AWS KMS key as well as the Customer Managed Key in Pulumi Cloud.
+the AWS KMS key as well as the customer managed key in Pulumi Cloud.
 
 ## Create the AWS KMS key
 
@@ -114,9 +113,23 @@ the AWS KMS key as well as the Customer Managed Key in Pulumi Cloud.
 ```
 
 Before you log out of the AWS console, make sure to make a note of your key’s ARN value and or alias ARN value as you
-will need it to set up the Customer Managed Key in Pulumi Cloud.
+will need it to set up the customer managed key in Pulumi Cloud.
 
-## Add the Customer Managed Key in Pulumi Cloud
+## Add the customer managed key in Pulumi Cloud
 
-Now you can add the Customer Managed Key in Pulumi Cloud as described in
-the [Customer Managed Keys documentation](/docs/administration/concepts/customer-managed-keys/).
+With the role ARN and key ARN from the previous steps, you can now register the key with Pulumi Cloud.
+
+{{< notes type="info" >}}
+When you add your first customer managed key, all data keys encrypted with the Pulumi-managed key are automatically
+re-encrypted with the new key. The encrypted data itself does not change.
+{{< /notes >}}
+
+1. In Pulumi Cloud, navigate to the **Customer Managed Keys** settings page (**Settings** → **Organization** →
+   **Customer Managed Keys**).
+1. Select **Add Customer Managed Key**.
+1. Enter a unique name for the key.
+1. Provide the **Role ARN** of the IAM role you created.
+1. Provide the **Key ARN** of the AWS KMS key. Alias ARNs are also supported.
+
+To set the key as your organization's default, or to disable a key later, see
+[Customer managed keys](/docs/administration/concepts/customer-managed-keys/).

--- a/content/docs/esc/concepts/customer-managed-keys.md
+++ b/content/docs/esc/concepts/customer-managed-keys.md
@@ -1,8 +1,8 @@
 ---
-title_tag: "Pulumi ESC: Customer Managed Keys"
+title_tag: "Pulumi ESC: Customer managed keys"
 meta_desc: Bring your own encryption keys to protect data within Pulumi Cloud for enhanced security and compliance.
-title: Customer Managed Keys
-h1: Customer Managed Keys
+title: Customer managed keys
+h1: Customer managed keys
 menu:
   esc:
     parent: esc-concepts
@@ -14,7 +14,7 @@ pulumi_cloud_feature: customer-managed-keys
 
 ## Overview
 
-Pulumi ESC supports Customer Managed Keys (CMKs) to improve the security and compliance of your data. CMKs allow you
+Pulumi ESC supports customer managed keys (CMKs) to improve the security and compliance of your data. CMKs allow you
 to use your own encryption keys to protect secrets in Pulumi ESC through an external
 Key Management System (KMS).
 
@@ -25,14 +25,14 @@ encrypted secrets do not change.
 Only organization admins can manage CMKs.
 
 {{% notes type="info" %}}
-Currently, Customer Managed Keys support keys from AWS KMS and are only used to encrypt data stored in Pulumi ESC.
+Currently, customer managed keys support keys from AWS KMS and are only used to encrypt data stored in Pulumi ESC.
 We are working on adding support for more KMS providers and expanding encryption to additional Pulumi products. If you
 have specific requirements, please [contact us](/contact/).
 {{% /notes %}}
 
-## Why use Customer Managed Keys?
+## Why use customer managed keys?
 
-Customer Managed Keys (CMKs) give you control over the encryption of your secrets in Pulumi ESC. By using your
+Customer managed keys (CMKs) give you control over the encryption of your secrets in Pulumi ESC. By using your
 own keys, you can:
 
 - Meet strict security and compliance requirements.
@@ -41,7 +41,8 @@ own keys, you can:
 
 This approach enhances data security and aligns with organizational or regulatory policies.
 
-## Customer Managed Keys documentation
+## Customer managed keys documentation
 
-See the [Customer Managed Keys](/docs/administration/concepts/customer-managed-keys/) documentation for complete usage
-instructions.
+For how customer managed keys work and how to view or disable them, see
+[Customer managed keys](/docs/administration/concepts/customer-managed-keys/). To set one up, follow the
+[AWS KMS](/docs/administration/guides/customer-managed-keys/aws-kms/) guide.

--- a/data/pulumi_pricing.yaml
+++ b/data/pulumi_pricing.yaml
@@ -197,7 +197,7 @@ editions:
         - Audit logs
         - Drift detection and remediation
         - Time-to-live stacks
-        - Customer-managed keys
+        - Customer managed keys
         - Priority feature requests
         - 12x5 Enterprise Support available
 
@@ -499,8 +499,8 @@ categories:
         available_from: enterprise
 
       - id: customer-managed-keys
-        name: Customer-managed keys
-        link: /docs/esc/concepts/customer-managed-keys/
+        name: Customer managed keys
+        link: /docs/administration/concepts/customer-managed-keys/
         available_from: enterprise
 
       - id: esc-integrations-sync


### PR DESCRIPTION
The procedure for adding a customer managed key was split mid-list across two pages. On the concept page, step 1 of **Adding a Customer Managed Key → AWS KMS** sent the reader to the AWS KMS guide — itself a five-section IAM/KMS walkthrough — and steps 2–6 waited back on the concept page. The guide, in turn, ended by pointing back at the concept page, so the two handed the reader back and forth.

## Changes

- `guides/customer-managed-keys/aws-kms.md` — the console steps now close out the guide as **Add the customer managed key in Pulumi Cloud**, after the IAM role and KMS key they depend on, so the AWS KMS path reads start to finish on one page. Steps 4 and 5 reference the role ARN and key ARN the reader was told to note earlier on the same page.
- `concepts/customer-managed-keys.md` — the AWS KMS list is gone. **Adding a customer managed key** stays as a short conceptual section (what adding a key means, the first-key re-encryption note) and links to the guide.
- `esc/concepts/customer-managed-keys.md` — its single pointer now splits: concept page for how CMKs work and how to view/disable them, AWS KMS guide for setup.
- `data/pulumi_pricing.yaml` — the `customer-managed-keys` row on `/pricing/` linked to the ESC page; repointed at the administration concept page, and its label matched to the docs.
- Feature name normalized to sentence case across all four pages, per AGENTS.md. Product UI strings are unchanged (**Customer Managed Keys** tab, **Add Customer Managed Key**, **Disable all Customer Managed Keys**).

## Reviewer notes

- **The concept page deliberately keeps three procedures** — Viewing, Disabling a key, Disabling all keys. Issue #21232 proposes moving those too, but they aren't KMS-specific, and the decision on this PR was to move only the KMS-specific steps. So the issue's *"Concept page retains only conceptual material"* box stays unchecked on purpose, not by oversight.
- **No files moved**, so no new aliases. The three existing aliases on the concept page are untouched — a 2024 blog post still reaches it through `/docs/pulumi-cloud/admin/customer-managed-keys/`.
- **Anchors are safe.** No `#…` link anywhere in the repo targets a CMK page. Sentence-casing headings doesn't move anchors (Hugo lowercases when it slugifies); the only anchor removed is `#aws-kms`, from the deleted subsection.
- Verified against a local server: all four pages render, and `/pricing/` resolves the repointed link. Prose-only change, so no dark-mode pass.

Fixes #21232