### PR TITLE
Enable previews for denny-hill pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - denny-hill
       - 'release/**'
 
 # Only the newest commit on a PR is worth building. Without this, pushing three


### PR DESCRIPTION
## Summary

- Run the docs pull request workflow for changes that target `denny-hill`.
- Let pricing-launch pull requests generate previews without targeting `master`.

This pull request only changes the workflow trigger. It cannot generate its own preview until the change is present on the base branch.

Validated with Prettier and `git diff --check`.
