### PR TITLE
infrastructure: public review-evidence bucket for the v3 evidence pages

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -354,6 +354,60 @@ new aws.s3.BucketPublicAccessBlock("content-review-ledger-public-access-block", 
     restrictPublicBuckets: true,
 });
 
+// Bucket for the pre-merge review evidence pages: one self-contained HTML
+// page per (PR, head SHA) plus a latest.html pointer, rendered by
+// scripts/review-v3/render-evidence-html.py and linked from the two pinned
+// review comments. Public by design — the content is the same verification
+// trail that used to live in a public PR comment, moved out to keep the
+// comments readable. One stable bucket (unlike the per-PR preview buckets):
+// evidence pages are part of the review's audit trail and must survive PR
+// close. Objects are world-readable but the bucket is not listable, matching
+// the origin-bucket posture below.
+const reviewEvidenceBucket = new aws.s3.Bucket("review-evidence", {});
+
+const reviewEvidenceWebsite = new aws.s3.BucketWebsiteConfiguration("review-evidence-website", {
+    bucket: reviewEvidenceBucket.id,
+    indexDocument: {
+        suffix: "index.html",
+    },
+});
+
+new aws.s3.BucketPublicAccessBlock("review-evidence-public-access-block", {
+    bucket: reviewEvidenceBucket.id,
+    blockPublicAcls: true,
+    blockPublicPolicy: false,
+    ignorePublicAcls: true,
+    restrictPublicBuckets: false,
+});
+
+new aws.s3.BucketPolicy("review-evidence-public-read-policy", {
+    bucket: reviewEvidenceBucket.bucket,
+    policy: reviewEvidenceBucket.arn.apply((arn) => JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+            {
+                Sid: "PublicReadObjects",
+                Effect: "Allow",
+                Principal: "*",
+                Action: "s3:GetObject",
+                Resource: `${arn}/*`,
+            },
+            {
+                Sid: "RestrictToTLSRequestsOnly",
+                Effect: "Deny",
+                Principal: "*",
+                Action: "s3:*",
+                Resource: [arn, `${arn}/*`],
+                Condition: {
+                    Bool: {
+                        "aws:SecureTransport": "false",
+                    },
+                },
+            },
+        ],
+    })),
+});
+
 // Grant the data warehouse's Snowpipe reader role read access to the buckets it
 // ingests, so their contents can be synced into Snowflake (pulumi/data#873,
 // pulumi/data#921). Only when DWH access is enabled.
@@ -1519,6 +1573,8 @@ if (config.supportRedirectDomain) {
 export const uploadsBucketName = uploadsBucket.bucket;
 export const socialStateBucketName = socialStateBucket.bucket;
 export const contentReviewLedgerBucketName = contentReviewLedgerBucket.bucket;
+export const reviewEvidenceBucketName = reviewEvidenceBucket.bucket;
+export const reviewEvidenceWebsiteEndpoint = reviewEvidenceWebsite.websiteEndpoint;
 export const originBucketWebsiteDomain = originBucket.websiteDomain;
 export const originBucketWebsiteEndpoint = originBucket.websiteEndpoint;
 export const cloudFrontDomain = cdn.domainName;

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -356,23 +356,28 @@ new aws.s3.BucketPublicAccessBlock("content-review-ledger-public-access-block", 
 
 // Bucket for the pre-merge review evidence pages: one self-contained HTML
 // page per (PR, head SHA) plus a latest.html pointer, rendered by
-// scripts/review-v3/render-evidence-html.py and linked from the two pinned
-// review comments. Public by design — the content is the same verification
-// trail that used to live in a public PR comment, moved out to keep the
-// comments readable. One stable bucket (unlike the per-PR preview buckets):
-// evidence pages are part of the review's audit trail and must survive PR
-// close. Objects are world-readable but the bucket is not listable, matching
-// the origin-bucket posture below.
+// scripts/review-v3/render-evidence-html.py (lands with the review-v3
+// machinery PR) and linked from the two pinned review comments. Public by
+// design — the content is the same verification trail that used to live in
+// a public PR comment, moved out to keep the comments readable. One stable
+// bucket (unlike the per-PR preview buckets): evidence pages are part of the
+// review's audit trail and must survive PR close, so the bucket is versioned
+// like the two state buckets above (latest.html is overwritten on every
+// re-review; versioning keeps the prior pointer). Objects are world-readable
+// but the bucket is not listable, matching the origin-bucket posture below.
+//
+// Deliberately NOT a static website: the S3 website endpoint is HTTP-only,
+// which the TLS-only policy statement below would deny outright. Pages are
+// linked by key at the bucket's HTTPS REST URL instead (`reviewEvidenceBaseUrl`
+// + `/<pr>/latest.html`), which the public-read statement already covers.
 const reviewEvidenceBucket = new aws.s3.Bucket("review-evidence", {});
 
-const reviewEvidenceWebsite = new aws.s3.BucketWebsiteConfiguration("review-evidence-website", {
+new aws.s3.BucketVersioning("review-evidence-versioning", {
     bucket: reviewEvidenceBucket.id,
-    indexDocument: {
-        suffix: "index.html",
-    },
+    versioningConfiguration: { status: "Enabled" },
 });
 
-new aws.s3.BucketPublicAccessBlock("review-evidence-public-access-block", {
+const reviewEvidencePublicAccessBlock = new aws.s3.BucketPublicAccessBlock("review-evidence-public-access-block", {
     bucket: reviewEvidenceBucket.id,
     blockPublicAcls: true,
     blockPublicPolicy: false,
@@ -380,6 +385,10 @@ new aws.s3.BucketPublicAccessBlock("review-evidence-public-access-block", {
     restrictPublicBuckets: false,
 });
 
+// New buckets start with all four Block Public Access settings on, so the
+// public-read policy must wait for the block above to flip
+// blockPublicPolicy off — otherwise the first `pulumi up` fails with
+// AccessDenied on PutBucketPolicy (same ordering as the uploads bucket).
 new aws.s3.BucketPolicy("review-evidence-public-read-policy", {
     bucket: reviewEvidenceBucket.bucket,
     policy: reviewEvidenceBucket.arn.apply((arn) => JSON.stringify({
@@ -406,6 +415,8 @@ new aws.s3.BucketPolicy("review-evidence-public-read-policy", {
             },
         ],
     })),
+}, {
+    dependsOn: [reviewEvidencePublicAccessBlock],
 });
 
 // Grant the data warehouse's Snowpipe reader role read access to the buckets it
@@ -1574,7 +1585,7 @@ export const uploadsBucketName = uploadsBucket.bucket;
 export const socialStateBucketName = socialStateBucket.bucket;
 export const contentReviewLedgerBucketName = contentReviewLedgerBucket.bucket;
 export const reviewEvidenceBucketName = reviewEvidenceBucket.bucket;
-export const reviewEvidenceWebsiteEndpoint = reviewEvidenceWebsite.websiteEndpoint;
+export const reviewEvidenceBaseUrl = pulumi.interpolate`https://${reviewEvidenceBucket.bucketRegionalDomainName}`;
 export const originBucketWebsiteDomain = originBucket.websiteDomain;
 export const originBucketWebsiteEndpoint = originBucket.websiteEndpoint;
 export const cloudFrontDomain = cdn.domainName;


### PR DESCRIPTION
The one piece of the docs-review v3 rollout that touches infrastructure: a stable public static-website bucket (modeled on the PR preview buckets, never deleted) that the v3 publish job writes `/<pr>/<sha>.html` and `/<pr>/latest.html` into.

Exposure is unchanged from today: this is the verification trail that currently ships inside the pinned PR comment. Kept separate from the code PRs (#21340, #21341, #21342) because merging it implies a stack update, which is a deliberate step — until the bucket exists, the publish job degrades to uploading the HTML as a workflow artifact.

Type-checks; not deployed.
