### PR TITLE
Add automatic logging changelog entry

### DIFF
--- a/content/releases/changelog/2026-08-10-automatic-logging.md
+++ b/content/releases/changelog/2026-08-10-automatic-logging.md
@@ -1,0 +1,13 @@
+---
+title: "Automatic logging for faster, more secure debugging"
+date: 2026-08-10
+meta_desc: Pulumi now writes an encrypted log file for every operation automatically, so you can securely share exactly what happened with the Pulumi team for debugging.
+authors:
+    - christian-nunciato
+---
+
+Pulumi now writes a log file for every operation automatically, so when something goes wrong you no longer have to reproduce it just to capture logs for the Pulumi team. The details are already on disk, waiting for you.
+
+Those logs are encrypted with your stack's secret manager and stored under `$PULUMI_HOME/logs`, and they're rotated out after seven days — or once they reach 500 MB — so they never fill up your disk. When you need a hand, [`pulumi logs share`](/docs/iac/cli/commands/pulumi_logs_share/) securely shares them with us, and [`pulumi logs decrypt`](/docs/iac/cli/commands/pulumi_logs_decrypt/) lets you inspect them yourself.
+
+Automatic logging is available as of v3.254.0. Read the [announcement post](/blog/automatic-logging/) to learn more.


### PR DESCRIPTION
## What

Adds a standalone `/releases/` changelog entry for **automatic logging** — `2026-08-10-automatic-logging.md`.

## Why a separate entry

Automatic logging (encrypted per-operation logs, `pulumi logs share` / `pulumi logs decrypt`) shipped in **v3.254.0** and was announced on the blog on **Aug 10**, but it never got a changelog entry: it predates the August CLI/SDK rollup's v3.256+ window, so it fell through the gap between "changelog by version" and "announced in August." Dated to the announcement so it lands in the August section where readers expect it.

## Notes

- Written in the established changelog voice; links the announcement blog and the `pulumi logs share` / `pulumi logs decrypt` command docs (both verified to exist).
- Passes `make lint` (filename↔`date`, `meta_desc` ≤160, title ≤60, sentence case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)