### PR TITLE
Docs review v3: downstream consumers read the evidence record

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -458,7 +458,10 @@ except as amended here.
 `compose-pr-body.py`): the ledger's `skipped_findings` / `clarity_flag`
 counters plus every banked finding extracted from the page's prior review
 PRs' "Findings not applied", "Screenshot check", and "Rendered content"
-sections, each with a stable `id` and its `source_pr`. The pre-step
+sections, each with a stable `id` and its `source_pr` — plus, for PRs
+reviewed on the v3 surface, what the pre-merge *reviewer* found and the page
+still carries (`source: pr-review`: findings left open, accepted as-is, or
+held over a dispute, and every pre-existing issue it filed). The pre-step
 artifacts (claims, Vale, readthrough, frontmatter) are also present and are
 your evidence base.
 

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -997,15 +997,32 @@ jobs:
             python3 scripts/content-review/compose-pr-body.py \
               --replace-notice judgment --body-file .pr-body-draft.md
           fi
+          # Bot-authored review PRs are free test traffic for the v3 review
+          # surface: while REVIEW_V3_BOT_PRS is '1' they are born carrying
+          # `surface:v3`, which the initial review lane reads off the opened
+          # event — so the label has to be on `gh pr create` itself, not
+          # added a second later. Fail-open: a repo without the label (or a
+          # create that fails for any reason) falls back to an unlabeled
+          # create, and a human never sees a difference either way.
+          LABEL_ARGS=()
+          if [ "${{ vars.REVIEW_V3_BOT_PRS }}" = "1" ]; then
+            LABEL_ARGS=(--label surface:v3)
+          fi
+          create_pr() {
+            gh pr create "$@" "${LABEL_ARGS[@]}" \
+              || { [ "${#LABEL_ARGS[@]}" -gt 0 ] \
+                   && echo "::warning::gh pr create with ${LABEL_ARGS[*]} failed (label missing from repo?); retrying unlabeled" \
+                   && gh pr create "$@"; }
+          }
           if make lint > .lint.log 2>&1; then
             echo "lint passed on $BRANCH; opening PR ready for review (fires triage → review)"
             echo "lint_result=passed" >> "$GITHUB_OUTPUT"
-            gh pr create --title "$TITLE" --body-file .pr-body-draft.md \
+            create_pr --title "$TITLE" --body-file .pr-body-draft.md \
               --base master --head "$BRANCH"
           else
             echo "::warning::make lint failed on $BRANCH; opening PR as draft"
             echo "lint_result=failed" >> "$GITHUB_OUTPUT"
-            gh pr create --draft --title "$TITLE" --body-file .pr-body-draft.md \
+            create_pr --draft --title "$TITLE" --body-file .pr-body-draft.md \
               --base master --head "$BRANCH"
           fi
           # Class label, fail-open: the label routes Robo-Cam's handling but

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -999,11 +999,15 @@ jobs:
           fi
           # Bot-authored review PRs are free test traffic for the v3 review
           # surface: while REVIEW_V3_BOT_PRS is '1' they are born carrying
-          # `surface:v3`, which the initial review lane reads off the opened
-          # event — so the label has to be on `gh pr create` itself, not
-          # added a second later. Fail-open: a repo without the label (or a
-          # create that fails for any reason) falls back to an unlabeled
-          # create, and a human never sees a difference either way.
+          # `surface:v3`. The initial review lane reads that label off the
+          # opened event once the lane-rewiring PR (stacked on the machinery
+          # PR) has merged — until then the label only drives the /resolve
+          # listener — so the label has to be on `gh pr create` itself, not
+          # added a second later. Two pre-reqs, in order: create the label
+          # (`gh label create` line in .github/labels-pr-review.md), THEN flip
+          # the variable. Fail-open: a repo without the label (or a create
+          # that fails for any reason) falls back to an unlabeled create with
+          # a ::warning::, and a human never sees a difference either way.
           LABEL_ARGS=()
           if [ "${{ vars.REVIEW_V3_BOT_PRS }}" = "1" ]; then
             LABEL_ARGS=(--label surface:v3)

--- a/.github/workflows/review-existing-content.yml
+++ b/.github/workflows/review-existing-content.yml
@@ -241,6 +241,10 @@ jobs:
             # Structured per-page findings (record-page-findings.py), synced so
             # the glow-up selector can hand each article its own record.
             echo "findings_uri=s3://$BUCKET/findings/" >> "$GITHUB_OUTPUT"
+            # The v3 pre-merge review's evidence records (scripts/review-v3/),
+            # `pr-review/<pr>/latest.json`; the glow-up selector hands each
+            # article the records for its own review PRs.
+            echo "pr_review_uri=s3://$BUCKET/pr-review/" >> "$GITHUB_OUTPUT"
             # Raw bucket name, handed to each worker via queue_json so a
             # per-worker `pulumi stack output` flake can't silently drop the
             # ledger write (the flake that caused duplicate re-reviews).
@@ -341,6 +345,12 @@ jobs:
           mkdir -p .findings-cache
           aws s3 sync "${{ steps.ledger-bucket.outputs.findings_uri }}" .findings-cache/ --quiet \
             || echo "::warning::findings records unavailable; the glow-up recoverability check is skipped this run and the worker falls back to the PR-body scrape"
+          # Pre-merge review evidence (v3): only each PR's latest.json — the
+          # per-SHA objects are history, not backlog. Best effort like the rest.
+          mkdir -p .pr-review-cache
+          aws s3 sync "${{ steps.ledger-bucket.outputs.pr_review_uri }}" .pr-review-cache/ --quiet \
+            --exclude "*" --include "*/latest.json" \
+            || echo "::warning::pre-merge review records unavailable; glow-up backlogs skip that source this run"
 
       # Deterministic selection: the model never chooses what to review.
       # Writes has_articles= / halted= to $GITHUB_OUTPUT for the gates below.
@@ -451,6 +461,9 @@ jobs:
           # read S3 itself (see record-page-findings.py).
           if [ -d .findings-cache ]; then
             ARGS+=(--findings-dir .findings-cache)
+          fi
+          if [ -d .pr-review-cache ]; then
+            ARGS+=(--pr-review-dir .pr-review-cache)
           fi
           if [ -f .traffic-snapshot ]; then
             ARGS+=(--traffic-file .traffic-snapshot)

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -42,6 +42,20 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
+      # collect_v3_ops() reads the pr-review/ prefixes of the content-review
+      # ledger bucket (discovered by name prefix, no Pulumi needed). Without
+      # credentials it degrades to {"available": false} on every scheduled
+      # run — the exact silent-dark failure the section is meant to surface.
+      # Best-effort like the other ledger readers: a credential failure
+      # leaves the rest of the digest intact.
+      - name: Configure AWS credentials
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
+          role-session-name: weekly-digest
+          aws-region: us-west-2
+
       # 1. COLLECT — deterministic, no model. Dumps the full digest JSON;
       # under dry_run it also echoes the raw JSON so queries are inspectable
       # before any model or Slack step runs.

--- a/scripts/content-review/build-glowup-backlog.py
+++ b/scripts/content-review/build-glowup-backlog.py
@@ -31,6 +31,17 @@ Sources, in order of authority:
 
 1. The structured findings record (`record-page-findings.py`), when the page has
    one. Forward-only: pages last reviewed before 2026-08-19 have none.
+1b. The pre-merge review's own evidence record for each prior review PR
+   (`pr-review/<pr>/latest.json`, written by the v3 review surface —
+   scripts/review-v3/README.md). This is what the docs REVIEWER found on the
+   content-review PR, as opposed to what the content-review run found on the
+   page: a finding left `open` when the PR closed, one a human accepted as-is,
+   a dispute the model held, and every pre-existing issue it filed are all
+   debt the page still carries. Fork-safe and machine-written, so it is read
+   before the PR-body scrape. Records reach the unprivileged worker the same
+   way the findings record does — stamped on the queue article by
+   select-glowup.py (`pr_review_records`) — or from `--pr-review-dir` on a
+   dispatcher-side run. Forward-only: PRs reviewed on the v2 monolith have none.
 2. Every prior review PR for the page, found by HEAD REF. An earlier version of
    this file asserted that reused branch names made older PRs undiscoverable, and
    so read only the pointer the ledger happened to carry. That was wrong, and it
@@ -65,6 +76,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -417,9 +429,118 @@ def banked_from_findings(record: dict | None) -> list[dict]:
     return out
 
 
+# Which pre-merge-review findings are still debt when the PR is done. Keyed on
+# the evidence object's `status` (scripts/review-v3/evidence-schema.json):
+#   open           — never answered before the PR closed/merged
+#   accepted-as-is — a human accepted the finding with a reason (the reason is
+#                    the prior disposition; the finding is the work)
+#   disputed-held  — the author disputed, the model held with evidence; the
+#                    reviewer who approved decided, but the page still says it
+#   resolved / conceded — done, or withdrawn as spurious: never re-proposed
+_PR_REVIEW_BANKABLE = {"open", "accepted-as-is", "disputed-held"}
+
+
+def banked_from_pr_review(records: list[dict]) -> list[dict]:
+    """Banked findings from the v3 pre-merge review records of prior PRs.
+
+    One item per still-open / accepted / held finding, plus every
+    pre-existing issue the review filed against the touched file (those are
+    the glow-up lane's bread and butter and the pre-merge review is the only
+    place they are recorded). The disposition note travels as
+    `prior_disposition` — context, never direction, same as everywhere else.
+    """
+    out: list[dict] = []
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        try:
+            number = int(rec.get("pr") or 0)
+        except (TypeError, ValueError):
+            number = 0
+        if not number:
+            continue
+        for f in rec.get("findings") or []:
+            if not isinstance(f, dict):
+                continue
+            status = str(f.get("status") or "open")
+            bucket = str(f.get("bucket") or "")
+            if status not in _PR_REVIEW_BANKABLE and bucket != "preexisting":
+                continue
+            text = str(f.get("text") or "").strip()
+            if not text:
+                continue
+            fid = str(f.get("id") or "F?")
+            where = str(f.get("file") or "").strip()
+            lines = f.get("lines") or []
+            if isinstance(lines, list) and lines:
+                where += f" L{lines[0]}" + (f"-{lines[-1]}" if len(lines) > 1 and lines[-1] != lines[0] else "")
+            disp = f.get("disposition") if isinstance(f.get("disposition"), dict) else {}
+            note = str(disp.get("note") or "").strip()
+            actor = str(disp.get("actor") or "").strip()
+            if status == "accepted-as-is":
+                prior = f"accepted as-is{' by ' + actor if actor else ''} on the pre-merge review of #{number}"
+            elif status == "disputed-held":
+                prior = f"disputed{' by ' + actor if actor else ''} on #{number}; the reviewer held it"
+            elif bucket == "preexisting":
+                prior = f"pre-existing issue filed by the pre-merge review of #{number} (out of that PR's scope)"
+            else:
+                prior = f"left open when #{number} closed"
+            if note:
+                prior += f": {note}"
+            section = "Pre-existing issues" if bucket == "preexisting" else "Pre-merge review findings"
+            detail = str(f.get("detail") or "").strip()
+            out.append({
+                "id": f"pr{number}-review-{fid}",
+                "section": section,
+                "source_pr": number,
+                "source": "pr-review",
+                "text": f"{text} — {prior}",
+                "finding": text + (f" ({where})" if where else ""),
+                "prior_disposition": prior + (f" — {detail}" if detail else ""),
+            })
+    return out
+
+
+def _pr_review_summary(rec: dict) -> dict:
+    fs = [f for f in (rec.get("findings") or []) if isinstance(f, dict)]
+    return {
+        "pr": rec.get("pr"),
+        "head_sha": rec.get("head_sha"),
+        "generated_at": rec.get("generated_at"),
+        "findings": len(fs),
+        "banked": sum(1 for f in fs if str(f.get("status") or "open") in _PR_REVIEW_BANKABLE
+                      or f.get("bucket") == "preexisting"),
+    }
+
+
+def load_pr_review_records(pr_review_dir: Path | None, numbers: list[int]) -> list[dict]:
+    """`latest.json` for each PR number from a local mirror of the
+    `pr-review/` prefix — laid out either as the bucket has it
+    (`<dir>/<pr>/latest.json`) or as record-evidence.py writes it locally
+    (`<dir>/<pr>-latest.json`). Missing is the normal case (v2-era PRs);
+    unreadable is warned and skipped."""
+    if pr_review_dir is None:
+        return []
+    out: list[dict] = []
+    for n in numbers:
+        for cand in (pr_review_dir / str(n) / "latest.json", pr_review_dir / f"{n}-latest.json"):
+            if not cand.is_file():
+                continue
+            try:
+                rec = json.loads(cand.read_text())
+            except (OSError, json.JSONDecodeError) as e:
+                warn(f"{cand} unreadable ({e}); skipping that PR's review record")
+                break
+            if isinstance(rec, dict):
+                out.append(rec)
+            break
+    return out
+
+
 def build(article: dict, entry: dict, prs: list[dict],
           findings_record: dict | None = None,
-          recovery: dict | None = None) -> dict:
+          recovery: dict | None = None,
+          pr_review_records: list[dict] | None = None) -> dict:
     backlog = {
         "schema_version": SCHEMA_VERSION,
         "slug": article.get("slug"),
@@ -449,6 +570,16 @@ def build(article: dict, entry: dict, prs: list[dict],
             "reviewed_at": (findings_record or {}).get("reviewed_at"),
             "counts": (findings_record or {}).get("counts"),
         }
+
+    # The pre-merge review's own records next: machine-written like the
+    # findings record, and the only source that carries what the REVIEWER of
+    # the content-review PR found. Deduped against everything below by label
+    # through _bank, so a finding the fix lane also banked is listed once.
+    reviews = [r for r in (pr_review_records or []) if isinstance(r, dict)]
+    if reviews:
+        for item in banked_from_pr_review(reviews):
+            _bank(backlog["banked"], item)
+        backlog["pr_review_records"] = [_pr_review_summary(r) for r in reviews]
 
     recovery = dict(recovery or {"heads_queried": [], "prs_found": len(prs),
                                  "prs_unreachable": [], "prs_without_sections": [],
@@ -671,7 +802,18 @@ def run(args) -> int:
             log(f"no findings record at {fr}; PR-body scrape only "
                 f"(expected for pages last reviewed before the record existed)")
 
-    backlog = build(article, entry, prs, findings_record, recovery)
+    # v3 pre-merge review records: stamped on the article by select-glowup.py
+    # (dispatcher had S3), and/or read from a local mirror for every PR the
+    # head-ref discovery found (dispatcher-side or manual runs). De-duplicated
+    # by PR number, the stamped copy winning — it is the one the run was
+    # selected on.
+    stamped = [r for r in (article.get("pr_review_records") or []) if isinstance(r, dict)]
+    seen_prs = {int(r.get("pr") or 0) for r in stamped}
+    discovered = [int(p.get("number") or 0) for p in prs if int(p.get("number") or 0) not in seen_prs]
+    pr_review_records = stamped + load_pr_review_records(
+        Path(args.pr_review_dir) if args.pr_review_dir else None, discovered)
+
+    backlog = build(article, entry, prs, findings_record, recovery, pr_review_records)
     Path(args.out).write_text(json.dumps(backlog, indent=2) + "\n")
     log(f"{len(backlog['banked'])} banked finding(s) from "
         f"{len(backlog['source_prs'])} PR(s) "
@@ -1038,6 +1180,92 @@ def self_test() -> int:
         finally:
             fx.unlink(missing_ok=True)
 
+    # --- v3 pre-merge review records -----------------------------------
+    rec = {
+        "schema_version": 1, "pr": 321, "head_sha": "a" * 40, "generated_at": "2026-09-02T00:00:00Z",
+        "findings": [
+            {"id": "F1", "bucket": "outstanding", "file": "content/docs/x.md", "lines": [40, 42],
+             "text": "Says `pulumi up --json` landed in 3.150; the changelog puts it in 3.163", "origin": "verdict:contradicted",
+             "status": "open", "disposition": None},
+            {"id": "F2", "bucket": "author-answer", "file": "content/docs/x.md", "lines": [58],
+             "text": "40% faster than the previous release", "origin": "verdict:unverifiable",
+             "status": "accepted-as-is",
+             "disposition": {"disposition": "accepted", "actor": "CamSoper",
+                             "note": "marketing owns the number", "updated_at": "2026-09-01T00:00:00Z"}},
+            {"id": "F3", "bucket": "outstanding", "file": "content/docs/x.md",
+             "text": "fixed thing", "origin": "model", "status": "resolved",
+             "disposition": {"disposition": "fixed", "actor": "x", "updated_at": "2026-09-01T00:00:00Z"}},
+            {"id": "F4", "bucket": "author-answer", "file": "content/docs/x.md",
+             "text": "conceded thing", "origin": "model", "status": "conceded",
+             "disposition": {"disposition": "refuted", "actor": "x", "updated_at": "2026-09-01T00:00:00Z"}},
+            {"id": "F5", "bucket": "reviewer-check", "file": "content/docs/x.md", "lines": [70],
+             "text": "Changelog says the flag landed in 3.150", "origin": "model",
+             "status": "disputed-held",
+             "disposition": {"disposition": "refuted", "actor": "author1",
+                             "note": "the changelog is wrong", "updated_at": "2026-09-01T00:00:00Z"}},
+            {"id": "F6", "bucket": "preexisting", "file": "content/docs/x.md", "lines": [12],
+             "text": "Intro still names the retired product", "origin": "model", "status": "open",
+             "disposition": None},
+            {"id": "F7", "bucket": "reviewer-check", "file": "content/docs/x.md",
+             "text": "Claim (L90): `pulumi convert` is the fastest path for most configurations", "origin": "model",
+             "status": "open", "disposition": None},
+        ],
+    }
+    items = banked_from_pr_review([rec])
+    by_id = {i["id"]: i for i in items}
+    check("pr-review: open, accepted, held, and pre-existing bank; resolved and conceded do not",
+          set(by_id) == {"pr321-review-F1", "pr321-review-F2", "pr321-review-F5",
+                         "pr321-review-F6", "pr321-review-F7"})
+    check("pr-review: the finding text is the work, the line ref rides along",
+          by_id["pr321-review-F1"]["finding"] == "Says `pulumi up --json` landed in 3.150; the changelog puts it in 3.163 (content/docs/x.md L40-42)")
+    check("pr-review: an accepted finding carries actor + note as its prior disposition",
+          by_id["pr321-review-F2"]["prior_disposition"]
+          == "accepted as-is by CamSoper on the pre-merge review of #321: marketing owns the number")
+    check("pr-review: a held dispute names the disputer and keeps the note",
+          by_id["pr321-review-F5"]["prior_disposition"].startswith("disputed by author1 on #321; the reviewer held it: the changelog"))
+    check("pr-review: pre-existing rows land in their own section",
+          by_id["pr321-review-F6"]["section"] == "Pre-existing issues"
+          and by_id["pr321-review-F1"]["section"] == "Pre-merge review findings")
+    check("pr-review: source and source_pr set for dedupe/ordering",
+          all(i["source"] == "pr-review" and i["source_pr"] == 321 for i in items))
+
+    # Through build(): the editorial-stance filter and the label dedupe apply
+    # to this source like every other, and the summary block records the PR.
+    art = {"slug": "docs-x", "path": "content/docs/x.md"}
+    pr_body = "\n".join(["## Findings not applied",
+                         "- **Says `pulumi up --json` landed in 3.150; the changelog puts it in 3.163** — needs an SME"])
+    bl = build(art, {"skipped_findings": 1}, [{"number": 400, "url": "u", "body": pr_body,
+                                               "headRefName": "content-review/docs-x"}],
+               None, None, [rec])
+    texts = {b["id"]: b for b in bl["banked"]}
+    check("pr-review through build: a Claim-labelled stance row is filtered like any other source",
+          "pr321-review-F7" not in texts)
+    check("pr-review through build: same label from a later PR body wins the dedupe",
+          "pr321-review-F1" not in texts
+          and any(b["source_pr"] == 400 and "pulumi up --json" in b["text"] for b in bl["banked"]))
+    check("pr-review through build: the rest bank alongside the PR-body rows",
+          {"pr321-review-F2", "pr321-review-F5", "pr321-review-F6"} <= set(texts))
+    check("pr-review through build: summary block names the record",
+          bl.get("pr_review_records") == [{"pr": 321, "head_sha": "a" * 40,
+                                           "generated_at": "2026-09-02T00:00:00Z",
+                                           "findings": 7, "banked": 5}])
+    check("pr-review through build: recovery state is 'recovered' with only review records",
+          build(art, {}, [], None, None, [rec])["recovery"]["state"] == "recovered")
+    check("no records: key absent, nothing banked from this source",
+          "pr_review_records" not in build(art, {}, [], None, None, []))
+
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / "321").mkdir()
+        (d / "321" / "latest.json").write_text(json.dumps(rec))
+        (d / "322-latest.json").write_text(json.dumps(dict(rec, pr=322)))
+        (d / "323").mkdir()
+        (d / "323" / "latest.json").write_text("{not json")
+        got = load_pr_review_records(d, [321, 322, 323, 324])
+        check("mirror: both bucket layout and local layout load; bad JSON and missing skip",
+              [r["pr"] for r in got] == [321, 322])
+        check("mirror: None dir loads nothing", load_pr_review_records(None, [321]) == [])
+
     if failures:
         print(f"\n{len(failures)} failure(s)", file=sys.stderr)
         return 1
@@ -1058,6 +1286,9 @@ def main() -> int:
     p.add_argument("--findings-dir", default="",
                    help="synced findings/ prefix; the structured spine, "
                         "preferred over scraping PR bodies")
+    p.add_argument("--pr-review-dir", default="",
+                   help="synced pr-review/ prefix (v3 pre-merge review evidence, "
+                        "`<pr>/latest.json`); read for every discovered prior PR")
     p.add_argument("--strict", action="store_true",
                    help="exit 2 when the ledger says findings were banked and none "
                         "could be recovered (default: warn and continue)")

--- a/scripts/content-review/select-glowup.py
+++ b/scripts/content-review/select-glowup.py
@@ -149,6 +149,42 @@ def source_pr_for(entry: dict) -> int | None:
     return int(entry.get("pr_number") or entry.get("last_pr_number") or 0) or None
 
 
+# The evidence object's per-finding shape is what build-glowup-backlog.py
+# reads; the trail, investigation log, and history are the bulk of a record
+# and none of it is backlog material, so the queue carries only this.
+_PR_REVIEW_KEEP = ("schema_version", "pr", "head_sha", "generated_at", "high_water", "findings")
+
+
+def pr_review_records_for(pr_review_dir: Path | None, entry: dict) -> list[dict]:
+    """The v3 pre-merge review records (`pr-review/<pr>/latest.json`) for the
+    ledger entry's PR pointers — both `pr_number` and `last_pr_number`, since
+    they name different PRs when the latest review opened one and an earlier
+    one banked the debt. Trimmed to the finding-level fields; never raises
+    (a missing record is the normal case for every v2-era PR)."""
+    if pr_review_dir is None:
+        return []
+    out: list[dict] = []
+    seen: set[int] = set()
+    for key in ("pr_number", "last_pr_number"):
+        try:
+            n = int(entry.get(key) or 0)
+        except (TypeError, ValueError):
+            n = 0
+        if not n or n in seen:
+            continue
+        seen.add(n)
+        f = pr_review_dir / str(n) / "latest.json"
+        if not f.is_file():
+            continue
+        try:
+            rec = json.loads(f.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(rec, dict) and isinstance(rec.get("findings"), list):
+            out.append({k: rec[k] for k in _PR_REVIEW_KEEP if k in rec})
+    return out
+
+
 def recoverable(entry: dict, record: dict | None) -> bool:
     """Can the worker actually fetch this page's banked findings?
 
@@ -217,6 +253,10 @@ def main() -> int:
     p.add_argument("--findings-dir", default="",
                    help="synced findings/ prefix; each selected article carries "
                         "its record into the unprivileged worker")
+    p.add_argument("--pr-review-dir", default="",
+                   help="synced pr-review/ prefix (v3 pre-merge review evidence); "
+                        "each selected article carries its PRs' latest.json records "
+                        "into the unprivileged worker")
     p.add_argument("--out", help="Queue JSON output path")
     p.add_argument("--traffic-file", help="S3-fetched traffic snapshot (CSV or JSON)")
     p.add_argument("--tiers", default=str(_select.DEFAULT_TIERS))
@@ -240,6 +280,7 @@ def main() -> int:
     today = parse_day(args.today) or datetime.now(timezone.utc).date()
     tier_rules = _select.load_tiers(Path(args.tiers))
     findings_dir = Path(args.findings_dir) if args.findings_dir else None
+    pr_review_dir = Path(args.pr_review_dir) if args.pr_review_dir else None
     # The recoverability filter reads the findings/ prefix. Without it every
     # lookup returns None, so applying the filter would declare the WHOLE
     # corpus unrecoverable and silently darken the lane — the one way this
@@ -404,6 +445,10 @@ def main() -> int:
             # it hands the record over rather than leaving the worker to scrape
             # the PR body (see record-page-findings.py).
             "findings_record": record,
+            # Same reason, other system of record: what the pre-merge REVIEWER
+            # found on this page's review PRs (v3 evidence, fork-safe and
+            # machine-written). Empty for v2-era PRs.
+            "pr_review_records": pr_review_records_for(pr_review_dir, entry),
             "score": score,
         })
 

--- a/scripts/content-review/test_select_glowup.py
+++ b/scripts/content-review/test_select_glowup.py
@@ -241,6 +241,29 @@ def main() -> int:
         check("no findings record" in q["repairs"][0]["reason"],
               "the repair names the reason")
 
+        # v3 pre-merge review records ride the queue the same way, trimmed to
+        # the finding-level fields (the trail is history, not backlog).
+        prdir = tmp / "pr-review"
+        (prdir / "555").mkdir(parents=True)
+        (prdir / "555" / "latest.json").write_text(json.dumps({
+            "schema_version": 1, "pr": 555, "head_sha": "c" * 40, "run_id": "1",
+            "generated_at": "2026-09-02T00:00:00Z", "high_water": 1,
+            "findings": [{"id": "F1", "bucket": "outstanding", "file": B, "text": "open thing",
+                          "origin": "model", "status": "open", "disposition": None}],
+            "trail": [{"file": B, "claim": "x", "verdict": "verified"}],
+            "investigation_log": {}, "history": [],
+        }))
+        q = run_select(repo, tiers, led_rec, "--count", "10", "--findings-dir", str(fdir),
+                       "--pr-review-dir", str(prdir))
+        by_path = {a["path"]: a for a in q["articles"]}
+        check(by_path[B]["pr_review_records"] and by_path[B]["pr_review_records"][0]["pr"] == 555,
+              "the PR-pointer page carries its pre-merge review record")
+        check("trail" not in by_path[B]["pr_review_records"][0]
+              and by_path[B]["pr_review_records"][0]["findings"][0]["id"] == "F1",
+              "the stamped record is trimmed to finding-level fields")
+        check(by_path[A]["pr_review_records"] == [],
+              "a page with no review PR carries an empty list, not a missing key")
+
         print("no --findings-dir: the check is skipped rather than stranding the corpus")
         # Every lookup returns None without the prefix, so applying the filter
         # would declare the whole corpus unrecoverable and darken the lane.

--- a/scripts/review-admin/review-admin.py
+++ b/scripts/review-admin/review-admin.py
@@ -11,6 +11,10 @@ S3 buckets, none of it human-browsable without pulling objects one at a time:
     blog-review/runs/<date>/…     per-run blog review findings
     blog-review/index/_summary.json  aggregate summary
     health/state.json             selection-signal health
+    pr-review/<pr>/latest.json    v3 PR review evidence (findings + dispositions)
+    pr-review/state/<pr>.json     SLA-sweep state (warns/escalations/closes)
+    pr-review/runs/<date>/…       per-sweep SLA action records
+    pr-review/waives/…            v3 merge-gate waive log
   social-post-state-* posted-social.json / posted.json
                                   per-post social publish timestamps
 
@@ -56,7 +60,7 @@ SOCIAL_BUCKET_PREFIX = "social-post-state-"
 CACHE_ENV = "REVIEW_ADMIN_CACHE"
 CACHE_DIRNAME = ".review-admin-cache"
 
-DOMAINS = ("docs", "claims", "blog", "social")
+DOMAINS = ("docs", "claims", "blog", "social", "pr-review")
 
 # Preferred column order for exports; unknown fields are appended after these.
 DOCS_COLUMNS = [
@@ -80,6 +84,10 @@ BLOG_ISSUE_COLUMNS = [
     "issue_category", "issue_severity",
 ]
 SOCIAL_COLUMNS = ["url", "platform", "posted_at", "failures", "source_file"]
+PR_REVIEW_COLUMNS = [
+    "pr", "head_sha", "blocking", "dispositions", "warns", "escalations",
+    "closes", "last_sweep_action", "generated_at",
+]
 
 
 def log(msg: str) -> None:
@@ -314,6 +322,124 @@ def load_social(cache: Path) -> list[dict]:
     return rows
 
 
+def load_pr_review_latest(cache: Path) -> list[dict]:
+    """One row per PR: `pr-review/<pr>/latest.json` -- the mirrored evidence
+    object (findings + their REVIEW_STATE dispositions). See
+    scripts/review-v3/README.md "The evidence object"."""
+    base = cache / "content-review" / "pr-review"
+    rows: list[dict] = []
+    if not base.is_dir():
+        return rows
+    for pr_dir in sorted(base.iterdir()):
+        if not pr_dir.is_dir() or not pr_dir.name.isdigit():
+            continue  # skip state/, runs/, waives/ -- only numeric <pr> dirs
+        record = load_json_file(pr_dir / "latest.json")
+        if record is not None:
+            record = dict(record)
+            record["_file"] = str(pr_dir / "latest.json")
+            rows.append(record)
+    return rows
+
+
+def load_pr_review_state(cache: Path) -> list[dict]:
+    """One row per PR: `pr-review/state/<pr>.json` -- the SLA-sweep's own
+    state (warns/escalations/closes), see scripts/review-v3/sla-sweep.py.
+
+    The PR number only lives in the filename (the state object itself has
+    no `pr` key -- see sla-sweep.py's state schema), so it's tagged onto
+    each record here as an int `pr` field: both `record_matches()` (`show`
+    by PR number) and `_pr_review_state_by_pr()` (join key) need it.
+    """
+    records = load_json_dir(cache / "content-review" / "pr-review" / "state")
+    for r in records:
+        stem = Path(r["_file"]).stem
+        if stem.isdigit():
+            r["pr"] = int(stem)
+    return records
+
+
+def load_pr_review_runs(cache: Path) -> list[dict]:
+    """All SLA-sweep run records across dates, each tagged with _run_date."""
+    runs_dir = cache / "content-review" / "pr-review" / "runs"
+    records: list[dict] = []
+    if not runs_dir.is_dir():
+        return records
+    for day in sorted(runs_dir.iterdir()):
+        if not day.is_dir():
+            continue
+        for record in load_json_dir(day):
+            record["_run_date"] = day.name
+            records.append(record)
+    return records
+
+
+def load_pr_review_waives(cache: Path) -> list[dict]:
+    """The v3 merge-gate waive log (`pr-review/waives/`) -- may not exist
+    yet on a repo where nobody has applied `review:waived`."""
+    return load_json_dir(cache / "content-review" / "pr-review" / "waives")
+
+
+def _pr_review_state_by_pr(cache: Path) -> dict[str, dict]:
+    return {Path(r["_file"]).stem: r for r in load_pr_review_state(cache)}
+
+
+def _latest_sweep_action_by_pr(cache: Path) -> dict[str, dict]:
+    """The most recent per-PR action entry across every synced run record,
+    keyed by PR number as a string (matching latest.json's directory name)."""
+    best: dict[str, tuple[str, dict]] = {}
+    for record in load_pr_review_runs(cache):
+        run_at = record.get("run_at") or record.get("_run_date") or ""
+        for action in record.get("actions") or []:
+            pr = str(action.get("pr"))
+            if pr not in best or run_at >= best[pr][0]:
+                best[pr] = (run_at, action)
+    return {pr: action for pr, (_run_at, action) in best.items()}
+
+
+def _summarize_sweep_action(action: dict) -> str:
+    """One-word label for the review-admin `list pr-review` table: the last
+    thing the SLA sweep did for this PR (warn/close/clear for author-time,
+    escalate/none for reviewer-time)."""
+    if not action:
+        return ""
+    if action.get("kind") == "author":
+        return (action.get("action") or {}).get("type", "")
+    if action.get("kind") == "reviewer":
+        types = [a.get("type") for a in action.get("actions") or []]
+        return "escalate" if "escalate" in types else (types[0] if types else "")
+    return ""
+
+
+def pr_review_rows(cache: Path) -> list[dict]:
+    """One row per PR: evidence-derived blocking/dispositions counts, the
+    SLA-sweep's warn/escalation/close counts, and its most recent action --
+    the `list pr-review` / dashboard table."""
+    states = _pr_review_state_by_pr(cache)
+    last_actions = _latest_sweep_action_by_pr(cache)
+    rows: list[dict] = []
+    for record in load_pr_review_latest(cache):
+        pr = str(record.get("pr") or "")
+        findings = record.get("findings") or []
+        blocking = sum(
+            1 for f in findings
+            if f.get("bucket") in ("outstanding", "author-answer") and not f.get("disposition")
+        )
+        dispositions = sum(1 for f in findings if f.get("disposition"))
+        state = states.get(pr) or {}
+        rows.append({
+            "pr": record.get("pr"),
+            "head_sha": (record.get("head_sha") or "")[:9],
+            "blocking": blocking,
+            "dispositions": dispositions,
+            "warns": len(state.get("warns") or []),
+            "escalations": len(state.get("escalations") or []),
+            "closes": len(state.get("closes") or []),
+            "last_sweep_action": _summarize_sweep_action(last_actions.get(pr) or {}),
+            "generated_at": record.get("generated_at"),
+        })
+    return rows
+
+
 # ---- flatteners -------------------------------------------------------------
 
 
@@ -366,6 +492,7 @@ def build_summary(cache: Path) -> dict:
     blog = load_blog_ledger(cache)
     runs = load_blog_runs(cache)
     social = load_social(cache)
+    pr_review = pr_review_rows(cache)
     return {
         "docs": {
             "articles": len(docs),
@@ -397,6 +524,14 @@ def build_summary(cache: Path) -> dict:
             "with_failures": len({r["url"] for r in social if r.get("failures")}),
             "latest_post": max((r.get("posted_at") or "" for r in social), default="n/a"),
         },
+        "pr_review": {
+            "prs": len(pr_review),
+            "blocking_total": sum(r["blocking"] for r in pr_review),
+            "dispositions_total": sum(r["dispositions"] for r in pr_review),
+            "warns_total": sum(r["warns"] for r in pr_review),
+            "escalations_total": sum(r["escalations"] for r in pr_review),
+            "closes_total": sum(r["closes"] for r in pr_review),
+        },
     }
 
 
@@ -426,6 +561,12 @@ def cmd_summary(args) -> int:
     print(f"Social post state       {s['social']['posts']} posts, {s['social']['rows']} platform sends, latest {s['social']['latest_post'][:10] or 'n/a'}")
     print(f"  platform: {counter_line(s['social']['by_platform'])}")
     print(f"  posts with recorded failures: {s['social']['with_failures']}")
+    print()
+    pr = s["pr_review"]
+    print(f"v3 PR review (pr-review/) {pr['prs']} PRs tracked, {pr['blocking_total']} blocking, "
+          f"{pr['dispositions_total']} findings dispositioned")
+    print(f"  SLA sweep: {pr['warns_total']} warns, {pr['escalations_total']} escalations, "
+          f"{pr['closes_total']} closes")
     print()
     health = load_health(cache)
     if health:
@@ -478,6 +619,11 @@ def list_rows(cache: Path, domain: str) -> tuple[list[dict], list[tuple[str, int
         return (rows, [
             ("url", 64), ("platform", 8), ("posted_at", 20), ("failures", 8),
         ], "posted_at")
+    if domain == "pr-review":
+        return (pr_review_rows(cache), [
+            ("pr", 7), ("head_sha", 10), ("blocking", 9), ("dispositions", 13),
+            ("warns", 6), ("escalations", 11), ("closes", 7), ("last_sweep_action", 18),
+        ], "generated_at")
     die(f"unknown domain '{domain}' (expected one of: {', '.join(DOMAINS)})")
 
 
@@ -489,8 +635,9 @@ def cmd_list(args) -> int:
     if args.verdict:
         rows = [r for r in rows if r.get("verdict") == args.verdict]
     if args.since:
-        date_field = "posted_at" if args.domain == "social" else \
-            "article_reviewed_at" if args.domain == "claims" else "reviewed_at"
+        date_field = {
+            "social": "posted_at", "claims": "article_reviewed_at", "pr-review": "generated_at",
+        }.get(args.domain, "reviewed_at")
         rows = [r for r in rows if (r.get(date_field) or "") >= args.since]
     rows.sort(key=lambda r: r.get(sort_field) or "", reverse=True)
     if args.limit:
@@ -508,6 +655,9 @@ def record_matches(record: dict, needle: str) -> bool:
         value = record.get(field) or ""
         if needle == value or needle in value:
             return True
+    pr = record.get("pr")
+    if pr is not None and needle == str(pr):
+        return True
     return False
 
 
@@ -520,6 +670,10 @@ def cmd_show(args) -> int:
         ("blog-review ledger", load_blog_ledger(cache)),
         ("blog-review runs", load_blog_runs(cache)),
         ("social post state", load_social(cache)),
+        ("pr-review latest (evidence)", load_pr_review_latest(cache)),
+        ("pr-review state (SLA sweep)", load_pr_review_state(cache)),
+        ("pr-review runs (SLA sweep)", load_pr_review_runs(cache)),
+        ("pr-review waives", load_pr_review_waives(cache)),
     ]
     hits = 0
     for title, records in sections:
@@ -583,6 +737,7 @@ def cmd_export(args) -> int:
     write_exports(load_blog_ledger(cache), out_dir, "blog-review", BLOG_COLUMNS, formats)
     write_exports(flatten_blog_issues(runs), out_dir, "blog-review-issues", BLOG_ISSUE_COLUMNS, formats)
     write_exports(load_social(cache), out_dir, "social-posts", SOCIAL_COLUMNS, formats)
+    write_exports(pr_review_rows(cache), out_dir, "pr-review", PR_REVIEW_COLUMNS, formats)
     return 0
 
 
@@ -660,6 +815,8 @@ const TABS = [
    cols:['slug','status','issues','post_date','reviewed_at','note']},
   {id:'social', label:'Social', rows:DATA.social, chips:'platform',
    cols:['url','platform','posted_at','failures','source_file']},
+  {id:'pr_review', label:'PR review', rows:DATA.pr_review, chips:'last_sweep_action',
+   cols:['pr','head_sha','blocking','dispositions','warns','escalations','closes','last_sweep_action','generated_at']},
 ];
 let active = 'overview';
 const state = {};   // per-tab: {q, chip, sortCol, sortDir}
@@ -697,6 +854,9 @@ function renderOverview(main) {
   mk('Fact-check claims', s.claims.claims, `${s.claims.articles} articles · ${fmtCounter(s.claims.by_verdict)}`);
   mk('Blog posts indexed', s.blog.posts, `${s.blog.issues} open issues · ${fmtCounter(s.blog.by_status)}`);
   mk('Social sends', s.social.rows, `${s.social.posts} posts · ${fmtCounter(s.social.by_platform)}`);
+  mk('v3 PRs tracked', s.pr_review.prs,
+     `${s.pr_review.blocking_total} blocking · ${s.pr_review.warns_total} warns · ` +
+     `${s.pr_review.escalations_total} escalations · ${s.pr_review.closes_total} closes`);
   main.append(cards);
   if (DATA.health && DATA.health.signals) {
     main.append(el('h2', {}, `Signal health (updated ${DATA.health.updated || '?'})`));
@@ -803,6 +963,7 @@ def render_html(cache: Path) -> str:
         "blog": [{k: v for k, v in r.items() if k != "_file"} for r in load_blog_ledger(cache)],
         "blog_issues": flatten_blog_issues(runs),
         "social": load_social(cache),
+        "pr_review": pr_review_rows(cache),
         "health": load_health(cache),
         "blog_summary": load_blog_summary(cache),
     }
@@ -876,6 +1037,31 @@ FIXTURES = {
                                           "linkedin": "2026-04-01T09:01:00+00:00",
                                           "_failures": 1}},
     },
+    "content-review/pr-review/21300/latest.json": {
+        "schema_version": 1, "repo": "pulumi/docs", "pr": 21300, "head_sha": "a" * 40,
+        "run_id": "run-1", "generated_at": "2026-08-31T17:00:00Z", "high_water": 2,
+        "findings": [
+            {"id": "F1", "bucket": "outstanding", "file": "content/docs/x.md",
+             "text": "Broken link", "origin": "verdict:contradicted", "status": "open"},
+            {"id": "F2", "bucket": "author-answer", "file": "content/docs/x.md",
+             "text": "Source?", "origin": "verdict:unverifiable", "status": "resolved",
+             "disposition": {"disposition": "refuted", "actor": "cam", "note": "n",
+                             "updated_at": "2026-08-31T18:00:00Z"}},
+        ],
+        "trail": [], "investigation_log": {}, "history": [],
+    },
+    "content-review/pr-review/state/21300.json": {
+        "schema": 1,
+        "warns": [{"at": "2026-08-31T12:00:00Z", "head_sha": "a" * 40}],
+        "escalations": [], "closes": [],
+    },
+    "content-review/pr-review/runs/2026-08-31/sweep-120000Z.json": {
+        "schema": 1, "run_at": "2026-08-31T12:00:00Z", "dry_run": False,
+        "actions": [
+            {"pr": 21300, "kind": "author", "head_sha": "a" * 40, "changed": True,
+             "action": {"type": "warn", "idle_days": 16.0, "undecided_count": 1}},
+        ],
+    },
 }
 
 
@@ -900,10 +1086,24 @@ def self_test() -> int:
         social = load_social(cache)
         assert len(social) == 2 and social[0]["failures"] == 1, social
 
+        pr_rows = pr_review_rows(cache)
+        assert len(pr_rows) == 1, pr_rows
+        row = pr_rows[0]
+        assert row["pr"] == 21300
+        assert row["head_sha"] == ("a" * 40)[:9]
+        assert row["blocking"] == 1, row  # F1 outstanding, no disposition
+        assert row["dispositions"] == 1, row  # F2 has a disposition
+        assert row["warns"] == 1 and row["escalations"] == 0 and row["closes"] == 0
+        assert row["last_sweep_action"] == "warn", row
+        assert record_matches({"pr": 21300}, "21300")
+
         summary = build_summary(cache)
         assert summary["claims"]["by_verdict"]["contradicted"] == 1
         assert summary["blog"]["issues"] == 1
         assert summary["social"]["posts"] == 1
+        assert summary["pr_review"]["prs"] == 1
+        assert summary["pr_review"]["blocking_total"] == 1
+        assert summary["pr_review"]["warns_total"] == 1
 
         out_dir = cache / "exports"
         out_dir.mkdir()
@@ -914,11 +1114,17 @@ def self_test() -> int:
         jsonl = [json.loads(line) for line in (out_dir / "claims.jsonl").read_text().splitlines()]
         assert jsonl[1]["verdict"] == "contradicted"
 
+        write_exports(pr_rows, out_dir, "pr-review", PR_REVIEW_COLUMNS, {"csv", "jsonl"})
+        pr_csv_lines = (out_dir / "pr-review.csv").read_text().splitlines()
+        assert len(pr_csv_lines) == 2  # header + 1 PR
+        assert pr_csv_lines[0].startswith("pr,head_sha,blocking")
+
         html = render_html(cache)
         assert "Review ledgers" in html
         assert "</script> honest" not in html          # escaped in embedded JSON
         assert "<\\/script> honest" in html
         assert "docs-get-started" in html
+        assert "PR review" in html and "21300" in html
 
     print("self-test OK")
     return 0

--- a/scripts/review-admin/test_review_admin.py
+++ b/scripts/review-admin/test_review_admin.py
@@ -129,6 +129,76 @@ def test_record_matches_slug_path_and_url():
     assert ra.record_matches({"url": "/blog/example-post/"}, "/blog/example-post/")
 
 
+def test_pr_review_rows_joins_evidence_state_and_last_action(cache: Path):
+    rows = ra.pr_review_rows(cache)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["pr"] == 21300
+    assert row["head_sha"] == "a" * 9
+    assert row["blocking"] == 1     # F1: outstanding, no disposition
+    assert row["dispositions"] == 1  # F2: has a disposition
+    assert row["warns"] == 1
+    assert row["escalations"] == 0
+    assert row["closes"] == 0
+    assert row["last_sweep_action"] == "warn"
+
+
+def test_pr_review_rows_empty_when_prefix_absent(tmp_path: Path):
+    assert ra.pr_review_rows(tmp_path) == []
+
+
+def test_load_pr_review_state_tags_pr_from_filename(cache: Path):
+    states = ra.load_pr_review_state(cache)
+    assert len(states) == 1
+    assert states[0]["pr"] == 21300
+    assert len(states[0]["warns"]) == 1
+
+
+def test_load_pr_review_runs_tags_run_date(cache: Path):
+    runs = ra.load_pr_review_runs(cache)
+    assert len(runs) == 1
+    assert runs[0]["_run_date"] == "2026-08-31"
+    assert runs[0]["actions"][0]["pr"] == 21300
+
+
+def test_record_matches_by_pr_number():
+    assert ra.record_matches({"pr": 21300}, "21300")
+    assert not ra.record_matches({"pr": 21300}, "99999")
+
+
+def test_build_summary_includes_pr_review(cache: Path):
+    s = ra.build_summary(cache)
+    assert s["pr_review"]["prs"] == 1
+    assert s["pr_review"]["blocking_total"] == 1
+    assert s["pr_review"]["warns_total"] == 1
+    assert s["pr_review"]["escalations_total"] == 0
+
+
+def test_list_pr_review(cache: Path, capsys):
+    class Args:
+        cache_dir = str(cache)
+        domain = "pr-review"
+        status = None
+        verdict = None
+        since = None
+        limit = None
+
+    assert ra.cmd_list(Args()) == 0
+    out = capsys.readouterr().out
+    assert "(1 rows)" in out
+    assert "21300" in out and "warn" in out
+
+
+def test_export_includes_pr_review(cache: Path, tmp_path: Path):
+    out = tmp_path / "out"
+    out.mkdir()
+    ra.write_exports(ra.pr_review_rows(cache), out, "pr-review", ra.PR_REVIEW_COLUMNS, {"csv"})
+    with (out / "pr-review.csv").open() as fh:
+        parsed = list(csv.DictReader(fh))
+    assert len(parsed) == 1
+    assert parsed[0]["pr"] == "21300"
+
+
 def test_list_filters(cache: Path, capsys):
     class Args:
         cache_dir = str(cache)

--- a/scripts/review-v3/README.md
+++ b/scripts/review-v3/README.md
@@ -112,9 +112,19 @@ already wearing the label — free v3 test traffic that no human author
 sees, once the lane rewiring has merged (before that the label only reaches
 the `/resolve` listener). Order of operations: run the `gh label create`
 line for `surface:v3` first, then flip the variable — otherwise every bot
-PR takes the unlabeled fallback with a `::warning::`. The check summary embeds the
-reviewer brief (merge-box delivery), and on red the sentinel PATCHes a ⛔
-strip into the author card naming the exact commands.
+PR takes the unlabeled fallback with a `::warning::`. The
+check summary embeds the reviewer brief (merge-box delivery), and on red the
+sentinel PATCHes a ⛔ strip into the author card naming the exact commands.
+
+**SLA sweep** (`sla-sweep.py`, `review-sla-sweep.yml`, cron every 2 h): its own
+switch is `REVIEW_V3_SLA` — the job runs only while it is `'1'` (a manual
+dispatch defaults to `dry_run`). Clocks are derived fresh from the GitHub
+timeline each sweep; only the actions taken are recorded, under
+`pr-review/state/<pr>.json` (per-PR idempotency: warns, closes, escalations
+keyed by clock epoch) and `pr-review/runs/<date>/<ts>.json` (immutable run
+records the weekly digest reduces). **Before flipping the switch, create the
+`review:author-stalled` label** (`.github/labels-pr-review.md` has the
+`gh label create` line) — the sweep applies it on the first author warn.
 
 `staging-deploy-pr.yml` makes G4's evidence: `/deploy-staging` (tools-team
 members only, same-repo branches only) dispatches the existing testing

--- a/scripts/review-v3/README.md
+++ b/scripts/review-v3/README.md
@@ -106,7 +106,10 @@ check-run, the review lanes skip their pokes; the state the file merges in),
 `'report'` = report-only (conclusions `neutral` with "would be: …" in the
 summary), `'1'` = enforcing. `/deploy-staging` follows the same switch. The
 surface itself is `REVIEW_V3_COMMENTS` (repo default) or the `surface:v3`
-label (one PR in or out, regardless of the variable). The check summary embeds the
+label (one PR in or out, regardless of the variable). `REVIEW_V3_BOT_PRS`
+= `'1'` makes the content-review and glow-up lanes open their bot PRs
+already wearing the label — free v3 test traffic that no human author
+sees. The check summary embeds the
 reviewer brief (merge-box delivery), and on red the sentinel PATCHes a ⛔
 strip into the author card naming the exact commands.
 

--- a/scripts/review-v3/README.md
+++ b/scripts/review-v3/README.md
@@ -109,7 +109,10 @@ surface itself is `REVIEW_V3_COMMENTS` (repo default) or the `surface:v3`
 label (one PR in or out, regardless of the variable). `REVIEW_V3_BOT_PRS`
 = `'1'` makes the content-review and glow-up lanes open their bot PRs
 already wearing the label — free v3 test traffic that no human author
-sees. The check summary embeds the
+sees, once the lane rewiring has merged (before that the label only reaches
+the `/resolve` listener). Order of operations: run the `gh label create`
+line for `surface:v3` first, then flip the variable — otherwise every bot
+PR takes the unlabeled fallback with a `::warning::`. The check summary embeds the
 reviewer brief (merge-box delivery), and on red the sentinel PATCHes a ⛔
 strip into the author card naming the exact commands.
 

--- a/scripts/weekly-digest/digest.py
+++ b/scripts/weekly-digest/digest.py
@@ -290,8 +290,9 @@ def collect_v3_ops(since: str, review_outcomes: dict) -> dict:
     (by lane/role), author-staleness warns and closes, waives, and a
     bulk-accept rate.
 
-    Syncs `pr-review/state/`, `pr-review/runs/`, and `pr-review/waives/`
-    from the ledger bucket (see scripts/review-v3/README.md and
+    Syncs `pr-review/runs/` and `pr-review/waives/` from the ledger bucket
+    (`pr-review/state/` is the sweep's idempotency ledger and carries nothing
+    this summary reads, so it is neither synced nor load-bearing) (see scripts/review-v3/README.md and
     sla-sweep.py's module docstring for the run-record shape) and reduces
     the run records in-window. The bulk-accept rate is NOT a second scrape
     -- it's derived from the `review_outcomes` aggregate collect_review_outcomes()
@@ -310,7 +311,7 @@ def collect_v3_ops(since: str, review_outcomes: dict) -> dict:
     with tempfile.TemporaryDirectory() as tmp:
         cache = Path(tmp)
         load_bearing_ok = True
-        for prefix in ("state", "runs", "waives"):
+        for prefix in ("runs", "waives"):
             proc = subprocess.run(
                 ["aws", "s3", "sync", f"s3://{bucket}/pr-review/{prefix}/",
                  str(cache / prefix), "--no-progress"],
@@ -318,9 +319,8 @@ def collect_v3_ops(since: str, review_outcomes: dict) -> dict:
             )
             if proc.returncode != 0:
                 # waives/ may legitimately not exist yet (nobody has waived
-                # a v3 gate); only state/ and runs/ not syncing is fatal to
-                # this section.
-                if prefix in ("state", "runs"):
+                # a v3 gate); only runs/ not syncing is fatal to this section.
+                if prefix == "runs":
                     sys.stderr.write(
                         f"warning: aws s3 sync failed for pr-review/{prefix}/: {proc.stderr.strip()[:300]}\n"
                     )

--- a/scripts/weekly-digest/digest.py
+++ b/scripts/weekly-digest/digest.py
@@ -13,9 +13,13 @@ Mirrors the query patterns in .claude/commands/dashboard/scripts/dashboard.sh
 but broadened: the issue query is the whole open backlog, not assignee-scoped.
 """
 
+import importlib.util
 import json
+import os
 import subprocess
 import sys
+import tempfile
+from collections import Counter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -27,6 +31,16 @@ OUTCOME_SCRAPER = (
     Path(__file__).resolve().parents[2]
     / ".claude/commands/docs-review/scripts/scrape-review-outcomes.py"
 )
+
+# v3 SLA-sweep state lives in the same content-review ledger bucket as
+# everything collect_review_outcomes/review-admin.py read, under pr-review/
+# (see scripts/review-v3/README.md). No stack-output wiring exists in this
+# script (unlike the credentialed record jobs) -- discover the bucket by
+# name prefix, review-admin.py's own technique, or accept it pre-resolved
+# via env (same variable name that tool uses, so one env setting works for
+# both).
+LEDGER_BUCKET_ENV = "CONTENT_REVIEW_LEDGER_BUCKET"
+LEDGER_BUCKET_PREFIX = "content-review-ledger-"
 
 
 def run_gh(args):
@@ -212,6 +226,156 @@ def collect_review_outcomes(since):
     return {"available": True, "since": since, **aggregate}
 
 
+def resolve_ledger_bucket() -> str | None:
+    """The content-review ledger bucket name, or None on any failure to
+    resolve it (no explicit env override, `aws` missing/unauthenticated, an
+    ambiguous or empty prefix match) -- collect_v3_ops() treats None as the
+    same "unavailable" degradation collect_review_outcomes() uses for a
+    scraper failure."""
+    explicit = os.environ.get(LEDGER_BUCKET_ENV, "").strip()
+    if explicit:
+        return explicit
+    try:
+        proc = subprocess.run(
+            ["aws", "s3api", "list-buckets", "--query",
+             f"Buckets[?starts_with(Name, '{LEDGER_BUCKET_PREFIX}')].Name", "--output", "json"],
+            capture_output=True, text=True,
+        )
+    except FileNotFoundError:
+        sys.stderr.write("warning: aws CLI not found; v3 ops summary unavailable\n")
+        return None
+    if proc.returncode != 0:
+        sys.stderr.write(f"warning: bucket discovery failed: {proc.stderr.strip()[:300]}\n")
+        return None
+    try:
+        names = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if len(names) == 1:
+        return names[0]
+    sys.stderr.write(f"warning: {len(names)} bucket(s) match '{LEDGER_BUCKET_PREFIX}*'; "
+                      f"set {LEDGER_BUCKET_ENV} explicitly\n")
+    return None
+
+
+def _bulk_accept_keys() -> tuple[str, str]:
+    """(bulk_key, accepted_key) -- the outcome-count field names for a
+    bulk `/resolve all ...` answer vs. any adjudicated accept/defer/n-a
+    answer, per scrape-review-outcomes.py's V3_ONLY_OUTCOME_KEYS.
+
+    Imported by path (loose coupling, not a hard dependency -- see
+    OUTCOME_SCRAPER) purely to validate the literal names below still exist
+    in that module's vocabulary; any import failure or a renamed key just
+    logs a warning and keeps the literals, since a missing key already
+    degrades cleanly to a 0 count downstream.
+    """
+    bulk_key, accepted_key = "bulk_accepted", "author_accepted"
+    try:
+        spec = importlib.util.spec_from_file_location("_scrape_outcomes_for_digest", OUTCOME_SCRAPER)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        keys = set(getattr(mod, "V3_ONLY_OUTCOME_KEYS", ()))
+        if bulk_key not in keys or accepted_key not in keys:
+            sys.stderr.write(
+                "warning: scrape-review-outcomes.py's V3_ONLY_OUTCOME_KEYS no longer names "
+                f"{bulk_key!r}/{accepted_key!r}; bulk-accept rate may be stale\n"
+            )
+    except Exception as exc:  # noqa: BLE001 -- never let a key-vocabulary check break the digest
+        sys.stderr.write(f"warning: could not import scrape-review-outcomes.py for key validation: {exc}\n")
+    return bulk_key, accepted_key
+
+
+def collect_v3_ops(since: str, review_outcomes: dict) -> dict:
+    """v3 SLA-sweep operational summary for the trailing window: escalations
+    (by lane/role), author-staleness warns and closes, waives, and a
+    bulk-accept rate.
+
+    Syncs `pr-review/state/`, `pr-review/runs/`, and `pr-review/waives/`
+    from the ledger bucket (see scripts/review-v3/README.md and
+    sla-sweep.py's module docstring for the run-record shape) and reduces
+    the run records in-window. The bulk-accept rate is NOT a second scrape
+    -- it's derived from the `review_outcomes` aggregate collect_review_outcomes()
+    already fetched this run, so a missing/unavailable outcomes block just
+    yields a 0/0 -> None rate rather than another `gh` round-trip.
+
+    Same degradation contract as collect_review_outcomes(): any failure to
+    resolve the bucket or sync its prefixes -> {"available": False}, a loud
+    signal for the synthesis prompt to render, never a silently dropped
+    section.
+    """
+    bucket = resolve_ledger_bucket()
+    if not bucket:
+        return {"available": False}
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = Path(tmp)
+        load_bearing_ok = True
+        for prefix in ("state", "runs", "waives"):
+            proc = subprocess.run(
+                ["aws", "s3", "sync", f"s3://{bucket}/pr-review/{prefix}/",
+                 str(cache / prefix), "--no-progress"],
+                capture_output=True, text=True,
+            )
+            if proc.returncode != 0:
+                # waives/ may legitimately not exist yet (nobody has waived
+                # a v3 gate); only state/ and runs/ not syncing is fatal to
+                # this section.
+                if prefix in ("state", "runs"):
+                    sys.stderr.write(
+                        f"warning: aws s3 sync failed for pr-review/{prefix}/: {proc.stderr.strip()[:300]}\n"
+                    )
+                    load_bearing_ok = False
+        if not load_bearing_ok:
+            return {"available": False}
+
+        escalations_by_role: Counter = Counter()
+        warns = 0
+        closes = 0
+        runs_dir = cache / "runs"
+        for run_file in sorted(runs_dir.rglob("*.json")) if runs_dir.is_dir() else []:
+            try:
+                record = json.loads(run_file.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            if (record.get("run_at") or "")[:10] < since:
+                continue
+            for pr_action in record.get("actions", []):
+                if pr_action.get("kind") == "author":
+                    a = pr_action.get("action") or {}
+                    if a.get("type") == "warn":
+                        warns += 1
+                    elif a.get("type") == "close":
+                        closes += 1
+                elif pr_action.get("kind") == "reviewer":
+                    for a in pr_action.get("actions") or []:
+                        if a.get("type") == "escalate":
+                            escalations_by_role[a.get("role") or "unknown"] += 1
+
+        waives_dir = cache / "waives"
+        waive_count = sum(1 for f in waives_dir.rglob("*.json")) if waives_dir.is_dir() else 0
+
+    bulk_key, accepted_key = _bulk_accept_keys()
+    human = {}
+    if review_outcomes.get("available"):
+        human = (review_outcomes.get("outcomes") or {}).get("human") or {}
+    bulk_accepted = human.get(bulk_key, 0)
+    author_accepted = human.get(accepted_key, 0)
+    bulk_accept_rate = round(100 * bulk_accepted / author_accepted) if author_accepted else None
+
+    return {
+        "available": True,
+        "since": since,
+        "escalations_total": sum(escalations_by_role.values()),
+        "escalations_by_role": dict(escalations_by_role),
+        "warns": warns,
+        "closes": closes,
+        "waives": waive_count,
+        "bulk_accepted": bulk_accepted,
+        "author_accepted": author_accepted,
+        "bulk_accept_rate": bulk_accept_rate,
+    }
+
+
 def search_count(qualifier):
     """Exact issue count via the search API's total_count (REST, not GraphQL)."""
     out = run_gh(
@@ -264,12 +428,14 @@ def main():
         )
     )
     review_outcomes = collect_review_outcomes(cutoff)
+    v3_ops = collect_v3_ops(cutoff, review_outcomes)
     digest = {
         "window_days": WINDOW_DAYS,
         "prs": prs,
         "issues": issues,
         "ci_health": ci_health,
         "review_outcomes": review_outcomes,
+        "v3_ops": v3_ops,
     }
     json.dump(digest, sys.stdout, indent=2)
     sys.stdout.write("\n")

--- a/scripts/weekly-digest/synthesis-prompt.md
+++ b/scripts/weekly-digest/synthesis-prompt.md
@@ -34,6 +34,11 @@ Then:
   - On a quiet week (no scraped PRs), collapse the whole block to a single line ("No reviewed PRs closed this week") -- never drop the block entirely.
 - End with ONE line of CI health derived from `ci_health` (status plus success rate / failure count if useful). `ci_health` is computed over the last 24 hours, so describe the window that way -- do NOT call it "last N runs".
 
+- v3 SLA ops -- a short trailing block (1-3 lines) from `v3_ops`, the SLA-sweep's own operational summary (escalations, staleness warns/closes, waives). Rules:
+  - If `v3_ops.available == false`, emit exactly one line saying v3 SLA telemetry was unavailable this week (loud degradation signal, same treatment as `review_outcomes.available == false` above -- never omit it).
+  - Otherwise, one line: `escalations_total` (with the `escalations_by_role` breakdown only if more than one role fired), `warns`, `closes`, and `waives`. On a fully quiet window (all four are 0) collapse to a single line ("No SLA escalations, staleness warnings, or waives this week") -- never drop the block.
+  - If `bulk_accept_rate` is not null, add a trailing clause noting it (e.g. "N% of accepted findings were bulk-resolved") only when `author_accepted` is at least a handful (say 3+) -- a rate computed from 1-2 answers is noise, skip the clause below that floor.
+
 ## Message 2 -- backlog_digest
 
 A scan of the open-issue backlog, not a recital. Do not list the whole backlog.


### PR DESCRIPTION
Third slice of the docs-review v3 rollout, stacked on #21340. Every consumer prefers the v3 evidence object when a PR has one and falls back to today's shape otherwise, so nothing changes until the surface flips.

- **weekly-digest**: `collect_v3_ops()` (waive rate, SLA breaches by lane, bulk-accept rate) and the synthesis prompt's v3 section.
- **review-admin**: a `pr-review` domain loader for the evidence ledger.
- **content-review**: the glow-up backlog gains a source — a review PR's still-open, accepted-as-is, or held findings and every pre-existing row from `pr-review/<pr>/latest.json`. `select-glowup.py --pr-review-dir` stamps trimmed records on the queue article (the worker has no AWS), and the dispatcher syncs only `*/latest.json`.

Verification: harness + lint green on the stack; builder self-test (77 checks) and selector test (68) cover the new source, dedupe, and the queue stamp.
