### PR TITLE
Add a more descriptive name to Dev Center cache clears

### DIFF
--- a/.github/workflows/invalidate-dev-cache.yml
+++ b/.github/workflows/invalidate-dev-cache.yml
@@ -1,4 +1,5 @@
 name: Invalidate /dev cache
+run-name: Invalidate /dev cache
 
 # Invalidates the Dev Center cache, which lives at `/dev` behind the CloudFront CDN managed by pulumi/docs.
 # We do this with a workflow dispatch because the Dev Center deploys on its own schedule (so its cache needs


### PR DESCRIPTION
Noticed dispatched events are called "dev-deployed", which seems vague:

<img width="632" height="418" alt="image" src="https://github.com/user-attachments/assets/e7726437-732b-408c-a44b-dba06a6a9fe1" />

Figured this change would help.