### PR TITLE
Fix dead Organization logo URL in structured data

### DIFF
--- a/layouts/partials/schema/graph-builder.html
+++ b/layouts/partials/schema/graph-builder.html
@@ -208,9 +208,9 @@
     "url" "https://www.pulumi.com"
     "logo" (dict
       "@type" "ImageObject"
-      "url" "https://www.pulumi.com/logos/brand/logo.png"
-      "width" 600
-      "height" 60
+      "url" "https://brand.pulumi.com/media/images/logos/horizontal-1200w.png"
+      "width" 1200
+      "height" 299
     )
     "description" $orgDescription
     "foundingDate" $orgFoundingDate
@@ -348,9 +348,9 @@
     "url" "https://www.pulumi.com"
     "logo" (dict
       "@type" "ImageObject"
-      "url" "https://www.pulumi.com/logos/brand/logo.png"
-      "width" 600
-      "height" 60
+      "url" "https://brand.pulumi.com/media/images/logos/horizontal-1200w.png"
+      "width" 1200
+      "height" 299
     )
     "description" $orgDescription
     "foundingDate" $orgFoundingDate


### PR DESCRIPTION
## What

The sitewide `https://www.pulumi.com/#organization` JSON-LD node — emitted on every page by `layouts/partials/schema/graph-builder.html` (full corporate node on the homepage, minimal identity node everywhere else) — cites `https://www.pulumi.com/logos/brand/logo.png` at 600×60 as the organization logo. That URL returns **404**: `static/logos/brand/` has never contained a `logo.png`, and the claimed 600×60 dimensions match no real asset.

## Fix

Point both occurrences at the brand portal's permanent canonical render:

```
https://brand.pulumi.com/media/images/logos/horizontal-1200w.png  (1200×299)
```

This is the approved horizontal/color/light variant from the brand logo API (`GET brand.pulumi.com/api/logo`), whose canonical URLs are query-string-free, immutable, and CDN-cacheable by contract — so the approved mark stays the brand team's to manage. It meets Google's Organization logo guidelines: ≥112×112px, crawlable and indexable (brand.pulumi.com robots allows all, no `X-Robots-Tag`), a supported format, and legible on a white background.

## Why now

Found while reviewing pulumi/registry#12245, which mirrors this node onto all ~59,600 registry pages. That PR already adopts this URL; this change keeps every page emitting the shared `@id` claiming the same logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tCPX5axmQ7pXpgbxYRfPB