### PR TITLE
Docs review v3: SLA sweep (dark behind REVIEW_V3_SLA)

### DIFF
--- a/.github/workflows/review-sla-sweep.yml
+++ b/.github/workflows/review-sla-sweep.yml
@@ -110,7 +110,7 @@ jobs:
           if [ -n "$BUCKET" ]; then
             echo "evidence_uri=s3://$BUCKET/pr-review" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::state bucket output unavailable; sla-sweep.py will degrade to local-only state"
+            echo "::warning::state bucket output unavailable; sla-sweep.py forces DRY-RUN this cycle (mutations without durable state would repeat every sweep)"
           fi
 
       # Comment-noise safety: a manual dispatch always honors its own

--- a/.github/workflows/review-sla-sweep.yml
+++ b/.github/workflows/review-sla-sweep.yml
@@ -1,0 +1,147 @@
+name: Review SLA sweep
+
+# The v3 review workflow's clocks: machine-enforced reviewer-wait SLAs
+# (one-shot escalation) and author-staleness warn/close. scripts/review-v3/
+# sla-sweep.py is the deterministic evaluator (no model, no PR code
+# checkout — it reads PR state through the GitHub API only); this workflow
+# gathers credentials, resolves the S3 evidence-layer bucket, and runs it.
+# See scripts/review-v3/README.md and .github/review-routing.yml (the `sla:`
+# and `author_staleness:` blocks) for the policy this enforces.
+#
+# SINGLE SWITCH — the REVIEW_V3_SLA repo variable gates BOTH whether the
+# scheduled job runs at all AND whether it's allowed to mutate anything:
+#   unset / anything but '1' -> the schedule no-op-skips the job entirely
+#     (job-level `if:`), so an unconfigured repo spends nothing here.
+#   '1' -> the schedule runs for real (comments, labels, closes, escalates).
+# workflow_dispatch always runs regardless of the variable (the testing
+# path), and always honors its own `dry_run` input rather than the
+# variable — a manual run never needs the switch flipped to preview safely.
+#
+# Written with explicit `== '1'` comparisons throughout, never `!= '0'` —
+# see review-sentinel.yml's REPORT_ONLY comment and the blog-review-index.yml
+# header for why: GitHub coerces an unset (null) variable and a string
+# through numeric comparison, so `!= '0'` is TRUE for unset and silently
+# defaults a switch like this one to ON. `== '1'` has no such trap: unset
+# coerces to false either way.
+
+on:
+  schedule:
+    # Every 2 hours, offset from the hour so it doesn't contend with other
+    # :00/:30 scheduled jobs.
+    - cron: '53 */2 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview actions without commenting, labeling, closing, or escalating'
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+  pull-requests: write   # labels, close
+  issues: write          # PR comments (issues API)
+  id-token: write        # ESC OIDC
+
+concurrency:
+  group: review-sla-sweep
+  cancel-in-progress: false   # never cut off a sweep mid-write
+
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
+
+jobs:
+  sweep:
+    name: Sweep open PRs (deterministic, credentialed)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: vars.REVIEW_V3_SLA == '1' || github.event_name == 'workflow_dispatch'
+    # PULUMI_STACK_NAME is an environment-scoped variable, so the job must
+    # select the environment to resolve the ledger bucket stack output
+    # (same reason blog-review-index.yml's select/record jobs do this).
+    environment: production
+    steps:
+      # continue-on-error: the sweep's own degradation contract handles
+      # missing credentials (local state + ::warning::, Slack line skipped),
+      # and a dry-run needs none of them. Also lets the fork battery
+      # exercise the sweep without ESC.
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        continue-on-error: true
+        uses: pulumi/esc-action@v3
+
+      - name: Checkout (default branch)
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python deps
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Configure AWS credentials
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::388588623842:role/ContinuousDelivery
+          role-session-name: review-sla-sweep
+          aws-region: us-west-2
+
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+
+      - name: Resolve evidence bucket
+        id: state-bucket
+        continue-on-error: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        run: |
+          BUCKET=$(pulumi -C infrastructure stack output contentReviewLedgerBucketName \
+            --stack "${{ vars.PULUMI_STACK_NAME }}" 2>/dev/null || true)
+          if [ -n "$BUCKET" ]; then
+            echo "evidence_uri=s3://$BUCKET/pr-review" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::state bucket output unavailable; sla-sweep.py will degrade to local-only state"
+          fi
+
+      # Comment-noise safety: a manual dispatch always honors its own
+      # dry_run input (default true — preview by default even with the
+      # switch flipped on); a scheduled run only mutates anything when the
+      # REVIEW_V3_SLA switch above is explicitly '1' (redundant with the
+      # job-level `if:`, kept here too so a future trigger added to `on:`
+      # without updating the job gate still can't mutate silently).
+      - name: Resolve dry-run mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            DRY_RUN="${{ github.event.inputs.dry_run }}"
+          elif [ "${{ vars.REVIEW_V3_SLA }}" = "1" ]; then
+            DRY_RUN=false
+          else
+            DRY_RUN=true
+          fi
+          echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+          echo "resolved dry_run=$DRY_RUN (event=${{ github.event_name }})"
+
+      - name: Run SLA sweep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_REVIEW_EVIDENCE_URI: ${{ steps.state-bucket.outputs.evidence_uri }}
+          # Optional — a missing/empty webhook is a silent no-op in
+          # slack_notify(), never a failure.
+          SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+        run: |
+          ARGS=(--repo "${{ github.repository }}")
+          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          python3 scripts/review-v3/sla-sweep.py "${ARGS[@]}"

--- a/scripts/review-v3/README.md
+++ b/scripts/review-v3/README.md
@@ -106,9 +106,25 @@ check-run, the review lanes skip their pokes; the state the file merges in),
 `'report'` = report-only (conclusions `neutral` with "would be: …" in the
 summary), `'1'` = enforcing. `/deploy-staging` follows the same switch. The
 surface itself is `REVIEW_V3_COMMENTS` (repo default) or the `surface:v3`
-label (one PR in or out, regardless of the variable). The check summary embeds the
-reviewer brief (merge-box delivery), and on red the sentinel PATCHes a ⛔
-strip into the author card naming the exact commands.
+label (one PR in or out, regardless of the variable). `REVIEW_V3_BOT_PRS`
+= `'1'` makes the content-review and glow-up lanes open their bot PRs
+already wearing the label — free v3 test traffic that no human author
+sees, once the lane rewiring has merged (before that the label only reaches
+the `/resolve` listener). Order of operations: run the `gh label create`
+line for `surface:v3` first, then flip the variable — otherwise every bot
+PR takes the unlabeled fallback with a `::warning::`. The
+check summary embeds the reviewer brief (merge-box delivery), and on red the
+sentinel PATCHes a ⛔ strip into the author card naming the exact commands.
+
+**SLA sweep** (`sla-sweep.py`, `review-sla-sweep.yml`, cron every 2 h): its own
+switch is `REVIEW_V3_SLA` — the job runs only while it is `'1'` (a manual
+dispatch defaults to `dry_run`). Clocks are derived fresh from the GitHub
+timeline each sweep; only the actions taken are recorded, under
+`pr-review/state/<pr>.json` (per-PR idempotency: warns, closes, escalations
+keyed by clock epoch) and `pr-review/runs/<date>/<ts>.json` (immutable run
+records the weekly digest reduces). **Before flipping the switch, create the
+`review:author-stalled` label** (`.github/labels-pr-review.md` has the
+`gh label create` line) — the sweep applies it on the first author warn.
 
 `staging-deploy-pr.yml` makes G4's evidence: `/deploy-staging` (tools-team
 members only, same-repo branches only) dispatches the existing testing

--- a/scripts/review-v3/sla-sweep.py
+++ b/scripts/review-v3/sla-sweep.py
@@ -680,6 +680,9 @@ def sweep(gh: Gh, config: routing.Config, *, now: datetime, dry_run: bool,
                     _try_label(gh, pr_number, gh.remove_label, AUTHOR_STALLED_LABEL)
                 state["warns"] = []
                 persisted = save_state(pr_number, state, evidence_uri, state_dir) if not dry_run else True
+                if not persisted:
+                    warn(f"PR #{pr_number}: state NOT persisted to {evidence_uri} — the stale-label "
+                         "clear will be retried next sweep")
                 run_actions.append({"pr": pr_number, "kind": None, "head_sha": head_sha,
                                     "changed": True,
                                     "actions": [{"type": "clear_stale_author_warn"}],

--- a/scripts/review-v3/sla-sweep.py
+++ b/scripts/review-v3/sla-sweep.py
@@ -425,12 +425,33 @@ def load_state(pr: int, uri: str, state_dir: Path) -> dict:
     return empty_sweep_state()
 
 
-def save_state(pr: int, state: dict, uri: str, state_dir: Path) -> None:
+def save_state(pr: int, state: dict, uri: str, state_dir: Path) -> bool:
+    """Persist per-PR state. Returns whether the DURABLE copy landed: the
+    S3 upload's result when a URI is set, True for a local-only run (the
+    caller decided local state was acceptable — see resolve_mutation_mode).
+    A False here is the signal the run record must carry: the mutation
+    happened, its record didn't, and the next sweep will not know."""
     local = local_state_path(state_dir, pr)
     local.parent.mkdir(parents=True, exist_ok=True)
     local.write_text(json.dumps(state, indent=2) + "\n")
     if uri:
-        _record_evidence.upload(state, _record_evidence.s3_key(uri, "state", f"{pr}.json"))
+        return _record_evidence.upload(state, _record_evidence.s3_key(uri, "state", f"{pr}.json"))
+    return True
+
+
+def durable_state_writable(uri: str, now: datetime) -> bool:
+    """Pre-flight for a real run: write a probe to the state prefix and read
+    it back. Mutating before knowing the state write can land is how a warn
+    or an escalation gets re-issued every sweep; this turns "the bucket
+    resolved" into "the bucket accepted a write from this runner"."""
+    if not uri:
+        return False
+    key = _record_evidence.s3_key(uri, "state", "_probe.json")
+    stamp = {"probe": now.isoformat()}
+    if not _record_evidence.upload(stamp, key):
+        return False
+    back = _s3_read_json(key)
+    return bool(back) and back.get("probe") == stamp["probe"]
 
 
 def write_run_record(record: dict, uri: str, state_dir: Path, now: datetime) -> None:
@@ -658,11 +679,11 @@ def sweep(gh: Gh, config: routing.Config, *, now: datetime, dry_run: bool,
                 if not dry_run:
                     _try_label(gh, pr_number, gh.remove_label, AUTHOR_STALLED_LABEL)
                 state["warns"] = []
-                if not dry_run:
-                    save_state(pr_number, state, evidence_uri, state_dir)
+                persisted = save_state(pr_number, state, evidence_uri, state_dir) if not dry_run else True
                 run_actions.append({"pr": pr_number, "kind": None, "head_sha": head_sha,
                                     "changed": True,
-                                    "actions": [{"type": "clear_stale_author_warn"}]})
+                                    "actions": [{"type": "clear_stale_author_warn"}],
+                                    **({} if persisted else {"state_persisted": False})})
             continue
 
         try:
@@ -705,7 +726,12 @@ def sweep(gh: Gh, config: routing.Config, *, now: datetime, dry_run: bool,
             continue
 
         if result.get("changed") and not dry_run:
-            save_state(pr_number, state, evidence_uri, state_dir)
+            if not save_state(pr_number, state, evidence_uri, state_dir):
+                # The mutation is already out; the next sweep will not know.
+                # Say so where the digest and a human will read it.
+                warn(f"PR #{pr_number}: state NOT persisted to {evidence_uri} — the action(s) below "
+                     "may be re-issued next sweep")
+                result = {**result, "state_persisted": False}
 
         run_actions.append({"pr": pr_number, "kind": kind, "head_sha": head_sha, **result})
 
@@ -718,7 +744,8 @@ def sweep(gh: Gh, config: routing.Config, *, now: datetime, dry_run: bool,
 # ---- CLI ----------------------------------------------------------------
 
 
-def resolve_mutation_mode(uri: str, dry_run: bool, allow_local_state: bool) -> tuple[bool, str | None]:
+def resolve_mutation_mode(uri: str, dry_run: bool, allow_local_state: bool,
+                          durable_ok: bool = True) -> tuple[bool, str | None]:
     """Whether this run may mutate, given where its state can live.
 
     State is what makes the sweep idempotent: a warn or an escalation that
@@ -728,8 +755,14 @@ def resolve_mutation_mode(uri: str, dry_run: bool, allow_local_state: bool) -> t
     dry-run, loudly. `--allow-local-state` is the developer override for a
     laptop whose --state-dir persists between runs.
     """
-    if dry_run or uri or allow_local_state:
-        return dry_run, None
+    if dry_run:
+        return True, None
+    if uri and not durable_ok:
+        return True, (f"{EVIDENCE_URI_ENV} is set but a probe write to its state prefix did not land: "
+                      "mutations whose record can't be persisted would be re-issued every sweep, so "
+                      "this run is DRY-RUN (nothing labeled, commented, closed, or escalated)")
+    if uri or allow_local_state:
+        return False, None
     return True, (f"{EVIDENCE_URI_ENV} unset and --allow-local-state not given: mutations without "
                   "durable state would be re-issued every sweep, so this run is DRY-RUN "
                   "(nothing labeled, commented, closed, or escalated)")
@@ -764,7 +797,9 @@ def main() -> int:
         return 1
 
     uri = os.environ.get(EVIDENCE_URI_ENV, "").strip()
-    dry_run, forced = resolve_mutation_mode(uri, args.dry_run, args.allow_local_state)
+    now = datetime.now(timezone.utc)
+    durable_ok = durable_state_writable(uri, now) if (uri and not args.dry_run) else True
+    dry_run, forced = resolve_mutation_mode(uri, args.dry_run, args.allow_local_state, durable_ok)
     if forced:
         warn(forced)
     elif not uri:
@@ -772,7 +807,7 @@ def main() -> int:
 
     gh = Gh(args.repo)
     record = sweep(
-        gh, config, now=datetime.now(timezone.utc), dry_run=dry_run,
+        gh, config, now=now, dry_run=dry_run,
         state_dir=Path(args.state_dir), evidence_uri=uri,
     )
     if forced:

--- a/scripts/review-v3/sla-sweep.py
+++ b/scripts/review-v3/sla-sweep.py
@@ -718,6 +718,23 @@ def sweep(gh: Gh, config: routing.Config, *, now: datetime, dry_run: bool,
 # ---- CLI ----------------------------------------------------------------
 
 
+def resolve_mutation_mode(uri: str, dry_run: bool, allow_local_state: bool) -> tuple[bool, str | None]:
+    """Whether this run may mutate, given where its state can live.
+
+    State is what makes the sweep idempotent: a warn or an escalation that
+    isn't durably recorded is re-issued on the next sweep — every two
+    hours, on every stalled PR at once. On a CI runner "locally recorded"
+    state dies with the job, so no durable URI ⇒ the run is forced to
+    dry-run, loudly. `--allow-local-state` is the developer override for a
+    laptop whose --state-dir persists between runs.
+    """
+    if dry_run or uri or allow_local_state:
+        return dry_run, None
+    return True, (f"{EVIDENCE_URI_ENV} unset and --allow-local-state not given: mutations without "
+                  "durable state would be re-issued every sweep, so this run is DRY-RUN "
+                  "(nothing labeled, commented, closed, or escalated)")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--repo")
@@ -725,6 +742,9 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--state-dir", default=DEFAULT_STATE_DIR,
                          help="local mirror of the pr-review/ state prefixes")
+    parser.add_argument("--allow-local-state", action="store_true",
+                         help="mutate even with no durable state URI (a persistent --state-dir "
+                              "on a developer machine); never on a CI runner")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
 
@@ -744,14 +764,19 @@ def main() -> int:
         return 1
 
     uri = os.environ.get(EVIDENCE_URI_ENV, "").strip()
-    if not uri:
-        warn(f"{EVIDENCE_URI_ENV} unset; state recorded locally only")
+    dry_run, forced = resolve_mutation_mode(uri, args.dry_run, args.allow_local_state)
+    if forced:
+        warn(forced)
+    elif not uri:
+        warn(f"{EVIDENCE_URI_ENV} unset; state recorded locally only (--allow-local-state)")
 
     gh = Gh(args.repo)
     record = sweep(
-        gh, config, now=datetime.now(timezone.utc), dry_run=args.dry_run,
+        gh, config, now=datetime.now(timezone.utc), dry_run=dry_run,
         state_dir=Path(args.state_dir), evidence_uri=uri,
     )
+    if forced:
+        record["forced_dry_run"] = forced
     print(json.dumps(record, indent=2))
     return 0
 

--- a/scripts/review-v3/sla-sweep.py
+++ b/scripts/review-v3/sla-sweep.py
@@ -486,7 +486,7 @@ def process_author_time(
             # Fresh author activity since the warn -> clear the label and
             # the warn record; a later idle period re-arms from scratch.
             if not dry_run:
-                gh.remove_label(pr_number, AUTHOR_STALLED_LABEL)
+                _try_label(gh, pr_number, gh.remove_label, AUTHOR_STALLED_LABEL)
             state["warns"] = []
             return {"changed": True, "action": {"type": "clear", "idle_days": round(idle_days, 2)}}
 
@@ -501,7 +501,7 @@ def process_author_time(
             )
             if not dry_run:
                 gh.create_issue_comment(pr_number, body)
-                gh.add_label(pr_number, AUTHOR_STALLED_LABEL)
+                _try_label(gh, pr_number, gh.add_label, AUTHOR_STALLED_LABEL)
             state["warns"] = warns + [{"at": now.isoformat(), "head_sha": head_sha}]
             return {"changed": True, "action": {
                 "type": "warn", "idle_days": round(idle_days, 2), "undecided_count": undecided_count,
@@ -527,6 +527,18 @@ def process_author_time(
     return {"changed": False, "action": {
         "type": "none", "idle_days": round(idle_days, 2), "warn_age_days": round(warn_age_days, 2),
     }}
+
+
+def _try_label(gh: Gh, pr_number: int, fn, label: str) -> None:
+    """Label mutations are best-effort. A missing label (review:author-stalled
+    is created by hand) is the expected failure, and nothing about the nudge
+    or the escalation depends on it — but a raise here, ordered before the
+    state write, would drop the record and re-post the comment every sweep.
+    Comments and closes stay fatal: those must not be retried blind."""
+    try:
+        fn(pr_number, label)
+    except Exception as exc:  # noqa: BLE001
+        log(f"PR #{pr_number}: label {label!r} {fn.__name__} failed ({exc}); continuing")
 
 
 # ---- REVIEWER-TIME processing (step 4) ---------------------------------------
@@ -584,7 +596,7 @@ def process_reviewer_time(
     # not linger — nothing in review-label-reconcile.yml covers this label.
     if state.get("warns"):
         if not dry_run:
-            gh.remove_label(pr_number, AUTHOR_STALLED_LABEL)
+            _try_label(gh, pr_number, gh.remove_label, AUTHOR_STALLED_LABEL)
         state["warns"] = []
         changed = True
         actions.append({"type": "clear_stale_author_warn"})
@@ -644,11 +656,7 @@ def sweep(gh: Gh, config: routing.Config, *, now: datetime, dry_run: bool,
             state = load_state(pr_number, evidence_uri, state_dir)
             if state.get("warns"):
                 if not dry_run:
-                    try:
-                        gh.remove_label(pr_number, AUTHOR_STALLED_LABEL)
-                    except Exception as exc:  # noqa: BLE001
-                        log(f"PR #{pr_number}: failed to clear {AUTHOR_STALLED_LABEL} ({exc})")
-                        continue
+                    _try_label(gh, pr_number, gh.remove_label, AUTHOR_STALLED_LABEL)
                 state["warns"] = []
                 if not dry_run:
                     save_state(pr_number, state, evidence_uri, state_dir)

--- a/scripts/review-v3/sla-sweep.py
+++ b/scripts/review-v3/sla-sweep.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""The SLA sweep — machine-enforced reviewer-wait clocks and author-staleness
+warn/close for the v3 PR review workflow.
+
+Two independent clocks run per open, non-draft PR, never both at once:
+
+  AUTHOR-TIME    the ball is in the author's court — unanswered 🚨/❓
+                 findings on the author card (or, for a legacy v2 PR, an
+                 outstanding legacy review), or a standing CHANGES_REQUESTED
+                 review. Idle past `author_staleness.warn_days` (from
+                 `.github/review-routing.yml`) gets a nudge comment + the
+                 `review:author-stalled` label; idle past `close_days`, with
+                 a warn old enough to prove the author had fair notice, gets
+                 the PR closed (one-click reopen).
+
+  REVIEWER-TIME  the ball is in a required reviewer's court — the routing
+                 matrix (`routing.py`) names a role and no unanswered
+                 finding or changes-requested review is standing in the way.
+                 Waiting past that role's `sla.<role>.business_days` gets a
+                 one-shot escalation comment (+ a best-effort Slack line)
+                 naming the role's `escalate_to` contact.
+
+A PR with no v3 author card AND no v2 pinned review (i.e. auto-review never
+ran, or the author lacks write access and the PR skips G1/G2 per
+`external_contributors`) is a legacy/no-state PR and is NEVER touched — this
+sweep only interprets state it can prove exists, fail-safe. A mechanical PR
+that resolves to no required role has no clock either.
+
+Deterministic, no model. Reuses sentinel.py's own gate-2 finding-parsing
+logic (`_card_rows`, `review_state.parse_state`) and the same
+`_mechanical_and_claims` classifier sentinel.py uses for gate 3 routing, so
+"answered" and "required role" can never mean something different here than
+they do at the merge gate — one classifier, one vocabulary (see AGENTS.md /
+review-routing.yml). Imported by path is unnecessary here: sla-sweep.py
+lives in the same directory as sentinel.py/routing.py/review_state.py, so a
+plain `import` after the sys.path insert (same trick sentinel.py itself
+uses) picks them up directly.
+
+## Clock-start derivation (REVIEWER-TIME)
+
+The exact timeline signals used, latest-of:
+
+  1. the `ready_for_review` timeline event, or the PR's `created_at` if it
+     was opened ready (never drafted) — the earliest a reviewer *could* have
+     looked;
+  2. the most recent `review_requested` timeline event whose
+     `requested_team.slug` matches the required role's team — reviewer-time
+     restarts if the role gets re-requested after already being satisfied
+     once (e.g. dismissed-on-push);
+  3. the author's last commit/comment timestamp, but ONLY when it postdates
+     the most recent standing CHANGES_REQUESTED review — this approximates
+     "the moment author-time ended and reviewer-time resumed" using only
+     signals the timeline actually carries (there is no explicit "author
+     answered changes-requested" event).
+
+This is a documented approximation, not a perfect state machine: a PR that
+was never changes-requested and never re-requested just clocks from
+ready-for-review/open, which is the common case.
+
+## Business days
+
+`business_days_between(start, end)` counts weekday (UTC, Mon-Fri) boundaries
+crossed walking from `start` to `end` one calendar day at a time — no
+holiday calendar (documented simplification, matches `author_staleness`'s
+plain-day math being separate: staleness idle is measured in *calendar*
+days, only the reviewer SLA clock is business days, per review-routing.yml).
+
+## State and evidence
+
+Same degradation contract as `record-evidence.py`: `PR_REVIEW_EVIDENCE_URI`
+unset means read/write local `.pr-review-state/` and emit one `::warning::`
+— never fail. Two kinds of records:
+
+  - `pr-review/state/<pr>.json` — mutable, read-modify-written each sweep:
+    `{"schema":1,"warns":[{"at","head_sha"}],
+       "escalations":[{"role","clock_start","at"}],"closes":[...]}`.
+    A PR keeps at most the *current* unresolved warn (cleared to `[]` the
+    moment fresh author activity postdates it) — old warns are not an
+    append-only log, they exist only to answer "has this author been
+    warned, and is the warning stale enough to justify a close."
+    `escalations` and `closes` ARE append-only (audit trail; escalations
+    are also how "once per clock epoch" is enforced — see below).
+  - `pr-review/runs/<date>/sweep-<HHMMSSZ>.json` — one immutable record per
+    sweep invocation (the S3 bucket is versioned, like the evidence object,
+    so the date-keyed `sweep.json` name in the design doc would already be
+    immutable per version; the HHMMSSZ suffix is a deliberate deviation to
+    keep same-day runs — this cron fires every 2 hours — from colliding as
+    local files, which don't get that free versioning).
+
+`--dry-run` never writes state, comments, labels, or closes — it computes
+and prints the same run-record JSON `main()` always prints, so dry-run
+output IS the "intended actions" preview.
+
+Self-contained — run the smoke checks with `sla-sweep.py --self-test`
+(delegates to test_sla_sweep.py, same convention as sentinel.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+sys.path.insert(0, str(HERE))
+import review_state  # noqa: E402
+import routing  # noqa: E402
+import sentinel  # noqa: E402
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# record-evidence.py's s3_key()/upload() are generic enough to reuse
+# verbatim (hyphenated filename -> import by path, same technique
+# record-evidence.py itself uses for validate-evidence.py).
+_record_evidence = _load("sla_sweep_record_evidence", HERE / "record-evidence.py")
+
+AUTHOR_STALLED_LABEL = "review:author-stalled"
+DEFAULT_STATE_DIR = ".pr-review-state"
+EVIDENCE_URI_ENV = "PR_REVIEW_EVIDENCE_URI"
+SLACK_WEBHOOK_ENV = "SLACK_WEBHOOK_URL"
+
+
+def log(msg: str) -> None:
+    print(f"sla-sweep: {msg}", file=sys.stderr)
+
+
+def warn(msg: str) -> None:
+    print(f"::warning::sla-sweep: {msg}", file=sys.stderr)
+
+
+class CorruptReviewState(Exception):
+    """The author card's REVIEW_STATE block exists but won't parse.
+
+    Fail-safe, same philosophy as an unparsable timeline: skip the PR rather
+    than guess whether its findings are answered.
+    """
+
+
+# ---- GitHub I/O ----------------------------------------------------------
+
+
+class Gh:
+    """Thin `gh` wrapper; every method is stubbed in tests."""
+
+    def __init__(self, repo: str):
+        self.repo = repo
+
+    def _run(self, args: list[str]) -> str:
+        result = subprocess.run(["gh", *args], text=True, capture_output=True, check=True)
+        return result.stdout
+
+    def list_open_prs(self) -> list[dict]:
+        out = self._run([
+            "pr", "list", "--repo", self.repo, "--state", "open", "--limit", "500",
+            "--json", "number,title,author,isDraft,headRefOid,createdAt,url",
+        ])
+        return json.loads(out)
+
+    def get_pr(self, pr: int) -> dict:
+        return json.loads(self._run(["api", f"repos/{self.repo}/pulls/{pr}"]))
+
+    def list_files(self, pr: int) -> list[dict]:
+        out = self._run(["api", "--paginate", f"repos/{self.repo}/pulls/{pr}/files"])
+        return json.loads(out)
+
+    def list_issue_comments(self, pr: int) -> list[dict]:
+        out = self._run(["api", "--paginate", f"repos/{self.repo}/issues/{pr}/comments"])
+        return json.loads(out)
+
+    def list_reviews(self, pr: int) -> list[dict]:
+        out = self._run(["api", "--paginate", f"repos/{self.repo}/pulls/{pr}/reviews"])
+        return json.loads(out)
+
+    def get_timeline(self, pr: int) -> list[dict]:
+        out = self._run(["api", "--paginate", f"repos/{self.repo}/issues/{pr}/timeline"])
+        return json.loads(out)
+
+    def create_issue_comment(self, pr: int, body: str) -> None:
+        self._run(["api", "--method", "POST", f"repos/{self.repo}/issues/{pr}/comments",
+                    "-f", f"body={body}"])
+
+    def add_label(self, pr: int, label: str) -> None:
+        self._run(["pr", "edit", str(pr), "--repo", self.repo, "--add-label", label])
+
+    def remove_label(self, pr: int, label: str) -> None:
+        self._run(["pr", "edit", str(pr), "--repo", self.repo, "--remove-label", label])
+
+    def close_pr(self, pr: int, body: str) -> None:
+        self._run(["pr", "close", str(pr), "--repo", self.repo, "--comment", body])
+
+
+# ---- business-day math -----------------------------------------------------
+
+
+def business_days_between(start: datetime, end: datetime) -> int:
+    """Weekday (UTC, Mon-Fri) boundaries crossed walking from start to end.
+
+    No holiday calendar (documented simplification). Measured as elapsed
+    distance, not a date-range count: Friday afternoon to Monday morning is
+    1 business day (the Sat/Sun crossing doesn't count, the Mon crossing
+    does), matching how the sweep uses it — a coarse "how long has this
+    role been waiting" gate against an integer business_days SLA.
+    """
+    if end <= start:
+        return 0
+    days = 0
+    cur = start
+    while cur.date() < end.date():
+        cur += timedelta(days=1)
+        if cur.weekday() < 5:  # Monday=0 .. Sunday=6
+            days += 1
+    return days
+
+
+# ---- timestamp helpers -----------------------------------------------------
+
+
+def _parse_ts(value: str | None) -> datetime:
+    """Raises ValueError on anything unparsable — callers treat that as an
+    unparsable timeline and skip the PR (fail-safe)."""
+    if not value:
+        raise ValueError("empty timestamp")
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+# ---- review helpers ---------------------------------------------------------
+
+
+def latest_review_per_user(reviews: list[dict]) -> dict[str, dict]:
+    """Oldest-first, keep the last STATEFUL review per user (mirrors
+    sentinel.py's G3 approvers loop: COMMENTED never voids a prior state)."""
+    latest: dict[str, dict] = {}
+    for r in reviews:
+        user = (r.get("user") or {}).get("login") or ""
+        if user and r.get("state") != "COMMENTED":
+            latest[user] = r
+    return latest
+
+
+# ---- classification (step 2) -----------------------------------------------
+
+
+def classify_waiting_state(
+    pr_detail: dict, files: list[dict], author_card: dict | None, legacy: dict | None,
+    reviews: list[dict], config: routing.Config,
+) -> tuple[str | None, dict | None, list[str]]:
+    """Returns (kind, extra, reasons). kind is "author", "reviewer", or None
+    (no clock — mechanical with no required role)."""
+    reasons: list[str] = []
+    undecided_count = 0
+    author_time = False
+
+    if author_card is not None:
+        body = author_card.get("body") or ""
+        try:
+            state = review_state.parse_state(body) or review_state.empty_state()
+        except ValueError as exc:
+            raise CorruptReviewState(str(exc)) from exc
+        rows = sentinel._card_rows(body, ("🚨", "❓"))
+        undecided = [r for r in rows if r["id"] not in state.get("findings", {})]
+        undecided_count = len(undecided)
+        if undecided_count:
+            author_time = True
+            reasons.append(f"{undecided_count} unanswered finding(s) on the author card")
+    elif legacy is not None:
+        vp = sentinel._load("sla_sweep_validate_pinned",
+                             sentinel._DOCS_REVIEW_SCRIPTS / "validate-pinned.py")
+        outstanding = len(vp.extract_bucket_bullets(legacy.get("body") or "", "🚨 Outstanding"))
+        undecided_count = outstanding
+        if outstanding:
+            author_time = True
+            reasons.append(f"{outstanding} outstanding finding(s) on the legacy review")
+
+    latest_reviews = latest_review_per_user(reviews)
+    if any(r.get("state") == "CHANGES_REQUESTED" for r in latest_reviews.values()):
+        author_time = True
+        reasons.append("latest review is CHANGES_REQUESTED")
+
+    if author_time:
+        return "author", {"undecided_count": undecided_count}, reasons
+
+    files_paths = [f["filename"] for f in files]
+    mechanical, claims, mech_reasons = sentinel._mechanical_and_claims(pr_detail, files)
+    resolution = routing.resolve_lanes(files_paths, mechanical, claims, config)
+    reasons.extend(mech_reasons)
+    if resolution.roles:
+        return "reviewer", {"roles": resolution.roles}, reasons
+    reasons.append("mechanical with no required roles — no clock")
+    return None, None, reasons
+
+
+# ---- timeline reads ---------------------------------------------------------
+
+
+def last_author_activity(timeline: list[dict], author_login: str, pr_created_at: str) -> datetime:
+    """max(author's last commit time, author's last comment time), from the
+    PR's issue-timeline events. Falls back to the PR's created_at when
+    neither is found (a PR with no timeline commit/comment events at all).
+
+    Uses `committed` events (any commit landing counts — the git commit
+    author and the PR author aren't always the same login, so this is a
+    documented simplification: any push activity resets the author clock)
+    and `commented` events whose actor matches the PR author login (a
+    reviewer's own comments must not reset the author's idle clock).
+    """
+    candidates: list[datetime] = []
+    for e in timeline:
+        event = e.get("event")
+        if event == "committed":
+            ts = (e.get("author") or {}).get("date") or (e.get("committer") or {}).get("date")
+            if ts:
+                candidates.append(_parse_ts(ts))
+        elif event == "commented":
+            actor_login = (e.get("actor") or e.get("user") or {}).get("login")
+            if actor_login and actor_login == author_login and e.get("created_at"):
+                candidates.append(_parse_ts(e["created_at"]))
+    if not candidates:
+        candidates.append(_parse_ts(pr_created_at))
+    return max(candidates)
+
+
+def reviewer_clock_start(
+    timeline: list[dict], pr_detail: dict, team_ref: str, reviews: list[dict],
+    last_activity: datetime,
+) -> datetime:
+    """Latest of the three candidates documented in the module docstring."""
+    candidates: list[datetime] = []
+
+    ready_events = [e for e in timeline if e.get("event") == "ready_for_review" and e.get("created_at")]
+    if ready_events:
+        candidates.append(max(_parse_ts(e["created_at"]) for e in ready_events))
+    else:
+        candidates.append(_parse_ts(pr_detail.get("created_at")))
+
+    _, slug = sentinel._team_org_slug(team_ref)
+    requested_events = [
+        e for e in timeline
+        if e.get("event") == "review_requested"
+        and (e.get("requested_team") or {}).get("slug") == slug
+        and e.get("created_at")
+    ]
+    if requested_events:
+        candidates.append(max(_parse_ts(e["created_at"]) for e in requested_events))
+
+    latest_reviews = latest_review_per_user(reviews)
+    changes_requested_times = [
+        _parse_ts(r["submitted_at"]) for r in latest_reviews.values()
+        if r.get("state") == "CHANGES_REQUESTED" and r.get("submitted_at")
+    ]
+    if changes_requested_times and last_activity > max(changes_requested_times):
+        candidates.append(last_activity)
+
+    return max(candidates)
+
+
+# ---- state I/O ----------------------------------------------------------
+
+
+def empty_sweep_state() -> dict:
+    return {"schema": 1, "warns": [], "escalations": [], "closes": []}
+
+
+def local_state_path(state_dir: Path, pr: int) -> Path:
+    return state_dir / "state" / f"{pr}.json"
+
+
+def _s3_read_json(key: str) -> dict | None:
+    """Best-effort S3 read; None on any failure (missing key, no aws CLI,
+    bad JSON) — mirrors record-evidence.py's load_prior()."""
+    try:
+        out = subprocess.run(["aws", "s3", "cp", key, "-"], capture_output=True, text=True, check=False)
+    except OSError:
+        return None
+    if out.returncode != 0:
+        return None
+    try:
+        data = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_state(pr: int, uri: str, state_dir: Path) -> dict:
+    if uri:
+        data = _s3_read_json(_record_evidence.s3_key(uri, "state", f"{pr}.json"))
+        if data is not None:
+            return data
+    local = local_state_path(state_dir, pr)
+    if local.is_file():
+        try:
+            return json.loads(local.read_text())
+        except (OSError, json.JSONDecodeError):
+            pass
+    return empty_sweep_state()
+
+
+def save_state(pr: int, state: dict, uri: str, state_dir: Path) -> None:
+    local = local_state_path(state_dir, pr)
+    local.parent.mkdir(parents=True, exist_ok=True)
+    local.write_text(json.dumps(state, indent=2) + "\n")
+    if uri:
+        _record_evidence.upload(state, _record_evidence.s3_key(uri, "state", f"{pr}.json"))
+
+
+def write_run_record(record: dict, uri: str, state_dir: Path, now: datetime) -> None:
+    date = now.date().isoformat()
+    fname = f"sweep-{now.strftime('%H%M%S')}Z.json"
+    local = state_dir / "runs" / date / fname
+    local.parent.mkdir(parents=True, exist_ok=True)
+    local.write_text(json.dumps(record, indent=2) + "\n")
+    if uri:
+        _record_evidence.upload(record, _record_evidence.s3_key(uri, "runs", date, fname))
+
+
+# ---- Slack ------------------------------------------------------------------
+
+
+def slack_notify(text: str) -> None:
+    """Best-effort — a webhook failure is a warning, never a sweep failure."""
+    url = os.environ.get(SLACK_WEBHOOK_ENV, "").strip()
+    if not url:
+        return
+    try:
+        req = urllib.request.Request(
+            url, data=json.dumps({"text": text}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        urllib.request.urlopen(req, timeout=10)  # noqa: S310 — fixed https webhook URL from env
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        warn(f"Slack webhook failed: {exc}")
+
+
+# ---- AUTHOR-TIME processing (step 3) -----------------------------------------
+
+
+def process_author_time(
+    gh: Gh, pr_number: int, head_sha: str, undecided_count: int, config: routing.Config,
+    state: dict, now: datetime, dry_run: bool, last_activity: datetime,
+) -> dict:
+    warn_days = config.author_staleness["warn_days"]
+    close_days = config.author_staleness["close_days"]
+    idle_days = (now - last_activity).total_seconds() / 86400.0
+    warns = state.get("warns") or []
+    last_warn = warns[-1] if warns else None
+
+    if last_warn is not None:
+        warn_at = _parse_ts(last_warn["at"])
+        if last_activity > warn_at:
+            # Fresh author activity since the warn -> clear the label and
+            # the warn record; a later idle period re-arms from scratch.
+            if not dry_run:
+                gh.remove_label(pr_number, AUTHOR_STALLED_LABEL)
+            state["warns"] = []
+            return {"changed": True, "action": {"type": "clear", "idle_days": round(idle_days, 2)}}
+
+    if last_warn is None:
+        if idle_days > warn_days:
+            body = (
+                f"This PR is waiting on you: {undecided_count} finding(s) need an answer — "
+                f"reply `@claude <your reasoning> #update-review`, or push the fix. It closes in "
+                f"{close_days - warn_days} days if nothing changes; reopening later is one click."
+            )
+            if not dry_run:
+                gh.create_issue_comment(pr_number, body)
+                gh.add_label(pr_number, AUTHOR_STALLED_LABEL)
+            state["warns"] = warns + [{"at": now.isoformat(), "head_sha": head_sha}]
+            return {"changed": True, "action": {
+                "type": "warn", "idle_days": round(idle_days, 2), "undecided_count": undecided_count,
+            }}
+        return {"changed": False, "action": {"type": "none", "idle_days": round(idle_days, 2)}}
+
+    warn_at = _parse_ts(last_warn["at"])
+    warn_age_days = (now - warn_at).total_seconds() / 86400.0
+    if idle_days > close_days and warn_age_days >= (close_days - warn_days):
+        body = (
+            f"Closing this PR as stale — no author activity in {round(idle_days)} day(s), past the "
+            f"{close_days}-day close threshold after the earlier stall warning. Reopening is one click "
+            f"(the Reopen button, or `gh pr reopen {pr_number}`) and the review picks up where it "
+            f"left off."
+        )
+        if not dry_run:
+            gh.close_pr(pr_number, body)
+        state["closes"] = (state.get("closes") or []) + [
+            {"at": now.isoformat(), "head_sha": head_sha, "idle_days": round(idle_days, 2)}
+        ]
+        return {"changed": True, "action": {"type": "close", "idle_days": round(idle_days, 2)}}
+
+    return {"changed": False, "action": {
+        "type": "none", "idle_days": round(idle_days, 2), "warn_age_days": round(warn_age_days, 2),
+    }}
+
+
+# ---- REVIEWER-TIME processing (step 4) ---------------------------------------
+
+
+def process_reviewer_time(
+    gh: Gh, pr_number: int, config: routing.Config, state: dict, now: datetime, dry_run: bool,
+    roles: set[str], timeline: list[dict], pr_detail: dict, reviews: list[dict],
+    last_activity: datetime,
+) -> dict:
+    escalations = list(state.get("escalations") or [])
+    actions = []
+    changed = False
+
+    for role in sorted(roles):
+        team_ref = config.teams[role]
+        clock_start = reviewer_clock_start(timeline, pr_detail, team_ref, reviews, last_activity)
+        clock_key = clock_start.isoformat()
+        waited = business_days_between(clock_start, now)
+        sla_days = config.sla[role]["business_days"]
+        escalate_to = config.sla[role]["escalate_to"]
+
+        already = any(e.get("role") == role and e.get("clock_start") == clock_key for e in escalations)
+        if waited > sla_days and not already:
+            todo = escalate_to.startswith("TODO")
+            mentioned = False
+            if todo:
+                log(f"PR #{pr_number}: sla.{role}.escalate_to is a TODO placeholder — "
+                    f"recording the breach without mentioning anyone")
+            else:
+                body = (f"@{escalate_to} — this PR has waited {waited} business day(s) for {role} "
+                        f"review (SLA: {sla_days}bd).")
+                if not dry_run:
+                    gh.create_issue_comment(pr_number, body)
+                    slack_notify(body)
+                mentioned = True
+            escalations.append({"role": role, "clock_start": clock_key, "at": now.isoformat()})
+            changed = True
+            actions.append({
+                "type": "escalate", "role": role, "waited_business_days": waited,
+                "sla_business_days": sla_days, "clock_start": clock_key,
+                "mentioned": mentioned, "escalate_to": escalate_to,
+            })
+        else:
+            actions.append({
+                "type": "none", "role": role, "waited_business_days": waited,
+                "sla_business_days": sla_days, "clock_start": clock_key,
+            })
+
+    state["escalations"] = escalations
+
+    # Defensive cleanup: a PR that's back in REVIEWER-TIME is no longer
+    # waiting on its author, so a stale review:author-stalled label/warn
+    # (left over from before the outstanding findings were answered) must
+    # not linger — nothing in review-label-reconcile.yml covers this label.
+    if state.get("warns"):
+        if not dry_run:
+            gh.remove_label(pr_number, AUTHOR_STALLED_LABEL)
+        state["warns"] = []
+        changed = True
+        actions.append({"type": "clear_stale_author_warn"})
+
+    return {"changed": changed, "actions": actions}
+
+
+# ---- sweep ------------------------------------------------------------------
+
+
+def sweep(gh: Gh, config: routing.Config, *, now: datetime, dry_run: bool,
+          state_dir: Path, evidence_uri: str) -> dict:
+    prs = gh.list_open_prs()
+    run_actions: list[dict] = []
+
+    for pr in prs:
+        pr_number = pr["number"]
+        if pr.get("isDraft"):
+            log(f"PR #{pr_number}: draft; skipping")
+            continue
+
+        try:
+            comments = gh.list_issue_comments(pr_number)
+        except Exception as exc:  # noqa: BLE001 — never let one bad PR kill the sweep
+            log(f"PR #{pr_number}: failed to list comments ({exc}); skipping")
+            continue
+
+        author_card = sentinel._find_comment(comments, sentinel.AUTHOR_MARKER)
+        legacy = sentinel._find_legacy_comment(comments) if author_card is None else None
+        if author_card is None and legacy is None:
+            log(f"PR #{pr_number}: no v3 author card or v2 pinned review — "
+                f"legacy/no-state PR, never touched")
+            continue
+
+        try:
+            pr_detail = gh.get_pr(pr_number)
+            files = gh.list_files(pr_number)
+            reviews = gh.list_reviews(pr_number)
+        except Exception as exc:  # noqa: BLE001
+            log(f"PR #{pr_number}: failed to fetch PR state ({exc}); skipping")
+            continue
+        head_sha = (pr_detail.get("head") or {}).get("sha") or pr.get("headRefOid") or ""
+
+        try:
+            kind, extra, reasons = classify_waiting_state(
+                pr_detail, files, author_card, legacy, reviews, config
+            )
+        except CorruptReviewState as exc:
+            log(f"PR #{pr_number}: REVIEW_STATE corrupt ({exc}); skipping (fail-safe)")
+            continue
+
+        if kind is None:
+            log(f"PR #{pr_number}: {reasons[-1] if reasons else 'no clock'}")
+            continue
+
+        try:
+            timeline = gh.get_timeline(pr_number)
+            if not isinstance(timeline, list):
+                raise ValueError("timeline response is not a list")
+            author_login = (pr_detail.get("user") or {}).get("login") or ""
+            created_at = pr_detail.get("created_at") or pr.get("createdAt") or ""
+            last_activity = last_author_activity(timeline, author_login, created_at)
+            if kind == "reviewer":
+                # Fail fast on bad timeline data for any required role's
+                # clock, not just the first one process_reviewer_time visits.
+                for role in extra["roles"]:
+                    reviewer_clock_start(timeline, pr_detail, config.teams[role], reviews, last_activity)
+        except Exception as exc:  # noqa: BLE001
+            log(f"PR #{pr_number}: unparsable timeline ({exc}); skipping")
+            continue
+
+        state = load_state(pr_number, evidence_uri, state_dir)
+
+        if kind == "author":
+            result = process_author_time(
+                gh, pr_number, head_sha, extra["undecided_count"], config, state, now, dry_run,
+                last_activity,
+            )
+        else:
+            result = process_reviewer_time(
+                gh, pr_number, config, state, now, dry_run, extra["roles"], timeline, pr_detail,
+                reviews, last_activity,
+            )
+
+        if result.get("changed") and not dry_run:
+            save_state(pr_number, state, evidence_uri, state_dir)
+
+        run_actions.append({"pr": pr_number, "kind": kind, "head_sha": head_sha, **result})
+
+    record = {"schema": 1, "run_at": now.isoformat(), "dry_run": dry_run, "actions": run_actions}
+    if not dry_run:
+        write_run_record(record, evidence_uri, state_dir, now)
+    return record
+
+
+# ---- CLI ----------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo")
+    parser.add_argument("--config", default=str(REPO_ROOT / ".github" / "review-routing.yml"))
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--state-dir", default=DEFAULT_STATE_DIR,
+                         help="local mirror of the pr-review/ state prefixes")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        import test_sla_sweep  # noqa: PLC0415 — the pytest file doubles as the harness
+
+        return test_sla_sweep.run_standalone()
+
+    if not args.repo:
+        parser.error("--repo is required")
+
+    try:
+        config = routing.load_config(args.config)
+    except routing.RoutingConfigError as exc:
+        for msg in exc.errors:
+            log(f"routing config error: {msg}")
+        return 1
+
+    uri = os.environ.get(EVIDENCE_URI_ENV, "").strip()
+    if not uri:
+        warn(f"{EVIDENCE_URI_ENV} unset; state recorded locally only")
+
+    gh = Gh(args.repo)
+    record = sweep(
+        gh, config, now=datetime.now(timezone.utc), dry_run=args.dry_run,
+        state_dir=Path(args.state_dir), evidence_uri=uri,
+    )
+    print(json.dumps(record, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/review-v3/sla-sweep.py
+++ b/scripts/review-v3/sla-sweep.py
@@ -290,12 +290,22 @@ def classify_waiting_state(
             reasons.append(f"{outstanding} outstanding finding(s) on the legacy review")
 
     latest_reviews = latest_review_per_user(reviews)
+    changes_requested_at: str | None = None
+    for r in latest_reviews.values():
+        if r.get("state") == "CHANGES_REQUESTED" and r.get("submitted_at"):
+            if changes_requested_at is None or r["submitted_at"] > changes_requested_at:
+                changes_requested_at = r["submitted_at"]
     if any(r.get("state") == "CHANGES_REQUESTED" for r in latest_reviews.values()):
         author_time = True
         reasons.append("latest review is CHANGES_REQUESTED")
 
     if author_time:
-        return "author", {"undecided_count": undecided_count}, reasons
+        # `changes_requested_at` lets process_author_time start the idle
+        # clock from when the author was actually asked for changes — a
+        # review landing on a branch last pushed 20 days ago must not read
+        # as 20 idle days on the next sweep.
+        return "author", {"undecided_count": undecided_count,
+                          "changes_requested_at": changes_requested_at}, reasons
 
     files_paths = [f["filename"] for f in files]
     mechanical, claims, mech_reasons = sentinel._mechanical_and_claims(pr_detail, files)
@@ -325,7 +335,10 @@ def last_author_activity(timeline: list[dict], author_login: str, pr_created_at:
     for e in timeline:
         event = e.get("event")
         if event == "committed":
-            ts = (e.get("author") or {}).get("date") or (e.get("committer") or {}).get("date")
+            # Committer date first: a rebase or cherry-pick keeps the author
+            # date, and "any push activity resets the clock" means when the
+            # commit landed, not when it was first written.
+            ts = (e.get("committer") or {}).get("date") or (e.get("author") or {}).get("date")
             if ts:
                 candidates.append(_parse_ts(ts))
         elif event == "commented":
@@ -454,9 +467,15 @@ def slack_notify(text: str) -> None:
 def process_author_time(
     gh: Gh, pr_number: int, head_sha: str, undecided_count: int, config: routing.Config,
     state: dict, now: datetime, dry_run: bool, last_activity: datetime,
+    changes_requested_at: str | None = None,
 ) -> dict:
     warn_days = config.author_staleness["warn_days"]
     close_days = config.author_staleness["close_days"]
+    # AUTHOR-TIME starts when the author was last active OR when they were
+    # last asked for changes, whichever is later — the same "when did this
+    # clock actually start" reasoning reviewer_clock_start applies.
+    if changes_requested_at:
+        last_activity = max(last_activity, _parse_ts(changes_requested_at))
     idle_days = (now - last_activity).total_seconds() / 86400.0
     warns = state.get("warns") or []
     last_warn = warns[-1] if warns else None
@@ -473,8 +492,10 @@ def process_author_time(
 
     if last_warn is None:
         if idle_days > warn_days:
+            why = (f"{undecided_count} finding(s) need an answer" if undecided_count
+                   else "a reviewer has requested changes")
             body = (
-                f"This PR is waiting on you: {undecided_count} finding(s) need an answer — "
+                f"This PR is waiting on you: {why} — "
                 f"reply `@claude <your reasoning> #update-review`, or push the fix. It closes in "
                 f"{close_days - warn_days} days if nothing changes; reopening later is one click."
             )
@@ -617,6 +638,23 @@ def sweep(gh: Gh, config: routing.Config, *, now: datetime, dry_run: bool,
 
         if kind is None:
             log(f"PR #{pr_number}: {reasons[-1] if reasons else 'no clock'}")
+            # A warned PR whose findings then got answered can land here
+            # (mechanical, no required role). Nothing else clears the label
+            # (review-label-reconcile.yml doesn't know it), so do it here.
+            state = load_state(pr_number, evidence_uri, state_dir)
+            if state.get("warns"):
+                if not dry_run:
+                    try:
+                        gh.remove_label(pr_number, AUTHOR_STALLED_LABEL)
+                    except Exception as exc:  # noqa: BLE001
+                        log(f"PR #{pr_number}: failed to clear {AUTHOR_STALLED_LABEL} ({exc})")
+                        continue
+                state["warns"] = []
+                if not dry_run:
+                    save_state(pr_number, state, evidence_uri, state_dir)
+                run_actions.append({"pr": pr_number, "kind": None, "head_sha": head_sha,
+                                    "changed": True,
+                                    "actions": [{"type": "clear_stale_author_warn"}]})
             continue
 
         try:
@@ -637,16 +675,26 @@ def sweep(gh: Gh, config: routing.Config, *, now: datetime, dry_run: bool,
 
         state = load_state(pr_number, evidence_uri, state_dir)
 
-        if kind == "author":
-            result = process_author_time(
-                gh, pr_number, head_sha, extra["undecided_count"], config, state, now, dry_run,
-                last_activity,
-            )
-        else:
-            result = process_reviewer_time(
-                gh, pr_number, config, state, now, dry_run, extra["roles"], timeline, pr_detail,
-                reviews, last_activity,
-            )
+        # The processors MUTATE (labels, comments, closes) and Gh._run raises
+        # on any failure — one `gh pr edit --add-label` error (the
+        # review:author-stalled label not created yet, say) must not abort
+        # the sweep for every PR after this one.
+        try:
+            if kind == "author":
+                result = process_author_time(
+                    gh, pr_number, head_sha, extra["undecided_count"], config, state, now, dry_run,
+                    last_activity, extra.get("changes_requested_at"),
+                )
+            else:
+                result = process_reviewer_time(
+                    gh, pr_number, config, state, now, dry_run, extra["roles"], timeline, pr_detail,
+                    reviews, last_activity,
+                )
+        except Exception as exc:  # noqa: BLE001 — never let one bad PR kill the sweep
+            log(f"PR #{pr_number}: {kind}-time processing failed ({exc}); state not saved, skipping")
+            run_actions.append({"pr": pr_number, "kind": kind, "head_sha": head_sha,
+                                "changed": False, "error": str(exc)[:300]})
+            continue
 
         if result.get("changed") and not dry_run:
             save_state(pr_number, state, evidence_uri, state_dir)

--- a/scripts/review-v3/test_sla_sweep.py
+++ b/scripts/review-v3/test_sla_sweep.py
@@ -432,9 +432,6 @@ def test_degradation_local_state_no_uri():
 
 # ---- Standalone harness --------------------------------------------------
 
-ALL_TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
-
-
 def test_changes_requested_only_clocks_from_the_review_not_the_old_push():
     """A standing CHANGES_REQUESTED on a branch last pushed 20 days ago is
     author-time, but the idle clock starts at the review, and the nudge
@@ -570,15 +567,57 @@ def test_cli_without_uri_does_not_mutate(monkeypatch, capsys):
     assert gh.comments_posted == [] and gh.labels_added == []
 
 
+def test_failed_state_upload_is_recorded_not_dropped(monkeypatch):
+    """Live bucket, upload fails: the run record must say the state did
+    not persist (the digest/human signal), not claim the warn stuck."""
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        gh.add_pr(1, comments=[author_card([("F1", "must")])], files=[docs_file_substantive()],
+                  timeline=[committed(iso(NOW - timedelta(days=16)))])
+        monkeypatch.setattr(sla_sweep._record_evidence, "upload", lambda record, key: False)
+        monkeypatch.setattr(sla_sweep, "_s3_read_json", lambda key: None)
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir,
+                                 evidence_uri="s3://bucket/pr-review")
+        a = record["actions"][0]
+        assert a["action"]["type"] == "warn" and a["state_persisted"] is False
+
+
+def test_probe_write_gates_real_runs(monkeypatch):
+    """A URI that resolves but can't be written forces dry-run before any
+    mutation; a URI that round-trips a probe does not."""
+    assert sla_sweep.resolve_mutation_mode("s3://b/pr-review", False, False, durable_ok=False)[0] is True
+    assert sla_sweep.resolve_mutation_mode("s3://b/pr-review", False, False, durable_ok=True) == (False, None)
+    store = {}
+    monkeypatch.setattr(sla_sweep._record_evidence, "upload", lambda record, key: store.__setitem__(key, record) or True)
+    monkeypatch.setattr(sla_sweep, "_s3_read_json", lambda key: store.get(key))
+    assert sla_sweep.durable_state_writable("s3://b/pr-review", NOW) is True
+    monkeypatch.setattr(sla_sweep._record_evidence, "upload", lambda record, key: False)
+    assert sla_sweep.durable_state_writable("s3://b/pr-review", NOW) is False
+    assert sla_sweep.durable_state_writable("", NOW) is False
+
+
 def run_standalone() -> int:
+    """The --self-test harness. Bound at call time (a module-level binding
+    only saw the tests defined above it — 12 of 19 at one point). Tests that
+    take pytest fixtures are pytest-only and are skipped here by name; the
+    merge-gating path (`pytest scripts/review-v3/`) collects everything."""
+    import inspect  # noqa: PLC0415
+    all_tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failures = 0
-    for t in ALL_TESTS:
+    for t in all_tests:
+        if inspect.signature(t).parameters:
+            print(f"  skip: {t.__name__} (pytest fixtures; run via pytest)")
+            continue
         try:
             t()
             print(f"  ok: {t.__name__}")
         except AssertionError as exc:
             failures += 1
             print(f"  FAIL: {t.__name__}: {exc}", file=sys.stderr)
+        except Exception as exc:  # noqa: BLE001 — a crash is a failure, not a harness abort
+            failures += 1
+            print(f"  FAIL: {t.__name__}: {type(exc).__name__}: {exc}", file=sys.stderr)
     if failures:
         print(f"{failures} sla-sweep test(s) failed", file=sys.stderr)
         return 1

--- a/scripts/review-v3/test_sla_sweep.py
+++ b/scripts/review-v3/test_sla_sweep.py
@@ -539,6 +539,37 @@ def test_stale_author_warn_cleared_on_no_clock_branch():
         assert record["actions"][0]["kind"] is None
 
 
+def test_no_durable_state_forces_dry_run():
+    """A CI runner's local state dies with the job; mutating without a
+    durable URI re-issues every warn/escalation each sweep. So: no URI and
+    no explicit --allow-local-state ⇒ dry-run, loudly."""
+    dry, why = sla_sweep.resolve_mutation_mode("", False, False)
+    assert dry is True and "DRY-RUN" in why
+    assert sla_sweep.resolve_mutation_mode("s3://b/pr-review", False, False) == (False, None)
+    assert sla_sweep.resolve_mutation_mode("", False, True) == (False, None)
+    assert sla_sweep.resolve_mutation_mode("", True, False) == (True, None)
+
+
+def test_cli_without_uri_does_not_mutate(monkeypatch, capsys):
+    """End to end through main(): stalled PR, no URI, no override → the
+    sweep runs but posts nothing, and the record says why."""
+    gh = StubGh()
+    gh.add_pr(1, comments=[author_card([("F1", "must")])], files=[docs_file_substantive()],
+              timeline=[committed(iso(NOW - timedelta(days=16)))])
+    monkeypatch.setattr(sla_sweep, "Gh", lambda repo: gh)
+    monkeypatch.delenv(sla_sweep.EVIDENCE_URI_ENV, raising=False)
+    with tempfile.TemporaryDirectory() as d:
+        import yaml  # noqa: PLC0415
+        cfg = Path(d) / "review-routing.yml"
+        cfg.write_text(yaml.safe_dump(RAW_CONFIG))
+        monkeypatch.setattr(sys, "argv", ["sla-sweep.py", "--repo", "pulumi/docs",
+                                          "--config", str(cfg), "--state-dir", d])
+        assert sla_sweep.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["dry_run"] is True and "DRY-RUN" in out["forced_dry_run"]
+    assert gh.comments_posted == [] and gh.labels_added == []
+
+
 def run_standalone() -> int:
     failures = 0
     for t in ALL_TESTS:

--- a/scripts/review-v3/test_sla_sweep.py
+++ b/scripts/review-v3/test_sla_sweep.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Tests for sla-sweep.py — author-staleness warn/close, reviewer-SLA
+escalation, business-day math, and the degradation/dry-run contracts.
+
+Runs under pytest (make test-review-pipeline) and standalone via
+`sla-sweep.py --self-test` (run_standalone below, same convention as
+test_sentinel.py). No pytest fixtures are used (no `tmp_path`) so every test
+also runs unmodified outside pytest — each test opens its own
+`tempfile.TemporaryDirectory()`, matching record-evidence.py's self-test
+style.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sla_sweep = _load("sla_sweep_under_test", HERE / "sla-sweep.py")
+import review_state  # noqa: E402
+import routing  # noqa: E402
+import sentinel  # noqa: E402
+
+HEAD = "a" * 40
+NOW = datetime(2026, 8, 31, 12, 0, tzinfo=timezone.utc)  # a Monday
+
+RAW_CONFIG = {
+    "schema": 1,
+    "teams": {
+        "docs-guild": "pulumi/docs-guild",
+        "marketing": "pulumi/docs-marketing-review",
+        "tools": "pulumi/docs-tools",
+    },
+    "bots": ["pulumi-bot"],
+    "matrix": {
+        "docs": {"mechanical": "none", "substantive": "docs-guild"},
+        "blog": {"mechanical": "none", "substantive": "marketing"},
+        "website": {"mechanical": "none", "substantive": "marketing"},
+        "programs": {"mechanical": "none", "substantive": "docs-guild"},
+        "infra": {"mechanical": "tools", "substantive": "tools", "staging_evidence": "required"},
+        "other": {"mechanical": "none", "substantive": "docs-guild"},
+    },
+    "claims_overlay": {"add": "marketing"},
+    "external_contributors": {"skip_gates": ["review-ran", "findings-answered"]},
+    "sla": {
+        "tools": {"business_days": 1, "escalate_to": "TODO-tools-lead"},
+        "docs-guild": {"business_days": 3, "escalate_to": "guild-lead"},
+        "marketing": {"business_days": 3, "escalate_to": "TODO-named-fallback"},
+    },
+    "author_staleness": {"warn_days": 14, "close_days": 21},
+    "waive": {"label": "review:waived", "log_prefix": "pr-review/waives/"},
+}
+CONFIG, _errors, _warnings = routing.validate_raw(RAW_CONFIG)
+assert CONFIG is not None, _errors
+
+
+# ---- Stub Gh --------------------------------------------------------------
+
+
+class StubGh:
+    def __init__(self, repo: str = "pulumi/docs"):
+        self.repo = repo
+        self.open_prs: list[dict] = []
+        self._pr_detail: dict[int, dict] = {}
+        self._comments: dict[int, list[dict]] = {}
+        self._files: dict[int, list[dict]] = {}
+        self._reviews: dict[int, list[dict]] = {}
+        self._timeline: dict[int, list[dict]] = {}
+        self.timeline_errors: set[int] = set()
+        self.comments_posted: list[tuple[int, str]] = []
+        self.labels_added: list[tuple[int, str]] = []
+        self.labels_removed: list[tuple[int, str]] = []
+        self.closed: list[tuple[int, str]] = []
+
+    def add_pr(self, number, *, draft=False, author="alice", created_at="2026-08-01T12:00:00Z",
+               comments=(), files=(), reviews=(), timeline=(), head_sha=HEAD):
+        self.open_prs.append({
+            "number": number, "isDraft": draft, "headRefOid": head_sha,
+            "createdAt": created_at, "author": {"login": author}, "title": "t",
+        })
+        self._pr_detail[number] = {
+            "head": {"sha": head_sha}, "draft": draft, "user": {"login": author},
+            "created_at": created_at, "number": number, "title": "t", "body": "",
+        }
+        self._comments[number] = list(comments)
+        self._files[number] = list(files)
+        self._reviews[number] = list(reviews)
+        self._timeline[number] = list(timeline)
+
+    def set_timeline(self, number, timeline):
+        self._timeline[number] = timeline
+
+    def list_open_prs(self):
+        return self.open_prs
+
+    def list_issue_comments(self, pr):
+        return self._comments[pr]
+
+    def get_pr(self, pr):
+        return self._pr_detail[pr]
+
+    def list_files(self, pr):
+        return self._files[pr]
+
+    def list_reviews(self, pr):
+        return self._reviews[pr]
+
+    def get_timeline(self, pr):
+        if pr in self.timeline_errors:
+            raise RuntimeError("gh api timeline failed")
+        return self._timeline[pr]
+
+    def create_issue_comment(self, pr, body):
+        self.comments_posted.append((pr, body))
+
+    def add_label(self, pr, label):
+        self.labels_added.append((pr, label))
+
+    def remove_label(self, pr, label):
+        self.labels_removed.append((pr, label))
+
+    def close_pr(self, pr, body):
+        self.closed.append((pr, body))
+
+
+# ---- Fixture builders (mirrors test_sentinel.py's grammar) ----------------
+
+
+def docs_file_substantive():
+    return {
+        "filename": "content/docs/iac/x.md",
+        "status": "modified",
+        "patch": "@@ -40,2 +40,3 @@\n context\n+Pulumi was founded in 2017 and 90% of teams agree.\n context",
+    }
+
+
+def infra_file():
+    return {
+        "filename": "layouts/partials/foo.html",
+        "status": "modified",
+        "patch": "@@ -1,1 +1,1 @@\n-<b>a</b>\n+<b>b</b>",
+    }
+
+
+def author_card(findings=(), state=None, head=HEAD):
+    """findings: list of (fid, section) where section is 'must' or 'answer'."""
+    must = [f for f, s in findings if s == "must"]
+    answer = [f for f, s in findings if s == "answer"]
+    lines = [
+        "<!-- CLAUDE_REVIEW 1/1 -->",
+        sentinel.AUTHOR_MARKER,
+        f"<!-- CLAUDE_REVIEW_HEAD {head} -->",
+        "## Review: author action needed — %d items block merge — Last updated x" % (len(must) + len(answer)),
+        "",
+        "### 🚨 Fix or disagree",
+        "",
+    ]
+    if must:
+        lines += ["| | ID | Where | Finding |", "|---|---|---|---|"]
+    for fid in must:
+        lines.append(f"| **{fid}** | `content/docs/iac/x.md` L10 | a problem |")
+    lines += ["", "### ❓ Questions for you", ""]
+    if answer:
+        lines += ["| | ID | Where | Finding |", "|---|---|---|---|"]
+    for fid in answer:
+        lines.append(f"| **{fid}** | `content/docs/iac/x.md` L20 | a question |")
+    lines += ["", "### ✅ Resolved since last review", "", "_none_", ""]
+    body = "\n".join(lines)
+    if state is None:
+        state = review_state.empty_state()
+        state["high_water"] = len(findings)
+    body += "\n" + review_state.serialize_block(state) + "\n"
+    body += "\n<!-- CLAUDE_REVIEW_FOOTER -->\nfooter text\n"
+    return {"id": 111, "body": body, "user": {"login": "github-actions[bot]"}}
+
+
+def clean_author_card():
+    return author_card([], state=review_state.empty_state())
+
+
+def review(user, state, submitted_at="2026-08-01T00:00:00Z"):
+    return {"user": {"login": user, "type": "User"}, "state": state, "submitted_at": submitted_at}
+
+
+def committed(date):
+    return {"event": "committed", "author": {"date": date}}
+
+
+def commented(login, date):
+    return {"event": "commented", "actor": {"login": login}, "created_at": date}
+
+
+def ready_for_review(date):
+    return {"event": "ready_for_review", "created_at": date}
+
+
+def review_requested(slug, date):
+    return {"event": "review_requested", "requested_team": {"slug": slug}, "created_at": date}
+
+
+def iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+# ---- Tests ------------------------------------------------------------------
+
+
+def test_author_stalled_warn_fires_once():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        idle_start = NOW - timedelta(days=16)  # > warn_days(14), < close_days(21)
+        gh.add_pr(1, comments=[author_card([("F1", "must")])], files=[docs_file_substantive()],
+                  timeline=[committed(iso(idle_start))])
+
+        record1 = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert len(gh.comments_posted) == 1
+        pr, body = gh.comments_posted[0]
+        assert pr == 1 and "waiting on you: 1 finding(s)" in body and "closes in 7 days" in body
+        assert gh.labels_added == [(1, sla_sweep.AUTHOR_STALLED_LABEL)]
+        state = json.loads((state_dir / "state" / "1.json").read_text())
+        assert len(state["warns"]) == 1
+        assert record1["actions"][0]["action"]["type"] == "warn"
+
+        # second sweep, same state on disk, no new activity -> no-op
+        sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert len(gh.comments_posted) == 1  # unchanged
+        assert len(gh.labels_added) == 1
+
+
+def test_close_only_after_warn_aged_enough():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        idle_start = NOW - timedelta(days=25)  # > close_days(21)
+        gh.add_pr(1, comments=[author_card([("F1", "must")])], files=[docs_file_substantive()],
+                  timeline=[committed(iso(idle_start))])
+        # warn recorded only 3 days ago -- gap needed is (21-14)=7 days
+        recent_warn_state = sla_sweep.empty_sweep_state()
+        recent_warn_state["warns"] = [{"at": iso(NOW - timedelta(days=3)), "head_sha": HEAD}]
+        sla_sweep.save_state(1, recent_warn_state, "", state_dir)
+
+        sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert gh.closed == []  # warn not aged enough yet
+
+        # age the warn past the gap and re-run
+        aged_warn_state = sla_sweep.empty_sweep_state()
+        aged_warn_state["warns"] = [{"at": iso(NOW - timedelta(days=8)), "head_sha": HEAD}]
+        sla_sweep.save_state(1, aged_warn_state, "", state_dir)
+
+        sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert len(gh.closed) == 1 and gh.closed[0][0] == 1
+        assert "Closing this PR as stale" in gh.closed[0][1]
+
+
+def test_activity_clears_warn_and_label():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        recent_activity = NOW - timedelta(days=1)  # fresh -- well under warn_days
+        gh.add_pr(1, comments=[author_card([("F1", "must")])], files=[docs_file_substantive()],
+                  timeline=[committed(iso(recent_activity))])
+        seeded = sla_sweep.empty_sweep_state()
+        seeded["warns"] = [{"at": iso(NOW - timedelta(days=10)), "head_sha": HEAD}]
+        sla_sweep.save_state(1, seeded, "", state_dir)
+
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert gh.labels_removed == [(1, sla_sweep.AUTHOR_STALLED_LABEL)]
+        assert record["actions"][0]["action"]["type"] == "clear"
+        state = json.loads((state_dir / "state" / "1.json").read_text())
+        assert state["warns"] == []
+
+
+def test_reviewer_sla_escalates_once_per_clock_epoch():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        created = NOW - timedelta(days=10)  # well past docs-guild's 3 business days
+        gh.add_pr(1, comments=[clean_author_card()], files=[docs_file_substantive()],
+                  created_at=iso(created), timeline=[])
+
+        sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert len(gh.comments_posted) == 1
+        assert "guild-lead" in gh.comments_posted[0][1]
+        assert "docs-guild" in gh.comments_posted[0][1]
+        state = json.loads((state_dir / "state" / "1.json").read_text())
+        assert len(state["escalations"]) == 1
+
+        # same clock epoch (no new review_requested/commit) -> no second escalation
+        sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert len(gh.comments_posted) == 1
+
+
+def test_new_push_review_cycle_rearms():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        created = NOW - timedelta(days=10)
+        gh.add_pr(1, comments=[clean_author_card()], files=[docs_file_substantive()],
+                  created_at=iso(created), timeline=[])
+
+        sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert len(gh.comments_posted) == 1
+
+        # a fresh review-request 6 days ago starts a NEW clock epoch, still
+        # past the 3-business-day SLA measured against `now`
+        gh.set_timeline(1, [review_requested("docs-guild", iso(NOW - timedelta(days=6)))])
+        sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert len(gh.comments_posted) == 2
+        state = json.loads((state_dir / "state" / "1.json").read_text())
+        assert len(state["escalations"]) == 2
+
+
+def test_business_days_fri_to_monday():
+    friday = datetime(2026, 8, 28, 17, 0, tzinfo=timezone.utc)
+    monday = datetime(2026, 8, 31, 9, 0, tzinfo=timezone.utc)
+    next_friday = datetime(2026, 9, 4, 9, 0, tzinfo=timezone.utc)
+    assert friday.weekday() == 4 and monday.weekday() == 0
+    assert sla_sweep.business_days_between(friday, monday) == 1
+    assert sla_sweep.business_days_between(monday, monday) == 0
+    assert sla_sweep.business_days_between(monday, next_friday) == 4
+    assert sla_sweep.business_days_between(next_friday, monday) == 0  # end before start
+
+
+def test_legacy_pr_untouched():
+    """No v3 author card AND no v2 pinned review -- never touched, fail-safe."""
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        gh.add_pr(1, comments=[], files=[docs_file_substantive()])
+
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert record["actions"] == []
+        assert gh.comments_posted == [] and gh.labels_added == [] and gh.closed == []
+        assert not (state_dir / "state" / "1.json").exists()
+
+
+def test_draft_skipped():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        gh.add_pr(1, draft=True, comments=[author_card([("F1", "must")])])
+
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert record["actions"] == []
+        assert gh.comments_posted == []
+
+
+def test_todo_escalate_to_records_but_doesnt_mention():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        created = NOW - timedelta(days=5)  # well past tools' 1 business day
+        gh.add_pr(1, comments=[clean_author_card()], files=[infra_file()],
+                  created_at=iso(created), timeline=[])
+
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert gh.comments_posted == []  # TODO placeholder -> no @-mention posted
+        state = json.loads((state_dir / "state" / "1.json").read_text())
+        assert len(state["escalations"]) == 1
+        assert state["escalations"][0]["role"] == "tools"
+        action = record["actions"][0]["actions"][0]
+        assert action["type"] == "escalate" and action["mentioned"] is False
+
+
+def test_unparsable_timeline_skips():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        gh.add_pr(1, comments=[author_card([("F1", "must")])], files=[docs_file_substantive()])
+        gh.timeline_errors.add(1)
+
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert record["actions"] == []
+        assert gh.comments_posted == []
+        assert not (state_dir / "state" / "1.json").exists()
+
+
+def test_dry_run_writes_nothing():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        idle_start = NOW - timedelta(days=16)
+        gh.add_pr(1, comments=[author_card([("F1", "must")])], files=[docs_file_substantive()],
+                  timeline=[committed(iso(idle_start))])
+
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=True, state_dir=state_dir, evidence_uri="")
+        assert record["actions"][0]["action"]["type"] == "warn"  # intended action is visible
+        assert gh.comments_posted == [] and gh.labels_added == []
+        assert not (state_dir / "state").exists()
+        assert not (state_dir / "runs").exists()
+
+
+def test_degradation_local_state_no_uri():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        idle_start = NOW - timedelta(days=16)
+        gh.add_pr(1, comments=[author_card([("F1", "must")])], files=[docs_file_substantive()],
+                  timeline=[committed(iso(idle_start))])
+
+        sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert (state_dir / "state" / "1.json").is_file()
+        run_files = list((state_dir / "runs" / NOW.date().isoformat()).glob("sweep-*.json"))
+        assert len(run_files) == 1
+
+
+# ---- Standalone harness --------------------------------------------------
+
+ALL_TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+
+
+def run_standalone() -> int:
+    failures = 0
+    for t in ALL_TESTS:
+        try:
+            t()
+            print(f"  ok: {t.__name__}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"  FAIL: {t.__name__}: {exc}", file=sys.stderr)
+    if failures:
+        print(f"{failures} sla-sweep test(s) failed", file=sys.stderr)
+        return 1
+    print("all sla-sweep self-tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_standalone())

--- a/scripts/review-v3/test_sla_sweep.py
+++ b/scripts/review-v3/test_sla_sweep.py
@@ -149,6 +149,16 @@ def docs_file_substantive():
     }
 
 
+def docs_file_mechanical():
+    """A one-word typo fix: inside the tightened mechanical bar, so a PR of
+    just this file resolves to no required role (kind None)."""
+    return {
+        "filename": "content/docs/iac/x.md",
+        "status": "modified",
+        "patch": "@@ -40,3 +40,3 @@\n context\n-Run teh command.\n+Run the command.\n context",
+    }
+
+
 def infra_file():
     return {
         "filename": "layouts/partials/foo.html",
@@ -423,6 +433,81 @@ def test_degradation_local_state_no_uri():
 # ---- Standalone harness --------------------------------------------------
 
 ALL_TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+
+
+def test_changes_requested_only_clocks_from_the_review_not_the_old_push():
+    """A standing CHANGES_REQUESTED on a branch last pushed 20 days ago is
+    author-time, but the idle clock starts at the review, and the nudge
+    must not say "0 finding(s)"."""
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        old_push = NOW - timedelta(days=20)
+        gh.add_pr(1, comments=[clean_author_card()], files=[docs_file_substantive()],
+                  timeline=[committed(iso(old_push))],
+                  reviews=[review("bob", "CHANGES_REQUESTED", iso(NOW - timedelta(days=2)))])
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert record["actions"][0]["kind"] == "author"
+        assert record["actions"][0]["action"]["type"] == "none"  # 2 idle days, not 20
+        assert gh.comments_posted == [] and gh.labels_added == []
+
+        # Now let the review itself age past warn_days: the nudge fires and
+        # names the reason rather than a zero count.
+        later = NOW + timedelta(days=13)
+        record = sla_sweep.sweep(gh, CONFIG, now=later, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert record["actions"][0]["action"]["type"] == "warn"
+        assert len(gh.comments_posted) == 1
+        body = gh.comments_posted[0][1]
+        assert "a reviewer has requested changes" in body and "0 finding(s)" not in body
+
+
+def test_committer_date_beats_author_date():
+    """A rebase keeps the author date; the push is what resets the clock."""
+    ev = {"event": "committed",
+          "author": {"date": iso(NOW - timedelta(days=40))},
+          "committer": {"date": iso(NOW - timedelta(days=1))}}
+    got = sla_sweep.last_author_activity([ev], "alice", iso(NOW - timedelta(days=60)))
+    assert got == sla_sweep._parse_ts(iso(NOW - timedelta(days=1)))
+
+
+def test_mutation_failure_does_not_abort_the_sweep():
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        idle_start = NOW - timedelta(days=16)
+        for n in (1, 2):
+            gh.add_pr(n, comments=[author_card([("F1", "must")])], files=[docs_file_substantive()],
+                      timeline=[committed(iso(idle_start))])
+        calls = []
+        real_add = gh.add_label
+        def flaky_add(pr, label):
+            calls.append(pr)
+            if pr == 1:
+                raise RuntimeError("label not found")
+            return real_add(pr, label)
+        gh.add_label = flaky_add
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        by_pr = {a["pr"]: a for a in record["actions"]}
+        assert "error" in by_pr[1] and by_pr[1]["changed"] is False
+        assert by_pr[2]["action"]["type"] == "warn"  # PR 2 still processed
+        assert not (state_dir / "state" / "1.json").exists()  # failed PR's state not saved
+
+
+def test_stale_author_warn_cleared_on_no_clock_branch():
+    """Warned PR whose findings got answered and which now resolves to
+    'mechanical, no required role': the label must not leak."""
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        gh.add_pr(1, comments=[clean_author_card()], files=[docs_file_mechanical()],
+                  timeline=[committed(iso(NOW - timedelta(days=1)))])
+        warned = sla_sweep.empty_sweep_state()
+        warned["warns"] = [{"at": iso(NOW - timedelta(days=3)), "head_sha": HEAD}]
+        sla_sweep.save_state(1, warned, "", state_dir)
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert gh.labels_removed == [(1, sla_sweep.AUTHOR_STALLED_LABEL)]
+        assert json.loads((state_dir / "state" / "1.json").read_text())["warns"] == []
+        assert record["actions"][0]["kind"] is None
 
 
 def run_standalone() -> int:

--- a/scripts/review-v3/test_sla_sweep.py
+++ b/scripts/review-v3/test_sla_sweep.py
@@ -488,9 +488,38 @@ def test_mutation_failure_does_not_abort_the_sweep():
         gh.add_label = flaky_add
         record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
         by_pr = {a["pr"]: a for a in record["actions"]}
+        # A label failure is best-effort: the warn still counts, its record
+        # is saved, PR 2 is processed as usual …
+        assert by_pr[1]["action"]["type"] == "warn" and by_pr[2]["action"]["type"] == "warn"
+        assert (state_dir / "state" / "1.json").exists()
+        assert [pr for pr, _ in gh.comments_posted] == [1, 2]
+        # … and — the review's second-order case — the nudge is NOT re-posted
+        # on the next sweep while add_label keeps failing.
+        sla_sweep.sweep(gh, CONFIG, now=NOW + timedelta(hours=2), dry_run=False, state_dir=state_dir, evidence_uri="")
+        assert [pr for pr, _ in gh.comments_posted] == [1, 2]
+        assert calls.count(1) == 1  # no retry storm either
+
+
+def test_comment_failure_is_fatal_for_that_pr_only():
+    """Comments stay fatal (never retried blind); the sweep continues."""
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d)
+        gh = StubGh()
+        idle_start = NOW - timedelta(days=16)
+        for n in (1, 2):
+            gh.add_pr(n, comments=[author_card([("F1", "must")])], files=[docs_file_substantive()],
+                      timeline=[committed(iso(idle_start))])
+        real_comment = gh.create_issue_comment
+        def flaky_comment(pr, body):
+            if pr == 1:
+                raise RuntimeError("502")
+            return real_comment(pr, body)
+        gh.create_issue_comment = flaky_comment
+        record = sla_sweep.sweep(gh, CONFIG, now=NOW, dry_run=False, state_dir=state_dir, evidence_uri="")
+        by_pr = {a["pr"]: a for a in record["actions"]}
         assert "error" in by_pr[1] and by_pr[1]["changed"] is False
-        assert by_pr[2]["action"]["type"] == "warn"  # PR 2 still processed
-        assert not (state_dir / "state" / "1.json").exists()  # failed PR's state not saved
+        assert not (state_dir / "state" / "1.json").exists()
+        assert by_pr[2]["action"]["type"] == "warn"
 
 
 def test_stale_author_warn_cleared_on_no_clock_branch():


### PR DESCRIPTION
Phase 5 machinery of the docs-review v3 rollout, split out of #21340 to keep that PR inside the 15k-line review budget. Stacked on the machinery branch.

`scripts/review-v3/sla-sweep.py` + `review-sla-sweep.yml`: clocks derived fresh each sweep from the GitHub timeline (reviewer-stalled → one escalation per epoch; author-stalled → warn at 14 days, close at 21 only if warned ≥ 7 days earlier; legacy PRs never closed). The job runs only while `REVIEW_V3_SLA == '1'`; a manual dispatch defaults to `dry_run`. Merging changes nothing.

Verification: `--self-test` + pytest (business-day math, canned timelines, idempotency, never-close-unclassifiable); harness + lint green on the stack.
