### PR TITLE
Added riverside form to events and added riverside css

### DIFF
--- a/archetypes/event/index.md
+++ b/archetypes/event/index.md
@@ -21,7 +21,8 @@ featured: false
 # Hide from the event list.
 unlisted: false
 
-# Show a registration form. Requires form.hubspot_form_id.
+# Show a registration form. Requires form.hubspot_form_id or
+# form.riverside_event_id.
 gated: false
 
 # Link to an external page instead of rendering the event page.
@@ -69,7 +70,8 @@ tags:
     languages: []
     clouds: []
 
-# Registration form (only rendered when gated: true).
+# Registration form (only rendered when gated: true). 
+# can  riverside_event_id instead, once migrated will update this to be riverside_event_id
 form:
     hubspot_form_id: ""
     salesforce_campaign_id: ""

--- a/content/events/extending-pulumi-neo-mcp-cloud-cli/index.md
+++ b/content/events/extending-pulumi-neo-mcp-cloud-cli/index.md
@@ -45,7 +45,7 @@ sessions:
       sortable_date: 2026-09-08T09:00:00.000-07:00
       duration: 60 minutes
       form:
-          hubspot_form_id: 13e8fea4-356f-42a2-8e6b-50300b49d666
+          riverside_event_id: 6a970364f31158d839105b35
           salesforce_campaign_id: 701PQ00000zDNF3YAO
       presenters:
           - name: Adam Gordon Bell

--- a/layouts/partials/events/riverside-form.html
+++ b/layouts/partials/events/riverside-form.html
@@ -1,0 +1,35 @@
+<div id="{{ .targetId }}" class="riverside-form">Loading...</div>
+<script
+    src="https://assets.riverside.fm/rs-webinar-form/loader.js"
+    async
+    data-api-base="https://riverside.com"
+    data-event-id="{{ .eventId }}"
+    data-target="#{{ .targetId }}"
+    crossorigin="anonymous">
+</script>
+<script>
+    document.addEventListener("riverside:registrationSuccess", function (e) {
+        var webinarLink = e.detail && e.detail.webinarLink;
+        var container = document.getElementById("{{ .targetId }}");
+        if (!container || !webinarLink) {
+            return;
+        }
+        var wrapper = document.createElement("div");
+        wrapper.className = "text-center py-5";
+        var message = document.createElement("p");
+        message.className = "mb-4";
+        message.innerText = "You're registered for this webinar.";
+        var join = document.createElement("a");
+        join.className = "btn btn-primary";
+        join.href = webinarLink;
+        join.target = "_blank";
+        join.rel = "noopener";
+        join.innerText = "Join webinar";
+        wrapper.appendChild(message);
+        wrapper.appendChild(join);
+        container.replaceChildren(wrapper);
+    });
+    document.addEventListener("riverside:registrationFailure", function (e) {
+        console.error("Registration failed:", (e.detail && e.detail.message) || "Unknown error");
+    });
+</script>

--- a/layouts/partials/events/type-content.html
+++ b/layouts/partials/events/type-content.html
@@ -131,11 +131,17 @@
                 {{ if and $.Params.gated (not .passed) }}
                     <div class="card p-8">
                         <h3 class="heading-3 mb-4">Register today</h3>
-                        <pulumi-hubspot-form
-                            form-id="{{ .form.hubspot_form_id }}"
-                            salesforce-campaign-id="{{ .form.salesforce_campaign_id }}"
-                            linkedin-conversion-id="24927140"
-                        ></pulumi-hubspot-form>
+                        {{ if .form.riverside_event_id }}
+                            {{ partial "events/riverside-form.html" (dict
+                                "eventId" .form.riverside_event_id
+                                "targetId" (printf "riverside-form-%s" .key)) }}
+                        {{ else }}
+                            <pulumi-hubspot-form
+                                form-id="{{ .form.hubspot_form_id }}"
+                                salesforce-campaign-id="{{ .form.salesforce_campaign_id }}"
+                                linkedin-conversion-id="24927140"
+                            ></pulumi-hubspot-form>
+                        {{ end }}
                     </div>
                 {{ else if .passed }}
                     {{ if $timePassed }}

--- a/scripts/lint/lint-markdown.js
+++ b/scripts/lint/lint-markdown.js
@@ -810,7 +810,8 @@ function parseDateTime(value) {
  *   - with more than one session, each needs a `label`, and no two may anchorize
  *     to the same key — the label is the tab, the badge, and the deep-link anchor,
  *     so a collision makes two sessions share one panel
- *   - a gated event needs a `form.hubspot_form_id` per session, since the
+ *   - a gated event needs a registration form id per session — either
+ *     `form.hubspot_form_id` or `form.riverside_event_id` — since the
  *     top-level form no longer applies
  *   - the top-level `form:` must be gone when sessions are present, so there's no
  *     ambiguity about which form a session renders
@@ -888,9 +889,10 @@ function checkEventSessions(obj, fullPath) {
         }
 
         const hubspotFormId = session.form && session.form.hubspot_form_id;
-        if (obj.gated === true && !hubspotFormId) {
+        const riversideEventId = session.form && session.form.riverside_event_id;
+        if (obj.gated === true && !hubspotFormId && !riversideEventId) {
             errors.push(
-                `${at} is missing 'form.hubspot_form_id'. A gated event needs a registration form per session.`,
+                `${at} is missing 'form.hubspot_form_id' or 'form.riverside_event_id'. A gated event needs a registration form per session.`,
             );
         } else if (hubspotFormId) {
             if (formIds.has(hubspotFormId)) {

--- a/theme/src/scss/_riverside.scss
+++ b/theme/src/scss/_riverside.scss
@@ -1,0 +1,145 @@
+// Riverside webinar registration form (layouts/partials/events/riverside-form.html).
+//
+// The widget renders plain light-DOM markup (BEM classes prefixed `rver`) and
+// injects its own <style id="rver-styles"> into <head> at runtime. That sheet
+// is UNLAYERED, and unlayered author styles beat anything in @layer on every
+// property both declare — specificity never enters into it. So this partial is
+// imported OUTSIDE @layer components (see main.scss), where nesting under
+// `.riverside-form` (the embed container) out-specifies the widget's
+// single-class rules regardless of injection order.
+//
+// Two rules follow from that:
+//   - Never move the import back inside @layer components: every contested
+//     declaration (background, border, padding, radius) silently loses there.
+//   - Everything is mirrored BY HAND from the shared system, via @apply and
+//     literal values. @extend is off the table because it grafts this file's
+//     selectors into the extended rule's own — layered — location, which
+//     re-loses the fight; and the shared/_forms.scss mixins and $-variables
+//     are invisible here because that partial is imported inside the @layer
+//     components block, which scopes them to it. The button block mirrors
+//     .btn/.btn-lg/.btn-primary/.btn-ghost (shared/_button.scss); the control
+//     chrome mirrors form-control-base/-lg and the textarea/select/check
+//     mixins (shared/_forms.scss). Keep them in sync if those change.
+//
+
+.riverside-form {
+    @apply text-sm relative;
+    .rver__hdr,
+    .rver__title,
+    .rver__sub {
+        @apply hidden;
+    }
+    .rver__label {
+        @apply block mb-1 font-normal text-gray-950;
+    }
+    .rver__row {
+        @apply block mb-6;
+    }
+
+    // first + last name share the top row, email gets its own,
+    // the two custom text fields (company, job title) share the third, and the
+    // language dropdown closes full-width. Built-in fields carry stable input
+    // names (name/lastName/email); custom short-text fields are matched by
+    // element — Riverside renders them as textareas (and any custom text input
+    // that isn't a name field is caught too), so the event's per-field ids
+    // never appear here. Anything else (selects, checkboxes, actions) spans
+    // the full row, and below sm the form stacks single-column as before.
+    form {
+        @apply sm:grid sm:grid-cols-2 sm:gap-x-4;
+
+        > * {
+            @apply sm:col-span-2;
+        }
+
+        .rver__row:has(input[name="name"]),
+        .rver__row:has(input[name="lastName"]),
+        .rver__row:has(textarea),
+        .rver__row:has(input[type="text"]:not([name="name"]):not([name="lastName"])) {
+            @apply sm:col-span-1;
+        }
+    }
+
+    .rver__input,
+    .rver__select,
+    .rver__textarea {
+        @apply block w-full min-w-0 appearance-none border border-gray-300 bg-white text-gray-950
+               transition-all outline-none placeholder:text-gray-500
+               disabled:pointer-events-none disabled:opacity-50 disabled:bg-gray-100
+               text-base md:text-sm h-10 px-3 py-2;
+
+        border-radius: var(--radius-md);
+        --form-resting-shadow: inset 0 2px 4px 0 rgb(0 0 0 / 0.12);
+        box-shadow: var(--form-resting-shadow, none);
+
+        &:focus,
+        &:focus-visible {
+            @apply border-violet-800;
+            box-shadow: inset 0 0 0 2px var(--color-violet-800), var(--form-resting-shadow, none);
+        }
+    }
+
+    // Deliberately NOT form-textarea-chrome: Riverside renders custom short-text fields (company, job title) as textareas
+    .rver__textarea {
+        @apply resize-none placeholder:text-transparent;
+    }
+
+    // form-select-chrome.
+    .rver__select {
+        @apply cursor-pointer pr-8;
+
+        --form-resting-shadow: inset 0 -2px 4px 0 rgb(0 0 0 / 0.08);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%239997a0' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
+        background-repeat: no-repeat;
+        background-position: right 0.625rem center;
+        background-size: 1rem;
+    }
+
+    // form-check-base, plus the checked glyph.
+    input[type="checkbox"] {
+        @apply appearance-none size-4 shrink-0 p-0 box-border border border-gray-300 bg-white align-middle
+               cursor-pointer transition-all outline-none bg-center bg-no-repeat
+               checked:bg-violet-primary checked:border-violet-primary
+               focus-visible:border-violet-primary focus-visible:ring-3 focus-visible:ring-violet-primary/50
+               disabled:pointer-events-none disabled:opacity-50;
+
+        background-size: 0.75rem;
+        box-shadow: none;
+        border-radius: 4px;
+
+        &:checked {
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m3.5 8 3 3 6-6.5'/%3E%3C/svg%3E");
+        }
+    }
+
+    .rver__btn {
+        @apply inline-flex items-center justify-center gap-1.5 shrink-0 max-w-full
+               overflow-hidden text-ellipsis text-sm font-normal border border-transparent
+               bg-clip-padding rounded-md transition-all outline-none cursor-pointer select-none
+               focus-visible:border-violet-primary focus-visible:ring-3 focus-visible:ring-violet-primary/50
+               active:translate-y-px
+               disabled:pointer-events-none disabled:opacity-50
+               h-10 py-2.25 px-4;
+
+        &:not(.rver__btn--ghost) {
+            @apply bg-violet-primary text-white hover:bg-violet-800;
+        }
+
+        &--ghost {
+            @apply text-gray-950 hover:bg-gray-100;
+        }
+    }
+
+    .rver__error {
+        @apply text-red-600 text-xs min-h-0 mt-1 empty:mt-0;
+    }
+
+    .rver__hint {
+        @apply opacity-50 text-xs font-normal;
+    }
+
+    .rver__sub a,
+    .rver__rich a {
+        @apply underline;
+        color: inherit;
+    }
+}

--- a/theme/src/scss/main.scss
+++ b/theme/src/scss/main.scss
@@ -389,6 +389,13 @@ $sitenav-offset: calc($sitenav-height + 16px);
 
 @import "consent-banner";
 
+// Riverside registration form overrides. Imported UNLAYERED because the widget
+// injects its own unlayered <style> at runtime, and unlayered author styles beat
+// anything in @layer on every contested property regardless of specificity —
+// inside @layer components these rules silently lose. Scoped to .riverside-form,
+// so it cannot affect anything outside the embed container.
+@import "riverside";
+
 // Docs dark mode. Imported UNLAYERED (not inside @layer components) so its dark
 // overrides win against the Tailwind utilities used by the docs header/buttons —
 // utilities beat the components layer regardless of specificity. Everything in


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's documentation contribution guidelines.

    Tip: open this PR as a **draft** while you iterate. Automated review
    fires when you mark it ready for review — drafting first keeps the
    review fresh and avoids comment noise. While iterating, you can also
    run /docs-review locally to catch findings before they cost review
    budget.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Added the riverside form to events as we are in the process of migrating over. Currently events can use either the riverside form or the hubspot form. You just need to replace "hubspot_form_id" with "riverside_event_id" now when creating an event. Can test at /events/extending-pulumi-neo-mcp-cloud-cli/#session-americas

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A
