### PR TITLE
claims-reverify: verify per claim text, give the verifier the page, stop marking on framing-drift

### DIFF
--- a/.claude/commands/docs-review/scripts/verify-claims.py
+++ b/.claude/commands/docs-review/scripts/verify-claims.py
@@ -688,6 +688,19 @@ def build_user_message(claim: dict, route: str, evidence_pack: dict | None,
         lines.append(f"- source_hint: {claim['source_hint']}")
     if claim.get("found_by"):
         lines.append(f"- found_by: {', '.join(str(x) for x in claim['found_by'])}")
+    # Set by callers that verify from the claims index (reverify-claims.py),
+    # where the claim arrives without the page: the extracted sentence may
+    # have lost the scope its heading establishes, and this puts it back.
+    if claim.get("context"):
+        lines += [
+            "",
+            "Where the page makes this claim — the heading it sits under and the "
+            "surrounding prose. The claim's scope is whatever this establishes; "
+            "judge the claim as the page states it there, not the sentence alone:",
+            "```",
+            str(claim["context"]),
+            "```",
+        ]
     if impl_refs and route in ("pass1", "pass3"):
         lines += [
             "",

--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -58,6 +58,7 @@ Read `.content-review-queue.json` from the repo root (written by
       "stale_claims": 1,
       "stale_claim_markers": [
         { "entity_key": "version/pulumi-package",
+          "claim_text": "Package source is saved to `packages` in Pulumi.yaml as of Pulumi 3.157.0.",
           "verdict": "contradicted",
           "evidence": "CHANGELOG lists \"Save package source to `packages` in Pulumi.yaml on `package add`\" under 3.163.0, not 3.157.0.",
           "source": "gh api repos/pulumi/pulumi/releases",
@@ -78,7 +79,9 @@ Read `.content-review-queue.json` from the repo root (written by
   nightly re-verification found contradicted (see §Claims index below). A
   non-zero count is why the page jumped the queue.
 - `stale_claim_markers` (when present) — **those findings in full**, each with
-  the `entity_key`, the `verdict`, the `evidence` the nightly verifier
+  the `entity_key`, the `claim_text` (the exact sentence the nightly verifier
+  checked — search the page for it; a marker without one predates 2026-09 and
+  names only the entity), the `verdict`, the `evidence` the nightly verifier
   recorded, the `source` it reached, and `unresolved_reviews` (how many prior
   reviews saw this marker and left it unresolved). **These are the highest-
   priority findings in your queue and you must address every one of them.**

--- a/.github/workflows/claims-reverify.yml
+++ b/.github/workflows/claims-reverify.yml
@@ -53,6 +53,21 @@ name: "Scheduled jobs: Re-verify volatile claims"
 #     such a check can never detect drift. Expect `fresh` to read far lower
 #     than it did on those two nights; the difference was never real.
 #
+# 2026-09-03: the lane marked two pages for a claim only one of them made.
+# `version/pulumi-cli` keys every version claim about the CLI; the freshest
+# was verified and the verdict fanned out to both pages. The verdict itself
+# was `framing-drift` on an extracted sentence that had lost its "AWS KMS"
+# heading. Both pages burned a review slot that afternoon (#21370, #21374).
+# Since then the unit of verification is the distinct claim text — one call
+# per wording, a marker only on the pages that share it, `claim_text` in the
+# marker — the verifier gets the page path and the heading + prose around
+# the claim, and `framing-drift` is reported but never marked (see
+# SOFT_VERDICTS and claim_groups in reverify-claims.py). A retro over the 16
+# nights with report artifacts (320 checks): 5 stale, of which that one was
+# false; 135 fresh; 174 inconclusive — 148 of them, 46% of every call the
+# lane has made, demoted for citing only our own docs, the same 42 entities
+# every rotation. That waste is the next fix, not this one.
+#
 # DEGRADATION HEALTH: this lane only Slacks when it finds STALE entities, so a
 # dead lane (claims index gone, API key missing, every check inconclusive)
 # would otherwise look identical to a healthy quiet one. The health steps at
@@ -252,16 +267,29 @@ jobs:
             --data "$(jq -n --arg ch "#docs-ops" --arg txt "$TEXT" \
               '{channel: $ch, text: $txt, unfurl_links: false}')"
 
-      # Counts only + a run link — the evidence lives in the report artifact
-      # and the ledger markers; the fix arrives as a normal content-review PR.
+      # Counts, the pages that were marked, and a run link — the evidence
+      # lives in the report artifact and the ledger markers; the fix arrives
+      # as a normal content-review PR. The counts are the honest split, not
+      # "N of M stale": on 2026-09-03 "2 of 20" read as eighteen clean when
+      # eight had verified and ten could not be checked at all. The marked
+      # pages are listed because a wrong one (same day: a page marked for a
+      # claim it never made) is obvious in a list and invisible in a count.
       - name: Post stale summary to Slack
         if: steps.reverify.outputs.has_stale == 'true'
         env:
           SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
         run: |
           TEXT=$(jq -r --arg run "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" '
-            "Nightly claims re-verify: \(.meta.n_stale) of \(.meta.n_checked) checked volatile entities are stale. " +
-            "Affected pages are boosted into the next content-review sweep. <\($run)|Run log>"
+            "Nightly claims re-verify: \(.meta.n_stale) stale · \(.meta.n_fresh) fresh · "
+            + "\(.meta.n_inconclusive) could not be verified"
+            + (if (.meta.n_demoted // 0) > 0 then " (\(.meta.n_demoted) cited only our own docs)" else "" end)
+            + (if (.meta.n_soft // 0) > 0 then " · \(.meta.n_soft) framing note(s), reported not marked" else "" end)
+            + " — \(.meta.n_checked) claims across \(.meta.n_due) entities.\n"
+            + "Marked for the next content-review sweep:"
+            + (if ((.meta.marked_pages // []) | length) > 0
+               then "\n" + ([.meta.marked_pages[] | "  • \(.)"] | join("\n"))
+               else " none (every stale page is generated or has no ledger entry)" end)
+            + "\n<\($run)|Run log>"
           ' .claims-reverify-report.json)
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \

--- a/scripts/content-review/reverify-claims.py
+++ b/scripts/content-review/reverify-claims.py
@@ -11,8 +11,12 @@ night instead of waiting for the page's next staleness-driven sweep.
 
 How a stale finding flows (no new human burden, no prose generation):
   1. An entity re-verifies `contradicted`/`mismatch`.
-  2. Every page asserting that entity gets a `stale_claims` marker written
-     into its LEDGER object (`ledger/<slug>.json`) — evidence attached. A page
+  2. Every page stating that claim gets a `stale_claims` marker written into
+     its LEDGER object (`ledger/<slug>.json`) — evidence and the claim text
+     attached, so the reviewing worker looks for that sentence rather than
+     re-deriving the finding. A page that words a different fact under the
+     same entity key is not marked (see `claim_groups`); neither is a page a
+     PR here cannot edit (`editable: false` in strategic-tiers.yaml). A page
      with no ledger object yet is skipped rather than stubbed: the marker
      write is a whole-object overwrite of a key `record-review.py` owns.
   3. `select-articles.py` adds a large additive boost for marked pages, so
@@ -20,17 +24,26 @@ How a stale finding flows (no new human burden, no prose generation):
      re-reviews the page, fixes it through the existing PR machinery, and
      its ledger/claims rewrites clear the marker automatically.
 
-Selection (deterministic, stateless): volatile keyed entities are deduped
-across pages (one verification per entity per night, fanned back out to all
-pages asserting it), entities already marked stale are skipped (they're
-waiting on a review, not on another check), the rest are sorted by entity
-key and swept in day-rotated chunks of `--count` — days-since-epoch modulo
-the chunk count picks tonight's chunk, so the whole volatile set is covered
-every ceil(N/count) nights with no persisted cursor.
+Selection (deterministic, stateless): volatile keyed entities are grouped
+across pages, entities with nothing live to check are held out (every claim
+already marked stale — waiting on a review, not on another check — or
+superseded by a newer review), the rest are sorted by entity key and swept in
+day-rotated chunks of `--count` — days-since-epoch modulo the chunk count
+picks tonight's chunk, so the whole volatile set is covered every
+ceil(N/count) nights with no persisted cursor.
+
+Inside a due entity, the unit of verification is each DISTINCT CLAIM TEXT
+(`claim_groups`): the entity key names the subject and drops the value, so
+`version/pulumi-cli` legitimately holds several different facts, and a
+verdict on one must reach only the pages that state it. Identical wording on
+several pages is still one call, fanned back out to all of them.
 
 Verification reuses `verify-claims.py`'s per-claim machinery (routing +
-agent-loop verifier) by module import; each entity's freshest claim record is
-the input. `contradicted`/`mismatch` → stale; `verified`/`matches` → fresh;
+agent-loop verifier) by module import; each group's freshest claim record is
+the input, with the page path and the heading + surrounding prose the claim
+sits under (`page_context`), so the verifier judges the claim as the page
+scopes it. `contradicted`/`mismatch` → stale; `framing-drift` → soft
+(reported, never marked — see SOFT_VERDICTS); `verified`/`matches` → fresh;
 anything else (`unverifiable`, errors) → inconclusive, reported but never
 marked — a flaky check must not burn review-queue slots.
 
@@ -72,11 +85,23 @@ ENTITY_KEY = HERE / ".claude/commands/docs-review/scripts/entity_key.py"
 SCHEMA_VERSION = 1
 DEFAULT_COUNT = 25
 MAX_CONCURRENCY = 8
-STALE_VERDICTS = {"contradicted", "mismatch", "framing-drift"}
+STALE_VERDICTS = {"contradicted", "mismatch"}
+# `framing-drift` says the claim is true but drawn too broadly. Reported, never
+# marked. This lane hands the verifier one extracted sentence, and extraction
+# routinely drops the scope the enclosing heading establishes: "add awssdk=v2
+# to the query string" under an "AWS KMS" heading came out of the index as a
+# claim about every AWS query string, and on 2026-09-03 its framing verdict
+# marked two pages — one of which never made the claim — and both burned a
+# review slot. A framing verdict here is a verdict on the extraction as often
+# as on the page. The PR-review pipeline keeps it because it reads the diff.
+SOFT_VERDICTS = {"framing-drift"}
 FRESH_VERDICTS = {"verified", "matches"}
 # Verdicts that assert something either way, and so have to rest on evidence
 # from outside the docs corpus to mean anything.
-DECIDED_VERDICTS = STALE_VERDICTS | FRESH_VERDICTS
+DECIDED_VERDICTS = STALE_VERDICTS | SOFT_VERDICTS | FRESH_VERDICTS
+# Lines of page read around a claim for the verifier's context: the enclosing
+# heading plus this many lines either side of the claim's own line range.
+CONTEXT_LINES = 6
 
 # Lazily-imported select-articles module (tier semantics live there).
 _SELECT = None
@@ -219,15 +244,92 @@ def volatile_entities(snapshots: list[dict], is_volatile=None) -> dict[str, list
     return entities
 
 
+def _norm_text(text) -> str:
+    """Whitespace-collapsed, case-folded claim text — the grouping key."""
+    return " ".join(str(text or "").split()).lower()
+
+
+def claim_groups(assertions: list[dict]) -> list[tuple[str, list[dict]]]:
+    """One entity's assertions split by what they actually say.
+
+    The entity key names the SUBJECT ("version/pulumi-cli"), and by design
+    drops the value, so it joins claims across pages and across time — that is
+    what lets a price change be caught on every page that quotes it. But the
+    same key also collects DIFFERENT facts about one subject: on 2026-09-03
+    `version/pulumi-cli` held "as of v3.33.1 the awskms URL takes
+    awssdk=v2&profile=" on one page and "since v3.35.3 pluginDownloadURL
+    understands github://" on another. Verifying one and fanning the verdict
+    out to both marked a page for a claim it never made.
+
+    So the unit of verification is the claim text, not the entity: each group
+    is verified on its own and only its own pages can be marked. Identical
+    wording on several pages still costs one call. Returns [(text, assertions)]
+    in first-seen order; `text` is the freshest assertion's original wording.
+    """
+    by_key: dict[str, list[dict]] = {}
+    for a in assertions:
+        by_key.setdefault(_norm_text(a["claim"].get("text")), []).append(a)
+    return [(representative(group).get("text") or "", group) for group in by_key.values()]
+
+
 def already_marked(key: str, assertions: list[dict], ledger: dict[str, dict]) -> bool:
-    """True when some page asserting this entity already carries its stale
-    marker — the entity is waiting on a review, not on another check."""
+    """True when some page asserting this claim already carries its stale
+    marker — the claim is waiting on a review, not on another check.
+
+    `assertions` is one entity's assertions of ONE claim text (see
+    `claim_groups`). A marker written since 2026-09 carries `claim_text`, and
+    only a marker for the same text counts: a marker for one claim under
+    `version/pulumi-cli` must not hold a different claim under the same key on
+    another page out of the rotation. A legacy marker with no `claim_text`
+    matches on the key alone, as it always did.
+    """
+    texts = {_norm_text(a["claim"].get("text")) for a in assertions}
     for a in assertions:
         entry = ledger.get(a["path"]) or {}
         for m in entry.get("stale_claims") or []:
-            if isinstance(m, dict) and m.get("entity_key") == key:
+            if not isinstance(m, dict) or m.get("entity_key") != key:
+                continue
+            if not m.get("claim_text") or _norm_text(m["claim_text"]) in texts:
                 return True
     return False
+
+
+_HEADING_RE = re.compile(r"^#{1,6}\s")
+_LINE_RANGE_RE = re.compile(r"L(\d+)(?:-(\d+))?")
+
+
+def page_context(repo_root: Path | None, path: str, line_range: str) -> str:
+    """The heading a claim sits under plus the prose around it, for the verifier.
+
+    The claims index persists each claim's `line_range` ("L676-680", or
+    several ranges "L90, L93-94"), and the runner has the checkout, so the
+    scope extraction dropped is recoverable at verification time: the nearest
+    heading above the first cited line, then CONTEXT_LINES either side of the
+    cited span. Empty when anything is missing — the verifier then sees the
+    claim exactly as it did before this existed, never a wrong excerpt.
+    """
+    if repo_root is None or not path:
+        return ""
+    spans = [(int(a), int(b or a)) for a, b in _LINE_RANGE_RE.findall(line_range or "")]
+    if not spans:
+        return ""
+    try:
+        lines = (repo_root / path).read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return ""
+    first = min(s[0] for s in spans)
+    last = max(s[1] for s in spans)
+    if first < 1 or first > len(lines):
+        return ""
+    heading = ""
+    for i in range(first - 1, -1, -1):
+        if _HEADING_RE.match(lines[i]):
+            heading = lines[i].strip()
+            break
+    lo = max(first - 1 - CONTEXT_LINES, 0)
+    hi = min(last + CONTEXT_LINES, len(lines))
+    body = "\n".join(lines[lo:hi]).strip()
+    return f"{heading}\n\n{body}".strip() if heading else body
 
 
 def superseded_by_review(assertions: list[dict], ledger: dict[str, dict]) -> bool:
@@ -434,8 +536,9 @@ def load_ledger(ledger_dir: Path) -> dict[str, dict]:
 
 
 def apply_markers(ledger: dict[str, dict], stale: list[dict], today: date,
-                  repo_root: Path | None = None) -> dict[str, dict]:
-    """Fold stale entity verdicts into the affected pages' ledger entries.
+                  repo_root: Path | None = None,
+                  tier_rules: list[dict] | None = None) -> dict[str, dict]:
+    """Fold stale claim verdicts into the affected pages' ledger entries.
 
     Returns {slug: updated entry (without bookkeeping keys)} for every entry
     that changed. Idempotent: a marker for an already-marked entity_key is
@@ -456,11 +559,27 @@ def apply_markers(ledger: dict[str, dict], stale: list[dict], today: date,
     guard existed. Such a contradiction is real and worth acting on, but the
     action is upstream of this repo (fix the `data/` source or the product
     metadata behind it), so the verdict is reported and left in the pool rather
-    than converted into a marker nothing can retire."""
+    than converted into a marker nothing can retire.
+
+    The same guard has to cover a page that IS on disk but that no PR may
+    edit — `editable: false` in strategic-tiers.yaml, the 254-file CLI command
+    reference being the big one. `fix_route()` already routes a claim whose
+    every page is such a tree upstream, but a claim that spans one editable
+    page and one generated page routes `local`, and the file check alone would
+    then mark the generated page too. The fix lane selects only editable pages,
+    so that marker could never be resolved there, and `already_marked()`
+    would hold the claim out of the rotation until the report lane happened
+    to rewrite the page's ledger entry. `tier_rules` is the same list
+    `fix_route()` reads; None (the pure-logic callers) checks files only."""
     changed: dict[str, dict] = {}
     for s in stale:
         marker = {
             "entity_key": s["entity_key"],
+            # The sentence the verdict is about. record-review.py carries every
+            # marker field forward, and the worker skill reads markers in
+            # full, so this reaches the reviewer as "find THIS sentence"
+            # rather than "find something about this entity".
+            "claim_text": s.get("claim_text") or "",
             "verdict": s["verdict"],
             "evidence": s.get("evidence") or "",
             "source": s.get("source") or "",
@@ -471,6 +590,12 @@ def apply_markers(ledger: dict[str, dict], stale: list[dict], today: date,
                 warn(
                     f"{page['path']} has no source file (generated page); reporting "
                     f"{s['entity_key']} without a marker no review could ever clear"
+                )
+                continue
+            if tier_rules and not _policy_for(page["path"], tier_rules).editable:
+                warn(
+                    f"{page['path']} is generated (editable: false); reporting "
+                    f"{s['entity_key']} without a marker no fix-lane review could clear"
                 )
                 continue
             entry = ledger.get(page["path"])
@@ -555,10 +680,87 @@ def inconclusive_breakdowns(results: list[dict]) -> tuple[dict, dict]:
     return (dict(sorted(by_type.items())), dict(sorted(by_reason.items())))
 
 
+def tally(results: list[dict], known_upstream: dict[str, dict],
+          upstream_repos: list[dict], repo_root: Path | None,
+          tier_rules: list[dict] | None) -> tuple[dict, list[dict]]:
+    """The report's verdict counts and the markable `stale` list, from the
+    verified results. Pure, so the accounting — which verdicts mark, which
+    only report, what counts as inconclusive — is pinned by the self-test
+    without a verifier in the loop. Annotates each result with `fix_route` /
+    `upstream` (and the upstream issue pointer or filing link) in place.
+    """
+    # Split contradicted results by whether anything in this repo could act on
+    # them. `upstream` findings are real and stay in the rotation forever: no
+    # marker (nothing could ever retire it), no queue boost (no page to boost),
+    # but reported every run so they never go quiet the way the three
+    # policy-pack findings did in August.
+    contradicted = [r for r in results if r["verdict"] in STALE_VERDICTS]
+    soft = [r for r in results if r["verdict"] in SOFT_VERDICTS]
+    for r in results:
+        r["fix_route"] = fix_route(
+            [{"path": p["path"]} for p in r["pages"]], repo_root, tier_rules)
+        r["upstream"] = r["fix_route"] != "local"
+    stale = [r for r in contradicted if not r["upstream"]]
+    upstream = [r for r in contradicted if r["upstream"]]
+    # New = we have not told anyone yet. Resolved = a finding we had filed
+    # upstream now verifies clean, i.e. the upstream fix landed. The second is
+    # the event the marker scheme structurally could not report, because a
+    # marked entity was never re-checked.
+    upstream_new = [r for r in upstream if r["entity_key"] not in known_upstream]
+    upstream_resolved = [r for r in results
+                         if r["entity_key"] in known_upstream
+                         and r["verdict"] in FRESH_VERDICTS]
+    for r in upstream:
+        entry = known_upstream.get(r["entity_key"])
+        if entry:
+            r["upstream_issue"] = entry.get("issue")
+        else:
+            r["file_issue_url"] = file_issue_url(
+                r, r.get("claim_text") or "", upstream_repos)
+
+    fresh = [r for r in results if r["verdict"] in FRESH_VERDICTS]
+    by_type, by_reason = inconclusive_breakdowns(results)
+    return {
+        "n_checked": len(results),
+        "n_stale": len(stale),
+        # Framing verdicts: decided, evidence-bearing, reported — never marked.
+        "n_soft": len(soft),
+        "soft_entities": [
+            {"entity_key": r["entity_key"], "pages": [p["path"] for p in r["pages"]]}
+            for r in sorted(soft, key=lambda x: x["entity_key"])],
+        "n_upstream": len(upstream),
+        "n_upstream_new": len(upstream_new),
+        "n_upstream_resolved": len(upstream_resolved),
+        "upstream_entities": [
+            {"entity_key": r["entity_key"], "issue": r.get("upstream_issue"),
+             "file_issue_url": r.get("file_issue_url"),
+             # Explicit, so the Slack step filters on the SAME property the
+             # count is computed from. Deriving "new" a second time from
+             # `issue == null` made the workflow depend on --self-test (in
+             # another file) rejecting a registry entry with no issue, to keep
+             # its own two numbers agreeing. One field, one definition.
+             "new": r["entity_key"] not in known_upstream,
+             "reason": r["fix_route"], "pages": [p["path"] for p in r["pages"]]}
+            for r in sorted(upstream, key=lambda x: x["entity_key"])],
+        "upstream_resolved_entities": sorted(r["entity_key"] for r in upstream_resolved),
+        "n_fresh": len(fresh),
+        # Against `contradicted`, not `stale`: an upstream finding is a decided
+        # verdict that simply routes elsewhere. Subtracting only the markable
+        # ones would book every upstream contradiction as inconclusive,
+        # inflating the rate the health signal watches and eventually
+        # degrading the lane for doing its job. Soft verdicts are decided too.
+        "n_inconclusive": len(results) - len(contradicted) - len(soft) - len(fresh),
+        "n_demoted": sum(1 for r in results if r.get("demoted_from")),
+        "inconclusive_by_type": by_type,
+        "inconclusive_by_reason": by_reason,
+    }, stale
+
+
 def finish(report: dict, out_path: Path) -> int:
     out_path.write_text(json.dumps(report, indent=2) + "\n")
     m = report["meta"]
-    log(f"checked={m['n_checked']} stale={m['n_stale']} fresh={m['n_fresh']} "
+    log(f"checked={m['n_checked']} stale={m['n_stale']} soft={m.get('n_soft', 0)} "
+        f"fresh={m['n_fresh']} "
         f"inconclusive={m['n_inconclusive']} (of which {m['n_demoted']} demoted for "
         f"own-corpus evidence) (volatile entities={m['n_entities']}, "
         f"eligible={m.get('n_eligible', 0)}, marked={m.get('n_marked', 0)}, "
@@ -574,6 +776,9 @@ def finish(report: dict, out_path: Path) -> int:
                 f"-> {e.get('issue') or 'NOT YET FILED'}")
     for k in m.get("upstream_resolved_entities") or []:
         log(f"upstream RESOLVED (now verifies clean, retire its upstream-claims.yaml entry): {k}")
+    for e in m.get("soft_entities") or []:
+        log(f"soft (framing-drift, reported not marked): {e['entity_key']} "
+            f"-> {', '.join(e.get('pages') or [])}")
     write_outputs(report)
     return 0
 
@@ -592,8 +797,8 @@ def run(args) -> int:
         "checked_at": today.isoformat(),
         "entities": [],
         "meta": {"n_snapshots": 0, "n_entities": 0, "n_marked": 0, "n_eligible": 0,
-                 "n_due": 0, "n_checked": 0, "n_stale": 0, "n_fresh": 0,
-                 "n_inconclusive": 0, "n_demoted": 0},
+                 "n_due": 0, "n_checked": 0, "n_stale": 0, "n_soft": 0, "n_fresh": 0,
+                 "n_inconclusive": 0, "n_demoted": 0, "marked_pages": []},
     }
     out_path = Path(args.out)
 
@@ -615,10 +820,20 @@ def run(args) -> int:
     entities = volatile_entities(snapshots, _load_is_volatile())
     report["meta"]["n_entities"] = len(entities)
 
-    marked = {k for k, v in entities.items() if already_marked(k, v, ledger)}
-    superseded = {k for k, v in entities.items()
-                  if k not in marked and superseded_by_review(v, ledger)}
-    unmarked = sorted(k for k in entities if k not in marked and k not in superseded)
+    # The rotation is over entity keys; inside a due entity the unit of
+    # verification is each distinct claim text (`claim_groups`). A group is
+    # live unless already marked or superseded. An entity with no live group
+    # is held out: "marked" when a marker is what holds it (waiting on a
+    # review), otherwise "superseded" (fresher evidence is on its way).
+    groups = {k: claim_groups(v) for k, v in entities.items()}
+    live = {k: [(text, asrt) for text, asrt in gs
+                if not already_marked(k, asrt, ledger)
+                and not superseded_by_review(asrt, ledger)]
+            for k, gs in groups.items()}
+    marked = {k for k, gs in groups.items() if not live[k]
+              and any(already_marked(k, asrt, ledger) for _, asrt in gs)}
+    superseded = {k for k in entities if not live[k] and k not in marked}
+    unmarked = sorted(k for k in entities if live[k])
     # n_eligible is the pool the rotation actually divides, and n_marked is
     # the backlog held out of it. Without both, a small n_due is ambiguous
     # between "the pool is nearly empty" and "the rotation handed tonight a
@@ -628,8 +843,12 @@ def run(args) -> int:
     report["meta"]["n_superseded"] = len(superseded)
     report["meta"]["n_eligible"] = len(unmarked)
     keys = tonight_chunk(unmarked, args.count, today)
+    # n_due counts entities; n_checked (below) counts verifier calls, one per
+    # live claim text, so n_checked >= n_due whenever a due entity is worded
+    # more than one way across the pages that assert it.
+    work = [(k, text, asrt) for k in keys for text, asrt in live[k]]
     report["meta"]["n_due"] = len(keys)
-    if not keys:
+    if not work:
         log("no volatile entities due tonight")
         return finish(report, out_path)
 
@@ -654,9 +873,16 @@ def run(args) -> int:
         warn(f"upstream-claims.yaml lists {key}, which matches no volatile entity "
              f"in the claims index; stale entry or a re-keyed claim")
 
-    def check_entity(key: str) -> dict:
-        claim = dict(representative(entities[key]))
+    def check_claim(item: tuple[str, str, list[dict]]) -> dict:
+        key, _, assertions = item
+        freshest = max(assertions, key=lambda a: a["reviewed_at"])
+        claim = dict(freshest["claim"])
         claim["__id"] = key
+        # The verifier's pass1 lane reads files, and without `file` it was
+        # told `file: ?` and could not open the page the claim came from.
+        claim["file"] = freshest["path"]
+        claim["context"] = page_context(repo_root, freshest["path"],
+                                        str(claim.get("line_range") or ""))
         claim["__route"] = vc.route_claim(claim, {})
         rec, err = vc.process_claim(api_key, claim, {}, args.model, repo_root, args.dry_run)
         verdict = rec.get("verdict")
@@ -673,73 +899,22 @@ def run(args) -> int:
             "source": rec.get("source"),
             "route": rec.get("route"),
             "error": err,
-            "pages": [{"path": a["path"], "slug": a["slug"]} for a in entities[key]],
+            "pages": [{"path": a["path"], "slug": a["slug"]} for a in assertions],
         }
 
-    with ThreadPoolExecutor(max_workers=min(MAX_CONCURRENCY, len(keys))) as pool:
-        results = list(pool.map(check_entity, keys))
+    with ThreadPoolExecutor(max_workers=min(MAX_CONCURRENCY, len(work))) as pool:
+        results = list(pool.map(check_claim, work))
 
-    # Split contradicted results by whether anything in this repo could act on
-    # them. `upstream` findings are real and stay in the rotation forever: no
-    # marker (nothing could ever retire it), no queue boost (no page to boost),
-    # but reported every run so they never go quiet the way the three
-    # policy-pack findings did in August.
-    contradicted = [r for r in results if r["verdict"] in STALE_VERDICTS]
-    for r in results:
-        r["fix_route"] = fix_route(
-            [{"path": p["path"]} for p in r["pages"]], repo_root, tier_rules)
-        r["upstream"] = r["fix_route"] != "local"
-    stale = [r for r in contradicted if not r["upstream"]]
-    upstream = [r for r in contradicted if r["upstream"]]
-    # New = we have not told anyone yet. Resolved = a finding we had filed
-    # upstream now verifies clean, i.e. the upstream fix landed. The second is
-    # the event the marker scheme structurally could not report, because a
-    # marked entity was never re-checked.
-    upstream_new = [r for r in upstream if r["entity_key"] not in known_upstream]
-    upstream_resolved = [r for r in results
-                         if r["entity_key"] in known_upstream
-                         and r["verdict"] in FRESH_VERDICTS]
-    for r in upstream:
-        entry = known_upstream.get(r["entity_key"])
-        if entry:
-            r["upstream_issue"] = entry.get("issue")
-        else:
-            r["file_issue_url"] = file_issue_url(
-                r, r.get("claim_text") or "", upstream_repos)
-
-    fresh = [r for r in results if r["verdict"] in FRESH_VERDICTS]
     report["entities"] = results
-    report["meta"]["n_checked"] = len(results)
-    report["meta"]["n_stale"] = len(stale)
-    report["meta"]["n_upstream"] = len(upstream)
-    report["meta"]["n_upstream_new"] = len(upstream_new)
-    report["meta"]["n_upstream_resolved"] = len(upstream_resolved)
-    report["meta"]["upstream_entities"] = [
-        {"entity_key": r["entity_key"], "issue": r.get("upstream_issue"),
-         "file_issue_url": r.get("file_issue_url"),
-         # Explicit, so the Slack step filters on the SAME property the count
-         # is computed from. Deriving "new" a second time from `issue == null`
-         # made the workflow depend on --self-test (in another file) rejecting
-         # a registry entry with no issue, to keep its own two numbers
-         # agreeing. One field, one definition.
-         "new": r["entity_key"] not in known_upstream,
-         "reason": r["fix_route"], "pages": [p["path"] for p in r["pages"]]}
-        for r in sorted(upstream, key=lambda x: x["entity_key"])]
-    report["meta"]["upstream_resolved_entities"] = sorted(
-        r["entity_key"] for r in upstream_resolved)
-    report["meta"]["n_fresh"] = len(fresh)
-    # Against `contradicted`, not `stale`: an upstream finding is a decided
-    # verdict that simply routes elsewhere. Subtracting only the markable ones
-    # would book every upstream contradiction as inconclusive, inflating the
-    # rate the health signal watches and eventually degrading the lane for
-    # doing its job.
-    report["meta"]["n_inconclusive"] = len(results) - len(contradicted) - len(fresh)
-    report["meta"]["n_demoted"] = sum(1 for r in results if r["demoted_from"])
-    report["meta"]["inconclusive_by_type"], report["meta"]["inconclusive_by_reason"] = \
-        inconclusive_breakdowns(results)
+    counts, stale = tally(results, known_upstream, upstream_repos, repo_root, tier_rules)
+    report["meta"].update(counts)
 
     if stale:
-        changed = apply_markers(ledger, stale, today, repo_root)
+        changed = apply_markers(ledger, stale, today, repo_root, tier_rules)
+        # What was actually marked, after the ledger-gap and editability
+        # guards — the Slack summary lists these so a wrong page is visible
+        # at a glance rather than three review slots later.
+        report["meta"]["marked_pages"] = sorted(e["path"] for e in changed.values())
         uri = os.environ.get("CONTENT_REVIEW_LEDGER_URI", "").strip()
         for slug, entry in sorted(changed.items()):
             local = Path(args.ledger_dir) / f"{slug}.json"
@@ -994,6 +1169,7 @@ def self_test() -> int:
     ledger = {"content/docs/a.md": {"path": "content/docs/a.md", "slug": "docs-a",
                                     "status": "clean", "_file": "x"}}
     stale = [{"entity_key": "version/pulumi-gcp", "verdict": "contradicted",
+              "claim_text": "pulumi-gcp v8.3.0",
               "evidence": "v9.0 released", "source": "gh release view",
               "pages": [{"path": "content/docs/a.md", "slug": "docs-a"},
                         {"path": "content/docs/b.md", "slug": "docs-b"}]}]
@@ -1003,7 +1179,8 @@ def self_test() -> int:
     check("existing entry keeps its fields",
           changed["docs-a"]["status"] == "clean" and "_file" not in changed["docs-a"])
     check("marker shape", changed["docs-a"]["stale_claims"][0] == {
-        "entity_key": "version/pulumi-gcp", "verdict": "contradicted",
+        "entity_key": "version/pulumi-gcp", "claim_text": "pulumi-gcp v8.3.0",
+        "verdict": "contradicted",
         "evidence": "v9.0 released", "source": "gh release view",
         "checked_at": "2026-07-09"})
     check("ledger gap is skipped, not stubbed over",
@@ -1037,6 +1214,28 @@ def self_test() -> int:
                                          "slug": "docs-a"}]}]
         check("page with a source file is still marked",
               set(apply_markers(led2, on_disk, today, root)) == {"docs-a"})
+        # A generated page that IS on disk (the CLI command reference) is
+        # `editable: false`: the fix lane can never select it, so a marker
+        # there could never be resolved. The tier rules, not the file check,
+        # are what catch it — and only when a claim spans an editable page too,
+        # since fix_route() already routes an all-generated claim upstream.
+        (root / "content/docs/iac/cli/commands").mkdir(parents=True)
+        (root / "content/docs/iac/cli/commands/pulumi-up.md").write_text("# gen\n")
+        gen_rules = [{"prefix": "content/docs/iac/cli/commands/", "tier": 0}]
+        led3 = {"content/docs/a.md": {"path": "content/docs/a.md",
+                                      "slug": "docs-a", "status": "clean"},
+                "content/docs/iac/cli/commands/pulumi-up.md": {
+                    "path": "content/docs/iac/cli/commands/pulumi-up.md",
+                    "slug": "docs-iac-cli-commands-pulumi-up", "status": "clean"}}
+        spanning = [{**gen[0], "pages": [
+            {"path": "content/docs/a.md", "slug": "docs-a"},
+            {"path": "content/docs/iac/cli/commands/pulumi-up.md",
+             "slug": "docs-iac-cli-commands-pulumi-up"}]}]
+        check("a non-editable page on disk gets no marker under the tier rules",
+              set(apply_markers(led3, spanning, today, root, gen_rules)) == {"docs-a"})
+        check("without tier rules the file check alone still marks it",
+              set(apply_markers(led3, spanning, today, root))
+              == {"docs-a", "docs-iac-cli-commands-pulumi-up"})
 
     check("already_marked sees the marker",
           already_marked("version/pulumi-gcp", ents["version/pulumi-gcp"], ledger))
@@ -1044,14 +1243,76 @@ def self_test() -> int:
           not already_marked("numerical/team-plan-price",
                              ents["numerical/team-plan-price"], ledger))
 
+    # Per-text grouping: the two pages word the pin differently, so they are
+    # two claims under one key — each verified on its own, each marking only
+    # its own pages. Identical wording on several pages stays one call.
+    gcp_groups = claim_groups(ents["version/pulumi-gcp"])
+    check("claim_groups splits distinct wordings", len(gcp_groups) == 2)
+    check("claim_groups keeps identical wording together",
+          len(claim_groups(ents["version/pulumi-gcp"] * 2)) == 2
+          and all(len(g) == 2 for _, g in claim_groups(ents["version/pulumi-gcp"] * 2)))
+    check("group text is the freshest wording of that group",
+          [t for t, _ in gcp_groups] == ["pulumi-gcp v8.2.0", "pulumi-gcp v8.3.0"])
+    g82 = [a for a in ents["version/pulumi-gcp"] if a["claim"]["text"] == "pulumi-gcp v8.2.0"]
+    g83 = [a for a in ents["version/pulumi-gcp"] if a["claim"]["text"] == "pulumi-gcp v8.3.0"]
+    text_marked = {"content/docs/b.md": {"path": "content/docs/b.md", "stale_claims": [
+        {"entity_key": "version/pulumi-gcp", "claim_text": "Pulumi-GCP  v8.2.0"}]}}
+    check("a text-bearing marker does not hold out a different wording",
+          not already_marked("version/pulumi-gcp", g83, text_marked))
+    check("a text-bearing marker holds out its own wording (case/space-insensitive)",
+          already_marked("version/pulumi-gcp", g82 + g83, text_marked))
+    legacy = {"content/docs/b.md": {"path": "content/docs/b.md", "stale_claims": [
+        {"entity_key": "version/pulumi-gcp"}]}}
+    check("a legacy marker with no claim_text holds out every wording",
+          already_marked("version/pulumi-gcp", g83, legacy))
+
+    # Page context: the heading the claim sits under plus the prose around it.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / "content/docs").mkdir(parents=True)
+        (root / "content/docs/ctx.md").write_text(
+            "# Secrets\n\nintro\n\n#### AWS KMS\n\nThe awskms provider.\n\n"
+            "As of v3.33.1, add awssdk=v2 to the query string.\n\n1. By ID\n")
+        ctx = page_context(root, "content/docs/ctx.md", "L9")
+        check("page_context leads with the enclosing heading", ctx.startswith("#### AWS KMS"))
+        check("page_context carries the claim's own line", "awssdk=v2" in ctx)
+        check("page_context reads a multi-range line_range",
+              "awssdk=v2" in page_context(root, "content/docs/ctx.md", "L3, L9-9"))
+        check("page_context is empty, never wrong, when it cannot read",
+              page_context(root, "content/docs/ctx.md", "") == ""
+              and page_context(root, "content/docs/missing.md", "L1") == ""
+              and page_context(root, "content/docs/ctx.md", "L400") == ""
+              and page_context(None, "content/docs/ctx.md", "L9") == "")
+
+    # Accounting: which verdicts mark, which only report, what is inconclusive.
+    page_a = [{"path": "content/docs/a.md", "slug": "docs-a"}]
+    rows = [
+        {"entity_key": "numerical/x", "verdict": "contradicted", "pages": page_a},
+        {"entity_key": "version/y", "verdict": "framing-drift", "pages": page_a},
+        {"entity_key": "version/z", "verdict": "verified", "pages": page_a},
+        {"entity_key": "numerical/w", "verdict": "unverifiable",
+         "demoted_from": "verified", "pages": page_a},
+    ]
+    counts, markable = tally(rows, {}, [], None, None)
+    check("framing-drift is soft: reported, never markable",
+          counts["n_soft"] == 1 and [r["entity_key"] for r in markable] == ["numerical/x"])
+    check("soft verdicts are decided, not inconclusive",
+          (counts["n_stale"], counts["n_fresh"], counts["n_inconclusive"],
+           counts["n_demoted"]) == (1, 1, 1, 1))
+    check("soft entities name their pages",
+          counts["soft_entities"] == [{"entity_key": "version/y",
+                                       "pages": ["content/docs/a.md"]}])
+
     # Health-observation meta: the early-exit paths must say why they stopped
     # (signal-health.py's reverify signal reads these fields).
 
-    def run_report(d: Path, extra_env_unset: list[str]) -> dict:
+    def run_report(d: Path, extra_env_unset: list[str], dry_run: bool = False) -> dict:
         saved = {k: os.environ.pop(k) for k in extra_env_unset if k in os.environ}
         try:
             argv = ["--claims-dir", str(d / "claims"), "--ledger-dir", str(d / "ledger"),
                     "--out", str(d / "report.json"), "--today", "2026-07-06"]
+            if dry_run:
+                argv.append("--dry-run")
             args = build_parser().parse_args(argv)
             run(args)
             return json.loads((d / "report.json").read_text())
@@ -1070,6 +1331,20 @@ def self_test() -> int:
         rep = run_report(d, ["ANTHROPIC_API_KEY"])
         check("due entities without API key -> skipped=no_api_key",
               rep["meta"]["skipped"] == "no_api_key" and rep["meta"]["n_due"] == 1)
+
+        # End to end (dry run, placeholder verdicts): one due entity worded two
+        # ways across two pages is one rotation slot and two verifier calls,
+        # and each result carries only the pages that share its wording.
+        (d / "claims" / "docs-b.json").write_text(
+            json.dumps(snap("b", "2026-07-05", dict(ver, text="pulumi-gcp v8.3.0"))))
+        rep = run_report(d, ["ANTHROPIC_API_KEY"], dry_run=True)
+        check("dry run verifies every distinct wording of a due entity",
+              (rep["meta"]["n_due"], rep["meta"]["n_checked"]) == (1, 2)
+              and "skipped" not in rep["meta"])
+        check("each result carries only the pages sharing its wording",
+              sorted((e["claim_text"], [p["slug"] for p in e["pages"]])
+                     for e in rep["entities"])
+              == [("pulumi-gcp v8.2.0", ["docs-a"]), ("pulumi-gcp v8.3.0", ["docs-b"])])
 
     if failures:
         print(f"\n{len(failures)} failure(s)", file=sys.stderr)


### PR DESCRIPTION
## What happened

The 2026-09-03 nightly run marked three pages; two were wrong.

- `version/pulumi-cli` keyed every version claim about the CLI. The freshest claim (secrets: "as of v3.33.1 add `awssdk=v2&profile=` to the query string") was verified and the verdict fanned out to executable-plugin.md, which asserts different facts under the same key (v3.35.3 `github://`, v3.56.0 `gitlab://`).
- The verdict itself was `framing-drift`: the extracted sentence had lost its `#### AWS Key Management Service (KMS)` heading, so the verifier read "the query string" as every AWS query string. On the page it is unambiguous.

Both pages jumped the 14:06 UTC queue and burned a review slot (#21370, #21374); the worker correctly refuted both markers. The one real finding (elb.md health-check timeout, verified against the AWS API reference) is in the 5-day post-review cooldown.

Retro over the 16 nights with report artifacts (320 checks): 5 stale (1 false), 135 fresh, 174 inconclusive — 148 of those demoted for citing only our own docs, the same 42 entities every rotation. That is the next PR, not this one.

## What changes

`scripts/content-review/reverify-claims.py`
- The unit of verification is the distinct claim text within an entity (`claim_groups`), not the entity. Identical wording across pages is still one call; a verdict marks only the pages that share its wording. Markers carry `claim_text`, and `already_marked()` matches on it (a legacy marker without one still matches on the key).
- The verifier gets `file` (it was being told `file: ?`, so its pass1 `read_file` lane could not open the page) and `context`: the enclosing heading plus ±6 lines, read from the checkout via the persisted `line_range` (`page_context`).
- `framing-drift` moves from `STALE_VERDICTS` to `SOFT_VERDICTS`: reported (`n_soft`, `soft_entities`), never marked. The docstring already said `contradicted`/`mismatch` → stale.
- `apply_markers()` takes the tier rules and skips `editable: false` pages, matching `fix_route()`. A claim spanning an editable page and a CLI-reference page previously marked both, and the fix lane can never select the second.
- Accounting extracted to `tally()` so the self-test pins it without a verifier in the loop. `meta.marked_pages` records what was actually marked.

`.claude/commands/docs-review/scripts/verify-claims.py` — `build_user_message` renders `claim["context"]` when present. Additive; the PR-review path never sets it.

`.github/workflows/claims-reverify.yml` — the Slack summary gives the honest split (stale / fresh / could not verify / framing notes) and lists the marked pages; the header records the incident and the retro numbers.

`.claude/commands/review-existing-content/SKILL.md` — documents `claim_text` on markers.

## Verification

- `python3 scripts/content-review/reverify-claims.py --self-test`: new checks for grouping, text-aware `already_marked`, `page_context`, the editable guard, `tally`, and a dry-run end to end (one entity in two wordings → one rotation slot, two calls, each result scoped to its own page).
- `make test-review-pipeline`: green.
- Replayed tonight's claims index through the new grouping offline: `version/pulumi-cli` splits into three single-page claims, and `page_context` for the awskms claim leads with the KMS heading.
