### PR TITLE
Add the /dev origin for the Dev Center

### DIFF
--- a/infrastructure/Pulumi.www-production.yaml
+++ b/infrastructure/Pulumi.www-production.yaml
@@ -9,6 +9,7 @@ config:
   www.pulumi.com:pathToOriginBucketMetadata: ../origin-bucket-metadata.json
   www.pulumi.com:registryStack: "pulumi/registry/production"
   www.pulumi.com:guidesStack: "pulumi/guides/production"
+  www.pulumi.com:devStack: "pulumi/www-site/production"
   www.pulumi.com:setRootRecord: "true"
   www.pulumi.com:websiteDomain: www.pulumi.com
   www.pulumi.com:websiteLogsBucketName: www-prod.pulumi.com-website-logs

--- a/infrastructure/Pulumi.www-testing.yaml
+++ b/infrastructure/Pulumi.www-testing.yaml
@@ -9,6 +9,7 @@ config:
   www.pulumi.com:pathToOriginBucketMetadata: ../origin-bucket-metadata.json
   www.pulumi.com:registryStack: "pulumi/registry/testing"
   www.pulumi.com:guidesStack: "pulumi/guides/testing"
+  www.pulumi.com:devStack: "pulumi/www-site/production"
   www.pulumi.com:answersStack: "pulumi/answers/testing"
   www.pulumi.com:versionedDocsStack: "pulumi/pulumi-docs-versioned/testing"
   www.pulumi.com:setRootRecord: "true"

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -990,6 +990,17 @@ if (config.devStack) {
             cachePolicyId: thirtyMinuteCachePolicy.id,
             originRequestPolicyId: allViewerExceptHostHeaderId,
         },
+        {
+            ...baseCacheBehavior,
+            targetOriginId: devCDN,
+            // The Dev Center (Astro) emits root-relative assets under /assets/*
+            // (CSS, JS, images), so those must reach the same origin as /dev or
+            // the pages render unstyled. pulumi/docs serves its own assets from
+            // /css and /js, so /assets is free to hand to marketing-web.
+            pathPattern: "/assets*",
+            cachePolicyId: thirtyMinuteCachePolicy.id,
+            originRequestPolicyId: allViewerExceptHostHeaderId,
+        },
     )
 }
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -56,6 +56,8 @@ const config = {
     // the guides stack to reference to route traffic to for `/guides` routes.
     guidesStack: stackConfig.get("guidesStack"),
 
+    devStack: stackConfig.get("devStack"),
+
     answersStack: stackConfig.get("answersStack"),
 
     // the versioned-docs storage stack (infrastructure/versioned-docs). When set, the
@@ -677,8 +679,8 @@ function cacheKeyPolicy(name: string, ttl: number, cacheKeyHeaders: string[] = [
 // "thirty-minute-cache" and "one-year-cache" names are preserved so Pulumi
 // updates them in place (adding the Brotli/Gzip flags) rather than replacing.
 //
-// thirtyMinuteCachePolicy varies on the Accept header so /registry/* and
-// /guides/* (which proxy to separate CDNs whose viewer-request functions do
+// thirtyMinuteCachePolicy varies on the Accept header so /registry/*, /guides/*,
+// and /dev/* (which proxy to separate CDNs whose viewer-request functions do
 // markdown content negotiation) cache HTML and markdown variants separately
 // at the apex layer. Without this, whichever variant populates the apex cache
 // first is served to every requester until TTL. Fragmentation is bounded to
@@ -961,6 +963,36 @@ if (config.guidesStack) {
     )
 }
 
+const devOrigins: aws.types.input.cloudfront.DistributionOrigin[] = [];
+const devBehaviors: aws.types.input.cloudfront.DistributionOrderedCacheBehavior[] = [];
+
+if (config.devStack) {
+    const devStack = new pulumi.StackReference(config.devStack);
+    const devCDN = devStack.getOutput("cloudFrontDomain");
+
+    devOrigins.push(
+        {
+            originId: devCDN,
+            domainName: devCDN,
+            customOriginConfig: {
+                originProtocolPolicy: "https-only",
+                httpPort: 80,
+                httpsPort: 443,
+                originSslProtocols: ["TLSv1.2"],
+            },
+        }
+    );
+    devBehaviors.push(
+        {
+            ...baseCacheBehavior,
+            targetOriginId: devCDN,
+            pathPattern: "/dev*",
+            cachePolicyId: thirtyMinuteCachePolicy.id,
+            originRequestPolicyId: allViewerExceptHostHeaderId,
+        },
+    )
+}
+
 // Versioned SDK & CLI docs: a permanent archive bucket (its own stack) reached as an
 // S3 website endpoint, served under /docs/versioned/*. Additive and fully optional —
 // when versionedDocsStack is unset, nothing here runs and the distribution is unchanged.
@@ -1131,6 +1163,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         },
         ...registryOrigins,
         ...guidesOrigins,
+        ...devOrigins,
         ...answersOrigins,
         ...versionedDocsOrigins,
         ...supportFormOrigins,
@@ -1162,6 +1195,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
 
         ...registryBehaviors,
         ...guidesBehaviors,
+        ...devBehaviors,
         ...answersBehaviors,
 
         // Versioned docs archives. Must come BEFORE /docs/reference/pkg/dotnet/* and

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -14,4 +14,9 @@ Disallow: /docs/search/$
 # Disallow azure-native-v2. See https://github.com/pulumi/pulumi-azure-native/issues/3420 for details.
 Disallow: /registry/packages/azure-native-v2
 
+# Keep the Dev Center (/dev) out of search until the cutover. Removed then, when
+# the redirects land and a Sitemap line for /dev/sitemap-index.xml is added.
+Disallow: /dev$
+Disallow: /dev/
+
 Sitemap: https://www.pulumi.com/sitemap-index.xml

--- a/scripts/run-pulumi.sh
+++ b/scripts/run-pulumi.sh
@@ -34,7 +34,7 @@ case ${PULUMI_ACTION} in
             echo "Invalidating CloudFront cache for distribution ${DISTRIBUTION_ID}..."
             if aws cloudfront create-invalidation \
                 --distribution-id "${DISTRIBUTION_ID}" \
-                --paths "/docs/*" "/registry/*" "/blog/*" "/tutorials/*" "/guides/*" "/product/*" "/pricing/*" "/contact/*" "/index.html" "/"; then
+                --paths "/docs/*" "/registry/*" "/blog/*" "/tutorials/*" "/dev/*" "/guides/*" "/product/*" "/pricing/*" "/contact/*" "/index.html" "/"; then
                 echo "CloudFront cache invalidation submitted successfully."
             else
                 echo "WARNING: CloudFront cache invalidation failed. Content will refresh within 30 minutes."


### PR DESCRIPTION
Adds a `/dev*` CloudFront behavior proxying to the pulumi/www-site (marketing-web) distribution, plus `/dev/*` in the deploy invalidation paths. Purely additive — `/dev` serves the new Dev Center while `/tutorials` and `/templates` stay live and untouched. Redirects, relinking, nav, and the robots.txt sitemap line follow in the cutover PR.

Requires the `pulumi/www-site/production` stack (marketing-web) to be deployed first, since the behavior references its `cloudFrontDomain` output.

Successfully deployed to testing here: https://www.pulumi-test.io/dev/

<img width="1177" height="1323" alt="image" src="https://github.com/user-attachments/assets/97f5bbc8-8e79-4e4c-bb50-86b538572cde" />
