### PR TITLE
GRO-557: Correct V6 deployment minute allowances

### DIFF
--- a/content/product/pulumi-deployments.md
+++ b/content/product/pulumi-deployments.md
@@ -79,7 +79,7 @@ faq:
 
       - header: Is there a free tier for Pulumi Deployments?
         content: |
-          The Free edition has 500 deploy minutes/month. The Essentials, Pro, and Enterprise editions all have 3,000 included deploy minutes/month.
+          The Free edition includes 500 deployment minutes per month. Essentials, Pro, and Enterprise do not have a separate fixed deployment-minute allowance. Deployment minutes draw from each edition's shared Pulumi Credits.
 
       - header: How does drift detection work?
         content: |


### PR DESCRIPTION
## Summary

- Remove the obsolete fixed 3,000-minute allowance for paid editions.
- Explain that paid-edition deployment minutes draw from shared Pulumi Credits.
- Keep the verified 500-minute Free allowance.

Depends on #21444. The entitlement source is `data/pulumi_pricing.yaml` in that pull request.

## Testing

- Ran Prettier on the changed file.
- Ran `git diff --check`.
