### PR TITLE
Trim esc/administration/_index.md to the ESC-specific pages

### DIFF
--- a/content/docs/esc/administration/_index.md
+++ b/content/docs/esc/administration/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Administration
 title_tag: Pulumi ESC administration
-meta_desc: Learn about managing Pulumi ESC organizations, self-hosting options, audit logs, and identity and access management features.
+meta_desc: Administer Pulumi ESC alongside the rest of your Pulumi Cloud organization, with audit logs, deletion protection, and customer managed keys.
 menu:
     esc:
         parent: esc-home
@@ -9,21 +9,14 @@ menu:
         weight: 8
 aliases:
   - /docs/esc/access-management/
-# The landing page itself lists both gated and ungated features, so it carries no
-# marker; the pages below it are Enterprise-gated unless they say otherwise.
+# The pages listed below mix gated features (audit logs, customer managed keys) with
+# ungated ones (deletion protection), so the landing page itself carries no marker.
 ---
 
-Pulumi ESC is built upon [Pulumi Cloud](/docs/administration/), our managed cloud service for individuals and teams that allows you to manage and secure infrastructure at scale.
-Learn how to configure organizations, monitor audit logs, bring your own encryption keys, manage identity and access and enable self-hosting.
+Pulumi ESC is built on [Pulumi Cloud](/docs/administration/) and is administered through the same organization as the rest of Pulumi. Organizations, teams and role-based access control, access tokens, SAML SSO, SCIM, OIDC issuers, and self-hosting are all documented under [Administration](/docs/administration/) and apply to environments exactly as they do to stacks; the permissions that govern environment access are catalogued in [Environment scopes](/docs/administration/reference/rbac-scopes/environments/). Self-hosted Pulumi Cloud deployments include ESC.
 
-- [Pulumi Cloud organizations](/docs/administration/concepts/organizations/): Set up and manage organizations for team collaboration and secrets and configuration management.
-- [Teams and Role-based access control (RBAC)](/docs/administration/concepts/rbac/teams/): Manage permissions at the organization and environment levels.
-- [Access tokens](/docs/administration/concepts/access-tokens/): Securely authenticate and automate ESC operations.
-- [Audit logs](/docs/esc/administration/audit-logs/): Access and configure audit logs to track activities and ensure compliance.
-- [Deletion protection](/docs/esc/administration/deletion-protection/): Prevent accidental deletion of critical environments.
-- [Customer Managed Keys](/docs/esc/concepts/customer-managed-keys/): Bring your own encryption keys for enhanced security and compliance.
-- [Access control](/docs/administration/reference/rbac-scopes/environments/): Manage environment permissions with role-based access controls at the organization and team levels.
-- [OpenID Connect (OIDC)](/docs/administration/guides/oidc-issuers/): Integrate with trusted third-party identity providers to authenticate users.
-- [SAML single sign-on (SSO)](/docs/administration/guides/saml/): Configure SAML-based authentication for centralized access management.
-- [SCIM](/docs/administration/guides/scim/): Simplify user provisioning with the SCIM protocol.
-- [Self-hosting](/docs/administration/self-hosting/): Self-hosted Pulumi Cloud deployments include ESC.
+The pages below cover what is specific to ESC:
+
+- [Audit logs](/docs/esc/administration/audit-logs/): How environment activity is recorded in your organization's audit log.
+- [Deletion protection](/docs/esc/administration/deletion-protection/): Prevent accidental deletion of environments holding critical configuration.
+- [Customer managed keys](/docs/esc/concepts/customer-managed-keys/): Bring your own encryption keys to protect the secrets ESC stores.

--- a/content/docs/esc/administration/audit-logs.md
+++ b/content/docs/esc/administration/audit-logs.md
@@ -1,11 +1,11 @@
 ---
 title_tag: Audit Logs | Pulumi ESC
 meta_desc: Pulumi ESC audit logs allow you to account for user activity within your organization.
-title: Audit Logs
+title: Audit logs
 h1: Pulumi ESC audit logs
 menu:
     esc:
-        name: Audit Logs
+        name: Audit logs
         parent: pulumi-esc-admin
         weight: 1
 pulumi_cloud_feature: audit-logs


### PR DESCRIPTION
Closes #21233. Part of the Administration IA epic (#21051).

## What and why

`content/docs/esc/administration/_index.md` was an eleven-item pointer list in which **eight items linked straight out to `/docs/administration/`** — organizations, teams/RBAC, access tokens, environment RBAC scopes, OIDC, SAML, SCIM, and self-hosting. Each carried its own hand-written description, worded independently of the ones on `administration/concepts/_index.md` and `administration/guides/_index.md`.

That is the same page described in two places: an extra hop for the reader, and guaranteed drift as Administration changes. With the Administration IA restructure (#21052, #21053, #21054) freshly landed, this is the moment to stop maintaining the second copy rather than re-point it and inherit the problem again.

## Changes

**`esc/administration/_index.md`** — the eight pass-through items collapse into one sentence pointing at `/docs/administration/`. Three genuinely ESC-specific pages remain:

| Page | Lives at |
|---|---|
| Audit logs | `esc/administration/audit-logs.md` |
| Deletion protection | `esc/administration/deletion-protection.md` |
| Customer managed keys | `esc/concepts/customer-managed-keys.md` |

`meta_desc` is rewritten to describe the trimmed page (it feeds `/llms.txt`). The frontmatter comment explaining why the page carries no `pulumi_cloud_feature` marker is updated — the list still mixes gated features (audit logs, CMK) with an ungated one (deletion protection), so a marker would be wrong.

The environment RBAC scope table is *named inside* the pointer sentence rather than given its own bullet with a description, since environments are ESC's own object type — so it stays discoverable without duplicating anything.

**`esc/administration/audit-logs.md`** — sentence-case fix on `title` and `menu.name` (`Audit Logs` → `Audit logs`), per the repo rule and the cleanup list in #21051. It was inconsistent with its sibling "Deletion protection"; `h1` already read "Pulumi ESC audit logs". No URL change.

## Decisions worth a look

- **Customer managed keys stays under `esc/concepts/`.** #21233 left this open. The file already carries `aliases: /docs/esc/administration/customer-managed-keys/` from an earlier move, so moving it back would undo that and need a fresh alias in the other direction. It is still *listed* here — it is an ESC page, not an Administration page, so listing it duplicates no Administration description.
- **The section survives rather than dissolving.** `esc/administration/` is down to two files, and folding them into `esc/operations/` + `esc/concepts/` was considered. Not taken: outside what #21233 asks for, and it would move two pages that four blog posts link to.

## No URLs change

The removed items were body links, not pages. The ESC left nav is built from per-page `menu:` frontmatter, so the tree under Administration is unaffected. Every inbound link targets `audit-logs` or `deletion-protection`, both of which stay put — `esc/concepts/_index.md`, `administration/concepts/audit-logs.md`, and four blog posts. The `/docs/esc/access-management/` alias is preserved.

## Verification

- `make lint` — passes (1865 files, 0 errors).
- `make lint-prose` — 0 errors, 0 warnings, 0 suggestions on both changed files.
- Local Hugo build: `/docs/esc/administration/` and all five outbound targets return 200; `/docs/esc/access-management/` still redirects to `/docs/esc/administration/`; the ESC nav renders "Audit logs" and "Deletion protection".
- No dark-mode pass needed — prose and frontmatter only, no new markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzK1fFbmeUjc6EdVMrbBxQ