### PR TITLE
Triage: edits inside existing code fences are not trivial

### DIFF
--- a/.claude/commands/docs-review/scripts/test_triage_classify.py
+++ b/.claude/commands/docs-review/scripts/test_triage_classify.py
@@ -185,8 +185,24 @@ def test_code_inside_existing_fence_is_not_trivial() -> None:
     before = len(_failures)
     path = "content/docs/iac/concepts/x.md"
 
-    # Fence marker visible as context: the edit is inside the block.
+    # Fence marker visible as context, PROSE-shaped body: only the marker can
+    # carry the signal, so this pins the fence-tracking half of the fix on
+    # its own (the review of PR #21309 noted a Java-bodied fixture here was
+    # also caught by the shape heuristic, leaving fence tracking untested).
+    # It inverts cleanly against the `prose` fixture below, which is the same
+    # shape with no marker and is asserted trivial.
     with_marker = [
+        " ```text",
+        " Set the region before you deploy.",
+        "-Use us-west-2 for the walkthrough.",
+        "+Use us-east-1 for the walkthrough.",
+        " Then run the deploy command.",
+    ]
+    r = run_classify(_pr(1, 1, [path]), _md_diff(path, with_marker))
+    check(r["trivial"] is False, f"a prose edit under a visible fence marker is not trivial; got {r}")
+
+    # Both signals at once: marker visible AND code-shaped body.
+    with_marker_code = [
         " ```java",
         " class AwsS3Website extends ComponentResource {",
         "-    public AwsS3Website(String name) {",
@@ -194,8 +210,8 @@ def test_code_inside_existing_fence_is_not_trivial() -> None:
         "         super(\"pkg:index:AwsS3Website\", name);",
         "     }",
     ]
-    r = run_classify(_pr(1, 1, [path]), _md_diff(path, with_marker))
-    check(r["trivial"] is False, f"an edit under a visible fence marker is not trivial; got {r}")
+    r = run_classify(_pr(1, 1, [path]), _md_diff(path, with_marker_code))
+    check(r["trivial"] is False, f"a code edit under a visible fence marker is not trivial; got {r}")
 
     # Hunk starts mid-fence: no marker in view, but the lines are code-shaped.
     mid_fence = [

--- a/.claude/commands/docs-review/scripts/test_triage_classify.py
+++ b/.claude/commands/docs-review/scripts/test_triage_classify.py
@@ -168,8 +168,67 @@ def test_domain_routing() -> None:
     assert_clean("test_domain_routing", before)
 
 
+def _md_diff(path: str, lines: list[str], old_start: int = 40) -> str:
+    """A one-hunk unified diff for `path` whose body is `lines` (each already
+    carrying its ` `/`+`/`-` marker)."""
+    olds = sum(1 for l in lines if not l.startswith("+"))
+    news = sum(1 for l in lines if not l.startswith("-"))
+    return (f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n"
+            f"@@ -{old_start},{olds} +{old_start},{news} @@\n" + "\n".join(lines) + "\n")
+
+
+def test_code_inside_existing_fence_is_not_trivial() -> None:
+    """`has_code_block_change` used to fire only when a changed line WAS a
+    fence marker, so a docs PR editing the Java/Go/TS inside existing fences
+    (+10 lines, one file) classified `review:trivial` and skipped review."""
+    print("test_code_inside_existing_fence_is_not_trivial")
+    before = len(_failures)
+    path = "content/docs/iac/concepts/x.md"
+
+    # Fence marker visible as context: the edit is inside the block.
+    with_marker = [
+        " ```java",
+        " class AwsS3Website extends ComponentResource {",
+        "-    public AwsS3Website(String name) {",
+        "+    AwsS3Website(String name) {",
+        "         super(\"pkg:index:AwsS3Website\", name);",
+        "     }",
+    ]
+    r = run_classify(_pr(1, 1, [path]), _md_diff(path, with_marker))
+    check(r["trivial"] is False, f"an edit under a visible fence marker is not trivial; got {r}")
+
+    # Hunk starts mid-fence: no marker in view, but the lines are code-shaped.
+    mid_fence = [
+        " import com.pulumi.resources.ComponentResourceOptions;",
+        " ",
+        "-public class AwsS3Website extends ComponentResource {",
+        "+class AwsS3Website extends ComponentResource {",
+        "     private final Output<String> url;",
+        "     public AwsS3Website(String name, AwsS3WebsiteArgs args) {",
+    ]
+    r = run_classify(_pr(1, 1, [path]), _md_diff(path, mid_fence))
+    check(r["trivial"] is False, f"a hunk that opens mid-fence with code-shaped lines is not trivial; got {r}")
+
+    # Prose with a parenthesis at a line end is still prose — still trivial.
+    prose = [
+        " Components group resources so a team can reuse them (see below).",
+        "-Each child inherits the parent's provider and options.",
+        "+Each child inherits the parent's provider options.",
+        " Read the next section for the registration step.",
+    ]
+    r = run_classify(_pr(1, 1, [path]), _md_diff(path, prose))
+    check(r["trivial"] is True, f"a prose-only edit stays trivial; got {r}")
+
+    # Deliberately NOT asserted: a hunk whose first context line is a CLOSING
+    # fence reads as if it opened one, so a prose edit right after a code
+    # block also classifies non-trivial. That is the direction the heuristic
+    # is built to fail in — a spurious review run — and it stays that way.
+    assert_clean("test_code_inside_existing_fence_is_not_trivial", before)
+
+
 def main() -> int:
-    tests = [test_oversized_threshold, test_domain_routing]
+    tests = [test_oversized_threshold, test_domain_routing,
+             test_code_inside_existing_fence_is_not_trivial]
     for t in tests:
         try:
             t()

--- a/.claude/commands/docs-review/scripts/triage-classify.py
+++ b/.claude/commands/docs-review/scripts/triage-classify.py
@@ -115,6 +115,32 @@ def split_files(diff_text: str) -> list[tuple[str, str]]:
     return out
 
 
+# Lines a compiler would recognise: statement/block terminators, declaration
+# keywords, comment openers, operators that don't occur in prose. Kept
+# deliberately narrow — a prose line ending in `)` or containing `=` is not
+# code; `{`, `;`, `=>`, `:=` and leading keywords are. The heuristic only ever
+# ADDS "this is code" signal, and a wrong call there costs one review run;
+# the wrong call in the other direction skipped the review entirely.
+_CODE_LINE_RE = re.compile(
+    r"^\s*(?:import |package |func |const |var |let |def |class |public |private |protected "
+    r"|return\b|export |from \S+ import |using |namespace |@\w+|#include|\}|\)|//|/\*|\*/)"
+    r"|[{};]\s*$|:=|=>|\(\)|\bnew \w+\("
+)
+
+
+def _looks_like_code(text: str) -> bool:
+    return bool(_CODE_LINE_RE.search(text))
+
+
+def _hunk_looks_like_code(body_lines: list[str], min_lines: int = 3, ratio: float = 0.6) -> bool:
+    """True when most of a hunk's non-blank lines (context + changes) read as
+    code — the shape of a hunk that starts inside a fenced block."""
+    texts = [ln[1:] for ln in body_lines if ln and ln[1:].strip()]
+    if len(texts) < min_lines:
+        return False
+    return sum(1 for t in texts if _looks_like_code(t)) / len(texts) >= ratio
+
+
 def iter_hunks(file_diff: str) -> Iterable[tuple[str, list[str]]]:
     """Yield (header_line, body_lines) per hunk."""
     header: str | None = None
@@ -221,12 +247,31 @@ def classify_file(path: str, file_diff: str) -> dict:
         else:
             state = "body"
 
+        # Code-inside-fences detection. `has_code_block_change` used to fire
+        # only when a changed line WAS a fence marker, so a PR rewriting the
+        # Java/Go/TypeScript inside existing fences classified as trivial
+        # (+10 lines of snippet fixes → `review:trivial` → review skipped).
+        # Two signals, both of which fail toward "code": (1) fence state
+        # tracked across the hunk's context lines; (2) a hunk with no marker
+        # in view whose lines mostly look like code (the hunk started
+        # mid-fence). Mis-calling prose "code" only costs a review run.
+        in_fence = False
+        if is_md and _hunk_looks_like_code(body_lines):
+            flags["has_code_block_change"] = True
+
         for line in body_lines:
             if not line:
                 continue
             marker = line[0]
             content = line[1:]
             stripped = content.strip()
+
+            if is_md and stripped.startswith(("```", "~~~")) and marker in " +-":
+                if marker == " ":
+                    in_fence = not in_fence
+                    continue
+                # a changed fence marker is itself a code-block change (below)
+                in_fence = not in_fence
 
             # Frontmatter boundary toggling — both context and changed
             # lines can be `---`. If a `---` line is added or removed,
@@ -252,7 +297,7 @@ def classify_file(path: str, file_diff: str) -> dict:
 
             # Body-side change
             flags["has_body_change"] = True
-            if stripped.startswith("```"):
+            if stripped.startswith(("```", "~~~")) or in_fence:
                 flags["has_code_block_change"] = True
             if "{{<" in stripped or "{{%" in stripped:
                 flags["has_shortcode_change"] = True


### PR DESCRIPTION
`triage-classify.py`'s `has_code_block_change` only fired when a *changed line was itself a fence marker*. Ten lines of Java/Go/TypeScript edits inside existing fences in one docs file therefore classified `review:trivial`, and the review was skipped entirely. Found on master on 2026-09-01 while tracing the PR #21291 recall gaps.

## What changed

Ported from commit 72a3c34d710 on `CamSoper/review-v3`, detection only (master has no `classify_mechanical`, and that stays on the v3 branch):

- `_CODE_LINE_RE` / `_looks_like_code` / `_hunk_looks_like_code`: a deliberately narrow "does this line read as code" heuristic (leading declaration keywords, `{`/`;` terminators, `=>`, `:=`, comment openers). A prose line ending in `)` or containing `=` is not code.
- Per-hunk `in_fence` tracking across context lines, and `~~~` fences count too. Any `+`/`-` line inside a fence sets `has_code_block_change`.
- A hunk that opens mid-fence (no marker in view) is caught when 60%+ of its non-blank lines are code-shaped (minimum 3 lines).

The heuristic fails toward "code" on purpose. A wrong call in that direction costs one review run; the wrong call in the other direction skipped the review. That includes a prose edit whose first context line is a closing fence -- it reads as an opener and the PR gets reviewed. The docstring says so.

## Test

`test_code_inside_existing_fence_is_not_trivial` in `test_triage_classify.py`, against `classify_pr(...)["trivial"]` the way the workflow consumes it:

- fence marker visible in context, Java edit inside -> not trivial
- hunk starting mid-fence with Java-shaped lines, no marker in view -> not trivial
- prose-only hunk with a parenthesis at a line end -> still trivial

`make test-review-pipeline` and `make lint` are green. The live check is the next docs PR that edits only code inside existing fences: it should come out of triage without `review:trivial`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsoKMcSKat1GicCbjz7fE9)_