### PR TITLE
Remove obsolete pulumi-ai-app-infra StackReference and dead Copilot CloudFront origin

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -104,9 +104,6 @@ const dotnetLowercaseFunction = new aws.cloudfront.Function("dotnet-lowercase-ur
     publish: true,
 });
 
-const aiAppStack = new pulumi.StackReference('pulumi/pulumi-ai-app-infra/prod');
-const cloudAiAppDomain = aiAppStack.requireOutput('cloudAiAppDistributionDomain');
-
 // Reference to the OSS Airflow on EKS stack for data warehouse access (only if enabled)
 let airflowIrsaRoleArn: pulumi.Output<any> | undefined;
 if (config.enableDataWarehouseAccess) {
@@ -1197,18 +1194,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
                 httpPort: 80,
                 httpsPort: 443,
                 originSslProtocols: ["TLSv1.2"],
-            },
-        },
-        {
-            originId: cloudAiAppDomain,
-            domainName: cloudAiAppDomain,
-            customOriginConfig: {
-                originProtocolPolicy: "https-only",
-                httpPort: 80,
-                httpsPort: 443,
-                originSslProtocols: ["TLSv1.2"],
-                originReadTimeout: 60,
-                originKeepaliveTimeout: 60,
             },
         },
         ...registryOrigins,


### PR DESCRIPTION
The `cloudAiAppDistributionDomain` output was deleted upstream (`pulumi-ai-app-infra` update #777), so `requireOutput` was failing every `www-production` deploy on master. The origin was already orphaned when the Copilot cache behaviors (`/pulumi-ai/copilot*`) were removed in #18291 — nothing routed to it — so this is a clean removal that unblocks deploys.