### PR TITLE
Reviewer brief: empty ⚠️ sentinel acknowledges stances; 'the first <ordinal>' is not a stance

### DIFF
--- a/.claude/commands/docs-review/scripts/apply-update.py
+++ b/.claude/commands/docs-review/scripts/apply-update.py
@@ -530,7 +530,12 @@ def _render_doc(body: str, rows: dict[str, dict], resolved_rows: list[str], doc:
             new_lines = _table(resolved_rows) if resolved_rows else [RESOLVED_PLACEHOLDER]
         else:
             bucket_rows = by_bucket.get(bucket)
-            new_lines = _table(bucket_rows) if bucket_rows else [SECTION_EMPTY.get(bucket, "")]
+            empty = SECTION_EMPTY.get(bucket, "")
+            if bucket == "reviewer-check":
+                # A stances H4 directly below the ⚠️ span still needs a human
+                # eye; the sentinel says so (same rule as the composer).
+                empty = cr.empty_checks_sentinel(end < len(lines) and lines[end].startswith(cr.STANCES_HEADING))
+            new_lines = _table(bucket_rows) if bucket_rows else [empty]
             if doc == "author" and detail_blocks:
                 for fid in by_bucket.get(bucket + ":ids", []):
                     if fid in detail_blocks:

--- a/.claude/commands/docs-review/scripts/build-evidence.py
+++ b/.claude/commands/docs-review/scripts/build-evidence.py
@@ -415,7 +415,12 @@ def _collapse_empty_tables(body: str, headings: dict[str, str]) -> str:
     for bucket, start, end in _sections(body, headings):
         content = [ln for ln in lines[start:end] if ln.strip()]
         if content and all(ln.startswith("|") and cr.is_table_furniture(ln) for ln in content):
-            edits.append((start, end, ["", _EMPTY_SENTINEL.get(bucket, ""), ""]))
+            sentinel = _EMPTY_SENTINEL.get(bucket, "")
+            if bucket == "reviewer-check":
+                # The span ends AT the stances H4 when one follows; the
+                # sentinel must not claim nothing needs a human eye then.
+                sentinel = cr.empty_checks_sentinel(end < len(lines) and lines[end].startswith(cr.STANCES_HEADING))
+            edits.append((start, end, ["", sentinel, ""]))
     for start, end, new in sorted(edits, reverse=True):
         lines[start:end] = new
     return "\n".join(lines) + ("\n" if body.endswith("\n") else "")

--- a/.claude/commands/docs-review/scripts/compose-review.py
+++ b/.claude/commands/docs-review/scripts/compose-review.py
@@ -2016,7 +2016,6 @@ _V3_EMPTY_CHECKS = "_Nothing needs a human eye beyond the rubber-stamp list belo
 # has to know (pulumi/docs#21369, 2026-09-03: "Nothing needs a human eye"
 # printed directly above a stance the reviewer was asked to confirm).
 _V3_EMPTY_CHECKS_STANCES = "_No findings to check — but the editorial stances below still need a human eye._"
-V3_EMPTY_CHECKS_SENTINELS = (_V3_EMPTY_CHECKS, _V3_EMPTY_CHECKS_STANCES)
 
 
 def empty_checks_sentinel(stances_follow: bool) -> str:

--- a/.claude/commands/docs-review/scripts/compose-review.py
+++ b/.claude/commands/docs-review/scripts/compose-review.py
@@ -2011,6 +2011,19 @@ def _review_state_block(high_water: int) -> str:
 _V3_EMPTY_OUTSTANDING = "_Nothing to fix — this section is empty._"
 _V3_EMPTY_QUESTIONS = "_No open questions for you._"
 _V3_EMPTY_CHECKS = "_Nothing needs a human eye beyond the rubber-stamp list below._"
+# The ⚠️ section can be empty of findings and still carry the verdict-free
+# editorial-stances H4 under it, which DOES need a human eye. The sentinel
+# has to know (pulumi/docs#21369, 2026-09-03: "Nothing needs a human eye"
+# printed directly above a stance the reviewer was asked to confirm).
+_V3_EMPTY_CHECKS_STANCES = "_No findings to check — but the editorial stances below still need a human eye._"
+V3_EMPTY_CHECKS_SENTINELS = (_V3_EMPTY_CHECKS, _V3_EMPTY_CHECKS_STANCES)
+
+
+def empty_checks_sentinel(stances_follow: bool) -> str:
+    """The ⚠️ section's empty-table sentinel; every emitter (composer,
+    build-evidence's collapse, apply-update's re-render) picks it here so the
+    wording can't contradict the stances block below it."""
+    return _V3_EMPTY_CHECKS_STANCES if stances_follow else _V3_EMPTY_CHECKS
 # The browser-editing hint under the author tables. Named because the section
 # and detail-block walkers in build-evidence.py / apply-update.py must treat it
 # as a boundary: a detail block that swallowed it, and a section span that ran
@@ -2298,7 +2311,8 @@ def compose_v3(args: argparse.Namespace) -> tuple[str, str, dict]:
         "### ⚠️ Check these before approving",
         "",
     ]
-    brief += _finding_table(check_lines, _V3_EMPTY_CHECKS)
+    stance_block = render_stances(prep["candidate_stances"])
+    brief += _finding_table(check_lines, empty_checks_sentinel(bool(stance_block)))
     if check_lines:
         _team_txt = getattr(args, "routed_team", "") or "the routed reviewer team"
         brief += ["", f"_Not your area? Any member of {_team_txt} can approve "
@@ -2310,7 +2324,6 @@ def compose_v3(args: argparse.Namespace) -> tuple[str, str, dict]:
     # `#### ` terminates every row walker (build-evidence, apply-update,
     # validate-pinned), so the sub-list is invisible to finding parsing and
     # survives an update-lane re-render of the table above it.
-    stance_block = render_stances(prep["candidate_stances"])
     if stance_block:
         brief += ["", stance_block]
     brief += [

--- a/.claude/commands/docs-review/scripts/extract-claims.py
+++ b/.claude/commands/docs-review/scripts/extract-claims.py
@@ -347,7 +347,13 @@ CAPABILITY_RES = [
 ]
 
 POSITIONING_RES = [
-    re.compile(r"\bthe\s+(?:only|first|canonical|primary|recommended|default|standard|de[- ]facto|leading|preferred)\b", re.IGNORECASE),
+    # "the first" is an ordinal far more often than a stance ("for the first
+    # deployment, create it" was filed as positioning on pulumi/docs#21369);
+    # keep "the first IaC tool" and drop the temporal/ordinal nouns.
+    re.compile(r"\bthe\s+(?:only|canonical|primary|recommended|default|standard|de[- ]facto|leading|preferred"
+               r"|first(?!\s+(?:time|step|deployment|run|pass|line|call|attempt|iteration|argument|parameter|element"
+               r"|item|entry|character|column|row|version|release|commit|request|example|section|part|half|page|one|few|two|three)\b))\b",
+               re.IGNORECASE),
     re.compile(r"\b(?:industry[- ]standard|best[- ]in[- ]class|widely adopted|the go[- ]to|the gold standard|battle[- ]tested|enterprise[- ]grade|world[- ]class|cutting[- ]edge|next[- ]generation|state[- ]of[- ]the[- ]art|revolutionary|seamlessly integrates?|blazing[- ]fast)\b", re.IGNORECASE),
     re.compile(r"\b(?:fastest|slowest|cheapest|easiest|simplest|most popular|most widely used|largest|smallest)\b", re.IGNORECASE),
 ]

--- a/.claude/commands/docs-review/scripts/extract-claims.py
+++ b/.claude/commands/docs-review/scripts/extract-claims.py
@@ -347,13 +347,13 @@ CAPABILITY_RES = [
 ]
 
 POSITIONING_RES = [
-    # "the first" is an ordinal far more often than a stance ("for the first
-    # deployment, create it" was filed as positioning on pulumi/docs#21369);
-    # keep "the first IaC tool" and drop the temporal/ordinal nouns.
-    re.compile(r"\bthe\s+(?:only|canonical|primary|recommended|default|standard|de[- ]facto|leading|preferred"
-               r"|first(?!\s+(?:time|step|deployment|run|pass|line|call|attempt|iteration|argument|parameter|element"
-               r"|item|entry|character|column|row|version|release|commit|request|example|section|part|half|page|one|few|two|three)\b))\b",
-               re.IGNORECASE),
+    # "the first" is a stance only as "the first X to/that <verb>" ("the
+    # first IaC tool to support…"); bare ordinals ("for the first deployment",
+    # "the first-class citizen", "the first 30 days") are not positioning
+    # (pulumi/docs#21369 filed one). A positive lookahead says what we want
+    # instead of denylisting nouns that keep leaking.
+    re.compile(r"\bthe\s+(?:only|canonical|primary|recommended|default|standard|de[- ]facto|leading|preferred)\b", re.IGNORECASE),
+    re.compile(r"\bthe\s+first\s+\w+(?:\s+\w+)?\s+(?:to|that)\s+\w+", re.IGNORECASE),
     re.compile(r"\b(?:industry[- ]standard|best[- ]in[- ]class|widely adopted|the go[- ]to|the gold standard|battle[- ]tested|enterprise[- ]grade|world[- ]class|cutting[- ]edge|next[- ]generation|state[- ]of[- ]the[- ]art|revolutionary|seamlessly integrates?|blazing[- ]fast)\b", re.IGNORECASE),
     re.compile(r"\b(?:fastest|slowest|cheapest|easiest|simplest|most popular|most widely used|largest|smallest)\b", re.IGNORECASE),
 ]

--- a/.claude/commands/docs-review/scripts/extract-claims.py
+++ b/.claude/commands/docs-review/scripts/extract-claims.py
@@ -353,7 +353,12 @@ POSITIONING_RES = [
     # (pulumi/docs#21369 filed one). A positive lookahead says what we want
     # instead of denylisting nouns that keep leaking.
     re.compile(r"\bthe\s+(?:only|canonical|primary|recommended|default|standard|de[- ]facto|leading|preferred)\b", re.IGNORECASE),
-    re.compile(r"\bthe\s+first\s+\w+(?:\s+\w+)?\s+(?:to|that)\s+\w+", re.IGNORECASE),
+    # The frame alone re-admits ordinals followed by an infinitive ("the first
+    # step to take"), so the ordinal nouns are rejected INSIDE the frame.
+    re.compile(r"\bthe\s+first\s+"
+               r"(?!(?:time|step|deployment|run|pass|line|call|attempt|iteration|argument|parameter"
+               r"|element|item|entry|thing|example|section|part|page|half|version|release|commit|request)\b)"
+               r"[\w-]+(?:\s+[\w-]+)?\s+(?:to|that)\s+\w+", re.IGNORECASE),
     re.compile(r"\b(?:industry[- ]standard|best[- ]in[- ]class|widely adopted|the go[- ]to|the gold standard|battle[- ]tested|enterprise[- ]grade|world[- ]class|cutting[- ]edge|next[- ]generation|state[- ]of[- ]the[- ]art|revolutionary|seamlessly integrates?|blazing[- ]fast)\b", re.IGNORECASE),
     re.compile(r"\b(?:fastest|slowest|cheapest|easiest|simplest|most popular|most widely used|largest|smallest)\b", re.IGNORECASE),
 ]

--- a/.claude/commands/docs-review/scripts/extract-claims.py
+++ b/.claude/commands/docs-review/scripts/extract-claims.py
@@ -357,7 +357,7 @@ POSITIONING_RES = [
     # step to take"), so the ordinal nouns are rejected INSIDE the frame.
     re.compile(r"\bthe\s+first\s+"
                r"(?!(?:time|step|deployment|run|pass|line|call|attempt|iteration|argument|parameter"
-               r"|element|item|entry|thing|example|section|part|page|half|version|release|commit|request)\b)"
+               r"|element|item|entry|thing|example|section|part|page|half|version|release|commit|request)s?\b)"
                r"[\w-]+(?:\s+[\w-]+)?\s+(?:to|that)\s+\w+", re.IGNORECASE),
     re.compile(r"\b(?:industry[- ]standard|best[- ]in[- ]class|widely adopted|the go[- ]to|the gold standard|battle[- ]tested|enterprise[- ]grade|world[- ]class|cutting[- ]edge|next[- ]generation|state[- ]of[- ]the[- ]art|revolutionary|seamlessly integrates?|blazing[- ]fast)\b", re.IGNORECASE),
     re.compile(r"\b(?:fastest|slowest|cheapest|easiest|simplest|most popular|most widely used|largest|smallest)\b", re.IGNORECASE),

--- a/.claude/commands/docs-review/scripts/test_compose_v3.py
+++ b/.claude/commands/docs-review/scripts/test_compose_v3.py
@@ -366,3 +366,30 @@ def test_stances_survive_build_evidence(v3_with_stances, tmp_path):
     assert html.returncode == 0, html.stderr
     page = (tmp_path / "e.html").read_text()
     assert 'id="stances"' in page and "fastest path" in page
+
+
+def test_empty_checks_sentinel_acknowledges_stances(v3_with_stances, tmp_path):
+    """An empty ⚠️ table above a stances H4 must not say nothing needs a human
+    eye (pulumi/docs#21369). All three emitters agree: apply-update's
+    re-render, build-evidence's collapse, and the composer's helper."""
+    author, brief, ev = v3_with_stances
+    assert cr.STANCES_HEADING in brief
+    # apply-update: every brief row dropped → the stance-aware sentinel.
+    rows = au._collect_rows(author, brief)
+    author_only = {fid: r for fid, r in rows.items() if r["doc"] == "author"}
+    out = au._render_doc(brief, author_only, [], doc="brief")
+    assert cr._V3_EMPTY_CHECKS_STANCES in out and cr._V3_EMPTY_CHECKS not in out
+    assert out.index(cr._V3_EMPTY_CHECKS_STANCES) < out.index(cr.STANCES_HEADING)
+    # build-evidence: a table left with only furniture collapses the same way.
+    be = _load("build_evidence_for_sentinel", HERE / "build-evidence.py")
+    lines = brief.splitlines()
+    span = next((s, e) for b, s, e in be._sections(brief, be.BRIEF_SECTIONS) if b == "reviewer-check")
+    furniture = lines[:span[0]] + ["", cr.FINDING_TABLE_HEADER, cr.FINDING_TABLE_SEPARATOR, ""] + lines[span[1]:]
+    collapsed = be._collapse_empty_tables("\n".join(furniture), be.BRIEF_SECTIONS)
+    assert cr._V3_EMPTY_CHECKS_STANCES in collapsed and cr._V3_EMPTY_CHECKS not in collapsed
+    # No stances below → the plain sentinel, unchanged.
+    assert cr.empty_checks_sentinel(False) == cr._V3_EMPTY_CHECKS
+    h4 = furniture.index(cr.STANCES_HEADING)
+    nxt = next(i for i in range(h4 + 1, len(furniture)) if furniture[i].startswith("### "))
+    without = "\n".join(furniture[:h4] + furniture[nxt:])
+    assert cr._V3_EMPTY_CHECKS in be._collapse_empty_tables(without, be.BRIEF_SECTIONS)

--- a/.claude/commands/docs-review/scripts/test_extract_claims.py
+++ b/.claude/commands/docs-review/scripts/test_extract_claims.py
@@ -128,6 +128,21 @@ def _types(doc: dict) -> set[str]:
 
 # ---- extract-claims.py: synthetic per-category --------------------------------
 
+def test_ordinal_the_first_is_not_a_stance() -> None:
+    """"the first" is an ordinal far more often than positioning: pulumi/docs#21369
+    filed "for the first deployment, create it" as an editorial stance."""
+    print("test_ordinal_the_first_is_not_a_stance")
+    d = run_extract(_mk_patch("content/docs/x.md", [
+        "The workflow below assumes a live `blue` environment already exists: for the first deployment, create it.",
+        "Run it the first time with `--yes`.",
+        "Pulumi was the first IaC tool to support general-purpose languages.",
+    ]))
+    pos = [c for c in d["claims"] if c["type"] == "positioning"]
+    check(not any("deployment" in c["text"] for c in pos), f"ordinal: 'the first deployment' must not be positioning; got {[c['text'] for c in pos]}")
+    check(not any("first time" in c["text"] for c in pos), f"ordinal: 'the first time' must not be positioning; got {[c['text'] for c in pos]}")
+    check(any("first IaC tool" in c["text"] for c in pos), f"stance: 'the first IaC tool' must stay positioning; got {[c['text'] for c in pos]}")
+
+
 def test_synthetic_categories() -> None:
     print("test_synthetic_categories")
     d = run_extract(_mk_patch("content/blog/x.md", [

--- a/.claude/commands/docs-review/scripts/test_extract_claims.py
+++ b/.claude/commands/docs-review/scripts/test_extract_claims.py
@@ -135,11 +135,13 @@ def test_ordinal_the_first_is_not_a_stance() -> None:
     d = run_extract(_mk_patch("content/docs/x.md", [
         "The workflow below assumes a live `blue` environment already exists: for the first deployment, create it.",
         "Run it the first time with `--yes`.",
+        "Stacks are the first-class unit here; the first steps take the first 30 days.",
         "Pulumi was the first IaC tool to support general-purpose languages.",
     ]))
     pos = [c for c in d["claims"] if c["type"] == "positioning"]
     check(not any("deployment" in c["text"] for c in pos), f"ordinal: 'the first deployment' must not be positioning; got {[c['text'] for c in pos]}")
     check(not any("first time" in c["text"] for c in pos), f"ordinal: 'the first time' must not be positioning; got {[c['text'] for c in pos]}")
+    check(not any(("first-class" in c["text"] or "first steps" in c["text"]) for c in pos), f"ordinal: hyphenated/plural/numeric 'the first' must not be positioning; got {[c['text'] for c in pos]}")
     check(any("first IaC tool" in c["text"] for c in pos), f"stance: 'the first IaC tool' must stay positioning; got {[c['text'] for c in pos]}")
 
 

--- a/.claude/commands/docs-review/scripts/test_extract_claims.py
+++ b/.claude/commands/docs-review/scripts/test_extract_claims.py
@@ -137,12 +137,14 @@ def test_ordinal_the_first_is_not_a_stance() -> None:
         "Run it the first time with `--yes`.",
         "Stacks are the first-class unit here; the first steps take the first 30 days.",
         "The first step to take is a preview; the first thing to do afterwards is read the diff.",
+        "The first steps to take are previews; the first lines that match are printed.",
         "Pulumi was the first IaC tool to support general-purpose languages.",
     ]))
     pos = [c for c in d["claims"] if c["type"] == "positioning"]
     check(not any("deployment" in c["text"] for c in pos), f"ordinal: 'the first deployment' must not be positioning; got {[c['text'] for c in pos]}")
     check(not any("first time" in c["text"] for c in pos), f"ordinal: 'the first time' must not be positioning; got {[c['text'] for c in pos]}")
     check(not any(("first-class" in c["text"] or "first steps" in c["text"]) for c in pos), f"ordinal: hyphenated/plural/numeric 'the first' must not be positioning; got {[c['text'] for c in pos]}")
+    check(not any(("first steps to" in c["text"] or "first lines that" in c["text"]) for c in pos), f"ordinal: plural 'the first steps to take' must not be positioning; got {[c['text'] for c in pos]}")
     check(not any(("first step to" in c["text"] or "first thing to" in c["text"]) for c in pos), f"ordinal: 'the first step to take' must not be positioning; got {[c['text'] for c in pos]}")
     check(any("first IaC tool" in c["text"] for c in pos), f"stance: 'the first IaC tool' must stay positioning; got {[c['text'] for c in pos]}")
 

--- a/.claude/commands/docs-review/scripts/test_extract_claims.py
+++ b/.claude/commands/docs-review/scripts/test_extract_claims.py
@@ -136,12 +136,14 @@ def test_ordinal_the_first_is_not_a_stance() -> None:
         "The workflow below assumes a live `blue` environment already exists: for the first deployment, create it.",
         "Run it the first time with `--yes`.",
         "Stacks are the first-class unit here; the first steps take the first 30 days.",
+        "The first step to take is a preview; the first thing to do afterwards is read the diff.",
         "Pulumi was the first IaC tool to support general-purpose languages.",
     ]))
     pos = [c for c in d["claims"] if c["type"] == "positioning"]
     check(not any("deployment" in c["text"] for c in pos), f"ordinal: 'the first deployment' must not be positioning; got {[c['text'] for c in pos]}")
     check(not any("first time" in c["text"] for c in pos), f"ordinal: 'the first time' must not be positioning; got {[c['text'] for c in pos]}")
     check(not any(("first-class" in c["text"] or "first steps" in c["text"]) for c in pos), f"ordinal: hyphenated/plural/numeric 'the first' must not be positioning; got {[c['text'] for c in pos]}")
+    check(not any(("first step to" in c["text"] or "first thing to" in c["text"]) for c in pos), f"ordinal: 'the first step to take' must not be positioning; got {[c['text'] for c in pos]}")
     check(any("first IaC tool" in c["text"] for c in pos), f"stance: 'the first IaC tool' must stay positioning; got {[c['text'] for c in pos]}")
 
 


### PR DESCRIPTION
Two things Cam spotted on the v3 reviewer brief for pulumi/docs#21369:

- **Contradictory sentinel.** The ⚠️ section read "Nothing needs a human eye beyond the rubber-stamp list below" directly above an editorial-stances block the reviewer is asked to confirm. The empty-table sentinel now comes from one helper that knows whether the stances H4 follows, used by all three emitters (composer, `build-evidence.py` collapse, `apply-update.py` re-render).
- **False-positive stance.** "for the first deployment, create it" matched the positioning regex's `the first`. Ordinal/temporal nouns after "the first" no longer match; "the first IaC tool" still does.

Regression tests for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgQPx7TyE73KH1Bk4TBfHq
