### PR TITLE
Remove the dead pulumi-ai-app-infra origin and stack reference

### DIFF
--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -1521,7 +1521,6 @@ The docs infrastructure integrates with other Pulumi projects via stack referenc
 ```typescript
 const registryStack = new pulumi.StackReference('pulumi/registry/production');
 const answersStack = new pulumi.StackReference('pulumi/answers/production');
-const aiAppStack = new pulumi.StackReference('pulumi/pulumi-ai-app-infra/prod');
 const guidesStack = new pulumi.StackReference('pulumi/guides/production');
 ```
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -104,9 +104,6 @@ const dotnetLowercaseFunction = new aws.cloudfront.Function("dotnet-lowercase-ur
     publish: true,
 });
 
-const aiAppStack = new pulumi.StackReference('pulumi/pulumi-ai-app-infra/prod');
-const cloudAiAppDomain = aiAppStack.requireOutput('cloudAiAppDistributionDomain');
-
 // Reference to the OSS Airflow on EKS stack for data warehouse access (only if enabled)
 let airflowIrsaRoleArn: pulumi.Output<any> | undefined;
 if (config.enableDataWarehouseAccess) {
@@ -1197,18 +1194,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
                 httpPort: 80,
                 httpsPort: 443,
                 originSslProtocols: ["TLSv1.2"],
-            },
-        },
-        {
-            originId: cloudAiAppDomain,
-            domainName: cloudAiAppDomain,
-            customOriginConfig: {
-                originProtocolPolicy: "https-only",
-                httpPort: 80,
-                httpsPort: 443,
-                originSslProtocols: ["TLSv1.2"],
-                originReadTimeout: 60,
-                originKeepaliveTimeout: 60,
             },
         },
         ...registryOrigins,


### PR DESCRIPTION
### Proposed changes

**This unblocks CI for the whole repo.** Every PR built after roughly 2026-09-04T19:21Z fails in `Install deps and build site`:

```
error: Running program '/home/runner/work/docs/docs/infrastructure/' failed:
Error: Required output 'cloudAiAppDistributionDomain' does not exist
       on stack 'pulumi/pulumi-ai-app-infra/prod'.
```

Someone removed that output on `pulumi-ai-app-infra/prod`. Because `infrastructure/index.ts` read it with `requireOutput` rather than `getOutput`, its absence aborts the entire `pulumi preview` inside `make ci_pull_request` -- so nothing can go green. First observed on [run 33922772096](https://github.com/pulumi/docs/actions/runs/33922772096/job/101202742442) (failed on both attempts, so not a transient).

#### The dependency was already dead

`cloudAiAppDomain` appeared exactly three times in the file: the `requireOutput`, and the `originId` / `domainName` of one CloudFront origin.

**Nothing targeted that origin.** The distribution has ten `targetOriginId` values and not one of them is `cloudAiAppDomain`, so no request has ever been routed to it.

The cause is a decommission that only finished on one side. The AI app was retired here -- `/ai` redirects to `/product/neo/` and `/ai/*` returns 410 Gone, both served by Lambda@Edge off the S3 origin (the cache behaviors are literally commented `/ai -> /product/neo/ redirect, /ai/* -> 410 Gone`). The origin block and its stack reference were left behind. CloudFront ignores an origin no behavior targets, so the leftover stayed invisible until the other team removed the output and turned inert config into a hard build dependency.

#### Why delete rather than soften to `getOutput`

Switching to `getOutput` would make CI green while preserving a cross-stack dependency that serves no traffic. Deleting it removes the coupling outright. Worth noting the Airflow reference twelve lines below already uses `getOutput` and degrades gracefully -- this one was the outlier.

### Testing

- `npx tsc --noEmit` passes in `infrastructure/`, and it is **not vacuous**: a deliberately injected type error (`const __probe: number = "..."`) is caught as `TS2322` at the same settings, so the file really is being checked.
- The five `yarn lint` (tslint) errors in this file are **pre-existing**. The identical set appears on unmodified master at line numbers offset by exactly the 15 lines removed here (1069→1066, 1470→1455, 1476→1461, 1548→1533, 1559→1544). Not introduced by this change, and `infrastructure/`'s tslint isn't wired into `make lint` or PR CI.
- **The `pulumi preview` on this PR is the real check.** It should show the one origin removed and nothing else. Please confirm that before merging -- I can't exercise CloudFront behavior from a review.

### Related issues (optional)

Blocks [#21377](https://github.com/pulumi/docs/pull/21377) and, as far as I can tell, every other open PR. Filed no issue since the fix is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3vuWejcQDE3xEGbKKC2SC

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3vuWejcQDE3xEGbKKC2SC)_