### PR TITLE
Sentence-case the Context API changelog title

### DIFF
--- a/content/releases/changelog/2026-08-26-context-api.md
+++ b/content/releases/changelog/2026-08-26-context-api.md
@@ -1,5 +1,5 @@
 ---
-title: "Query Your Infrastructure with the Pulumi Context API"
+title: "Query your infrastructure with the Pulumi Context API"
 date: 2026-08-26
 meta_desc: "The Pulumi Context API is now in public preview: a queryable graph spanning IaC state, stack dependencies, and discovered cloud resources."
 authors:


### PR DESCRIPTION
## What

Applies the brand guide's sentence-case rule for headings to the existing Context API changelog entry (`2026-08-26-context-api.md`):

> "Query **Your Infrastructure with** the Pulumi Context API" → "Query **your infrastructure with** the Pulumi Context API"

"Pulumi Context API" stays capitalized as a product name.

## Notes

- Title-only change; the slug and URL are unaffected, so no `aliases` entry is needed.
- Passes `make lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)