### PR TITLE
validate-pinned: accept the composer's count when a v3 row is rewritten in place

### DIFF
--- a/.claude/commands/docs-review/scripts/test_validate_pinned_v3.py
+++ b/.claude/commands/docs-review/scripts/test_validate_pinned_v3.py
@@ -146,6 +146,23 @@ def test_model_added_placeholder_row_is_legal() -> None:
     assert "v3-blocking-count" not in ids
 
 
+def test_blocking_count_accepts_composed_count_over_in_place_rewrite() -> None:
+    """The model rewrote F1 in place as Spurious and, as instructed, left the
+    composer's header alone. build-evidence.py recomputes the header after
+    validation, so the composed count (3) is legal here — and so is the
+    recomputed one (2), which the update/resolve lanes re-validate
+    (pulumi/docs#21372: refusing the composed count failed the review)."""
+    row = next(l for l in AUTHOR.splitlines() if l.startswith("| **F1** |"))
+    cells = row.split(" | ")
+    cells[-1] = "**Spurious:** the comparison was against stale data |"
+    rewritten = AUTHOR.replace(row, " | ".join(cells))
+    assert "v3-blocking-count" not in rule_ids(check(author=rewritten))
+    recomputed = rewritten.replace("guide v1 — 3 items block merge", "guide v1 — 2 items block merge")
+    assert "v3-blocking-count" not in rule_ids(check(author=recomputed))
+    still_wrong = rewritten.replace("guide v1 — 3 items block merge", "guide v1 — 1 item blocks merge")
+    assert "v3-blocking-count" in rule_ids(check(author=still_wrong))
+
+
 def test_blocking_count_mismatch() -> None:
     wrong = AUTHOR.replace("guide v1 — 3 items block merge", "guide v1 — 7 items block merge")
     assert "v3-blocking-count" in rule_ids(check(author=wrong))

--- a/.claude/commands/docs-review/scripts/validate-pinned.py
+++ b/.claude/commands/docs-review/scripts/validate-pinned.py
@@ -2978,15 +2978,30 @@ def check_v3_blocking_count(ctx: Context) -> list[Violation]:
         state = {}
     answered = {fid for fid, e in (state.get("findings") or {}).items() if isinstance(e, dict)}
 
-    def _blocking(p: dict | None) -> bool:
-        return bool(p) and p["id"] not in answered and not _V3_REWRITTEN_RE.match(p["body"])
+    def _open(p: dict | None) -> bool:
+        return bool(p) and p["id"] not in answered
 
+    def _blocking(p: dict | None) -> bool:
+        return _open(p) and not _V3_REWRITTEN_RE.match(p["body"])
+
+    # Two counts are legal, because the header is recomputed AFTER this
+    # rule runs. The model is told never to hand-edit it: a row it rewrites
+    # in place as Spurious/Mis-sourced/Pre-existing therefore still shows in
+    # the composer's count on the draft (build-evidence.py files the rewrite
+    # and recomputes the header before publish), while the published body
+    # the update/resolve lanes re-validate already carries the recomputed,
+    # rewrite-excluded count. Accepting only the latter refused every review
+    # that dismissed a finding in place (pulumi/docs#21372, 2026-09-03: one
+    # 🚨 row rewritten Spurious, header still "1 item", review:error).
     total = sum(1 for _, _, p in rows if _blocking(p) or p is None)
     numbered = sum(1 for _, _, p in rows if _blocking(p) and p["id"] != "F?")
+    composed_total = sum(1 for _, _, p in rows if _open(p) or p is None)
+    composed_numbered = sum(1 for _, _, p in rows if _open(p) and p["id"] != "F?")
     stated = int(m.group(1)) if m.group(1) else 0
-    if stated not in (total, numbered):
+    if stated not in (total, numbered, composed_total, composed_numbered):
         return [Violation("v3-blocking-count", "<author header>",
-                          f"(N blocking) matches the open 🚨+❓ row count ({numbered} composed, {total} with additions; dispositioned and rewritten rows excluded)",
+                          f"(N blocking) matches the open 🚨+❓ row count ({numbered} composed, {total} with additions; "
+                          f"dispositioned rows excluded; rewritten rows may count either way: {composed_numbered}/{composed_total})",
                           f"header says {stated}",
                           "Don't hand-edit the count; if you removed a row, disposition it instead (Spurious/Mis-sourced/Pre-existing rewrite) — build-evidence.py recomputes the header.")]
     return []


### PR DESCRIPTION
First real-traffic v3 failure: pulumi/docs#21372 (glow-up bot PR, re-reviewed on `surface:v3`) landed `review:error` instead of a card. The model dismissed the only 🚨 finding in place as `**Spurious:**` and, as instructed, left the header alone; `v3-blocking-count` only accepted the rewrite-excluded count, so the composer's "1 item blocks merge" was refused and the run never reached build-evidence.py, which is what recomputes the header.

The rule now accepts either count. Verified against the actual failed draft from run 33776049588: validates clean, builds, header recomputes to "nothing blocks merge", evidence object schema-valid. Regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgQPx7TyE73KH1Bk4TBfHq
