### PR TITLE
docs: self-hosted search supports OpenSearch 3.x

### DIFF
--- a/content/docs/administration/self-hosting/components/search.md
+++ b/content/docs/administration/self-hosting/components/search.md
@@ -20,7 +20,7 @@ pulumi_cloud_feature: self-hosting
 To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends](/docs/iac/concepts/state-and-backends/).
 {{< /self-hosting-trial-note >}}
 
-Pulumi Cloud provides resource search features that require an OpenSearch cluster. Self-hosted installations require a compatible OpenSearch cluster and changes to the API container configuration to enable these features.
+Pulumi Cloud provides resource search features that require an OpenSearch cluster. Self-hosted installations require a compatible OpenSearch cluster -- both v2.x and v3.x are supported -- and changes to the API container configuration to enable these features.
 
 When the service container is launched with a valid search configuration, it will connect to the OpenSearch cluster and automatically index any existing resources managed by the self-hosted Pulumi installation.
 If the OpenSearch cluster is not reachable, then the Pulumi Console will display an error message on the Resources page indicating that the search cluster is unavailable, but will otherwise operate normally.
@@ -33,9 +33,9 @@ It is important to note that the search cluster is not in the critical path of P
 
 ## Minimum System Requirements
 
-| Type       | Properties   | Notes                                                                                                                                                                                                                                                                 |
-|------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| OpenSearch | v2.x cluster | Pulumi Cloud has been tested with OpenSearch v2.9 and v2.11                                                                                                                                                                                                           |
+| Type       | Properties           | Notes                                                                                                          |
+|------------|----------------------|----------------------------------------------------------------------------------------------------------------|
+| OpenSearch | v2.x or v3.x cluster | Pulumi Cloud runs OpenSearch v3.7. We recommend the latest patch release of either the v2.19.x or the v3.x line. |
 
 ## API Environment Variables
 

--- a/content/docs/administration/self-hosting/operations/architecture.md
+++ b/content/docs/administration/self-hosting/operations/architecture.md
@@ -30,7 +30,7 @@ This page describes the high-level architecture of a self-hosted Pulumi Cloud de
 | Component | Description |
 | :-- | :-- |
 | Object storage | Blob storage for checkpoint (state) files and policy packs. Supported: S3 and compatible implementations, Azure Blob Storage, Google Cloud Storage |
-| Search | OpenSearch 2.x or Elasticsearch 7.x for resource search and AI features |
+| Search | OpenSearch 2.x or 3.x, or Elasticsearch 7.x, for resource search and AI features |
 
 ## Data flow
 


### PR DESCRIPTION
## What

The self-hosting docs told operators the search requirement was a **v2.x cluster**, "tested with OpenSearch v2.9 and v2.11". Pulumi Cloud now runs **OpenSearch v3.7**, so that guidance was both stale and needlessly narrow — it steered self-hosted users away from a version we run in production ourselves.

| | Before | After |
|---|---|---|
| `components/search.md` | `v2.x cluster` — "tested with v2.9 and v2.11" | `v2.x or v3.x cluster` — "Pulumi Cloud runs v3.7. We recommend the latest patch release of either the v2.19.x or the v3.x line." |
| `operations/architecture.md` | `OpenSearch 2.x or Elasticsearch 7.x` | `OpenSearch 2.x or 3.x, or Elasticsearch 7.x` |

Also added the supported range to the intro paragraph, where a reader first learns a cluster is needed.

## Notes

- **Recommends version *lines*, not exact patches.** Latest at time of writing is 2.19.6 and 3.8.0; naming those pins the doc to a release cadence it can't keep up with, so it points at `v2.19.x` / `v3.x` instead.
- **`network.md` deliberately untouched** — it only documents port 9200 and makes no version claim.
- The client genuinely supports both majors: Pulumi Cloud has been running 3.7 on the same OpenSearch client that self-hosted installations use, so this records demonstrated behaviour rather than widening a support promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)