### PR TITLE
GRO-542: Clarify V6 policy boundaries

### DIFF
--- a/content/docs/insights/policy/policy-packs/authoring.md
+++ b/content/docs/insights/policy/policy-packs/authoring.md
@@ -1073,6 +1073,8 @@ As shorthand, specify enforcement levels directly:
 <a id="remediate"></a>
 **Enforcement levels:**
 
+In Pulumi Cloud, Essentials reports organization-managed policies in advisory mode. Pro adds mandatory enforcement, and Enterprise adds automatic remediation.
+
 - **advisory** - Issues warnings but allows deployments to proceed
 - **mandatory** - Blocks deployments when violations are detected
 - **remediate** - Automatically fixes violations in place, available in the [Enterprise edition](/pricing/#policy-enforcement-modes); see [Remediating policy violations](#remediating-policy-violations)

--- a/content/docs/insights/policy/policy-packs/metadata.md
+++ b/content/docs/insights/policy/policy-packs/metadata.md
@@ -21,7 +21,7 @@ The table below describes all supported metadata fields and their usage:
 |-------|-----------|-------------|
 | `name` | Yes | Unique identifier for the policy within the policy pack. |
 | `description` | Yes | Short summary of what the policy checks or enforces. |
-| `enforcementLevel` | No | Defines how the policy behaves on violation. Options: `advisory` (warn only), `mandatory` (block deployment), `remediate` (auto-fix violations), or `disabled` (turn off policy). The `remediate` level is available in the [Enterprise edition](/pricing/#policy-enforcement-modes). |
+| `enforcementLevel` | No | Defines how the policy behaves on violation. Options: `advisory` (warn only), `mandatory` (block deployment), `remediate` (auto-fix violations), or `disabled` (turn off policy). Organization-managed `mandatory` enforcement is available with Pro and Enterprise. The `remediate` level is available with [Enterprise](/pricing/#policy-enforcement-modes). |
 | `severity` | No | Indicates the seriousness of violations. Valid values: `low`, `medium`, `high`, `critical`. |
 | `displayName` | No | Human-readable name for the policy (used for display instead of `name`). |
 | `remediationSteps` | No | Guidance for how to fix a violation or bring a resource into compliance. |


### PR DESCRIPTION
## Summary

- State that Essentials reports organization-managed policies in advisory mode.
- State that Pro adds mandatory enforcement and Enterprise adds automatic remediation.
- Apply the same boundary to the policy metadata reference.

Depends on #21444. The entitlement source is `data/pulumi_pricing.yaml` in that pull request.

## Testing

- Ran Prettier on the changed files.
- Ran `git diff --check`.
