### PR TITLE
GRO-548: Correct cloud account policy guidance

### DIFF
--- a/content/docs/insights/discovery/connect-cloud-accounts.md
+++ b/content/docs/insights/discovery/connect-cloud-accounts.md
@@ -108,7 +108,7 @@ The wizard shows how many accounts, subscriptions, or projects it discovered and
 
 The access level determines which permissions Pulumi receives in each account:
 
-- **Build & Manage (read and write)**: the default. Enables [Pulumi Neo](/docs/ai/), infrastructure as code, deployments, and policies that remediate issues automatically (Enterprise edition). Grants `AdministratorAccess` in AWS, **Contributor** in Azure, or **Editor** in Google Cloud.
+- **Build & Manage (read and write)**: the default. Enables [Pulumi Neo](/docs/ai/), infrastructure as code, Deployments, and policy remediation when your organization uses the Enterprise edition. Grants `AdministratorAccess` in AWS, **Contributor** in Azure, or **Editor** in Google Cloud.
 - **Discovery & Policy (read-only)**: limited to discovery scanning and inventory. Pulumi can't modify your infrastructure. Grants `ReadOnlyAccess` in AWS, **Reader** in Azure, or **Viewer** in Google Cloud.
 
 Select **Change access level** to switch the default, or set a different level for individual accounts under **Per account access**. If your security review requires it, start with read-only access; you can raise access for specific accounts later.
@@ -135,7 +135,7 @@ For AWS, choose the regions to scan. The defaults are `us-east-1`, `us-east-2`, 
 
 ### Policy pack
 
-Policy evaluation is enabled by default, and the pack depends on your organization's edition. The Essentials and Pro editions apply the Pulumi Best Practices pack for your provider. The Enterprise edition applies a provider-specific compliance pack by default (the CIS AWS Foundations Benchmark, CIS Microsoft Azure Foundations Benchmark, or CIS Google Cloud Platform Foundations Benchmark), and for AWS or Google Cloud, you can choose NIST 800-53 instead. You can also turn policy off. See [pre-built policy packs](/docs/insights/policy/policy-packs/pre-built-packs/) for what each pack checks, and [Pricing](/pricing/) for edition availability.
+Available policy capabilities depend on your organization's edition. Essentials includes audit policies, policy results in advisory mode, and the Pulumi Best Practices pack. Pro adds organization-managed policy enforcement, preventative policies, and custom policy packs. Enterprise adds conformance packs, unlimited custom policy packs, and policy remediation. You can turn policy evaluation off. See [pre-built policy packs](/docs/insights/policy/policy-packs/pre-built-packs/) for available packs, and [Pricing](/pricing/) for a full edition comparison.
 
 When you're done, select **Next**. The wizard then creates the resources described in [What the wizard creates](#what-the-wizard-creates) and connects each selected account.
 


### PR DESCRIPTION
## Summary

- Describe policy capabilities by V6 edition in the Connect cloud accounts guide.
- Remove unsupported claims about the policy pack selected by the wizard.
- Clarify that automatic policy remediation requires Enterprise.

Depends on #21444.

## Testing

- Ran Prettier on the changed file.
- Ran `git diff --check`.
