### PR TITLE
GRO-545: Correct Pulumi Cloud FAQ for V6

### DIFF
--- a/content/docs/support/faq/pulumi-cloud.md
+++ b/content/docs/support/faq/pulumi-cloud.md
@@ -193,8 +193,9 @@ To discuss that, [contact us](/contact/).
   include Pulumi Neo, Resource Search, or Property Search.
 
 - **Essentials** adds organizations with unlimited users, secure collaboration
-  and CI/CD, Resource Search and Property Search, webhooks, automatic secrets
-  rotation, audit logs, and policy results in advisory mode.
+  and CI/CD, Pulumi Neo, Resource Search and Property Search, webhooks, automatic
+  secrets rotation, audit logs, audit policies, the Pulumi Best Practices policy
+  pack, and policy results in advisory mode.
 
 - **Pro** adds SAML/SSO and advanced role-based access control,
   organization-managed policy enforcement, preventative policies, custom policy
@@ -205,7 +206,8 @@ To discuss that, [contact us](/contact/).
   conformance packs for CIS, CIS Kubernetes, CMMC, HITRUST, ISO 27001, NIST,
   and PCI DSS,
   [SCIM](/docs/administration/guides/scim/) user and group sync, unlimited
-  custom policy packs, and policy remediation.
+  custom policy packs, policy remediation, GitHub Enterprise Server support,
+  and unlimited custom roles.
 
 For a feature-by-feature comparison, see the [pricing page](/pricing/).
 


### PR DESCRIPTION
## Summary

- Add Pulumi Neo and the full Essentials policy set to the V6 FAQ.
- Add GitHub Enterprise Server support and unlimited custom roles to Enterprise.
- Keep the existing V6 naming, pricing, and legacy SKU guidance.

Depends on #21444.

## Testing

- Ran Prettier on the changed file.
- Ran `git diff --check`.
