### PR TITLE
GRO-561: Add V6 pricing launch blog

### DIFF
--- a/content/blog/new-pulumi-cloud-pricing-plans/index.md
+++ b/content/blog/new-pulumi-cloud-pricing-plans/index.md
@@ -1,0 +1,68 @@
+---
+title: "Introducing the New Pulumi Cloud Plans"
+title_tag: "New Pulumi Cloud Plans: Free, Essentials, Pro, and Enterprise"
+date: 2026-09-15
+draft: false
+meta_desc: "Meet the new Pulumi Cloud Free, Essentials, Pro, and Enterprise plans, with unlimited users on paid plans and self-service credit top-ups."
+authors:
+    - mark-huber
+tags:
+    - features
+    - ai
+category: product
+schema_type: auto
+
+# Optional: Social media promotional copy (for reference only, does not auto-post)
+social:
+    twitter:
+    linkedin:
+---
+
+Infrastructure teams do not grow in a straight line. A new service, an acquisition, or an agent-driven workflow can expand the infrastructure under management before the next budget cycle. Pulumi Cloud pricing should let a team start at the right level, understand what it will pay, and add capacity without a sales call.
+
+On September 15, 2026, we are introducing four new Pulumi Cloud plans: **Free, Essentials, Pro, and Enterprise**. Every paid plan supports unlimited users. Self-service Essentials and Pro customers can also buy discounted Pulumi Credits in Pulumi Cloud when they need more capacity.
+
+<!--more-->
+
+## Choose the capabilities you need
+
+The new plans follow a clear capability ladder:
+
+| Plan | Monthly price | Included managed resources | Designed for |
+| --- | ---: | ---: | --- |
+| **Free** | $0 | No resource limit | One person managing infrastructure with core IaC, state management, Pulumi Deployments, and basic Pulumi ESC. |
+| **Essentials** | $40 | 500 | Teams that need unlimited users, Pulumi Neo, Resource Search, Property Search, audit logs, and advisory policy results. |
+| **Pro** | $400 | 2,000 | Teams that need SAML SSO, configurable RBAC, audit-log export, policy enforcement, preventative policies, custom policy packs, drift remediation, and scheduled automation. |
+| **Enterprise** | $2,000 | 4,750 | Organizations that need conformance packs, policy remediation, SCIM, self-hosting, GitHub Enterprise Server support, and unlimited custom roles. |
+
+Free has no managed-resource limit and does not require a credit card. It supports one user. Neo, Resource Search, and Property Search start with Essentials.
+
+Enterprise is available as a $2,000 monthly self-service plan. Organizations can also [contact our team](/contact/?form=sales) for an annual contract and custom volume pricing.
+
+See the [Pulumi Cloud pricing page](/pricing/) for the complete feature comparison and usage rates.
+
+## Add credits without changing plans
+
+Pulumi Credits are the shared billing unit for Pulumi Cloud usage. One Pulumi Credit costs $1. The monthly price for Essentials and Pro creates a credit pool for the billing period.
+
+Self-service Essentials and Pro customers can buy discounted credit top-ups in Pulumi Cloud. The purchase flow shows the price and discount before checkout. Contracted credit pools do not yet support self-service top-ups.
+
+This gives a team two paths. It can add credits in Pulumi Cloud when usage grows, or it can [contact our team](/contact/?form=sales) for an annual commitment and custom volume pricing.
+
+## What this means for existing customers
+
+We will move existing self-service customers to the new plans in stages. We will preserve the features they already use, and active coupons will continue with their existing expiration dates.
+
+The effect depends on the customer:
+
+- If the move does not change the recurring price or feature access, we will move the customer without requiring action.
+- If the assigned plan costs less, the customer will receive the lower price when we move it.
+- If the assigned plan would cost more, we will notify the customer and start a transition trial at its current price. The customer can choose another eligible plan before the trial ends.
+
+Contracted customers are outside this automatic migration. Their plans change at renewal unless our Sales team works with them earlier.
+
+## Start with the full estate
+
+Pulumi Free lets one person manage an estate of any size at no charge. This makes it possible to import an existing infrastructure estate, keep its state and history in Pulumi Cloud, and decide when collaboration or advanced capabilities justify a paid plan.
+
+Create a [free Pulumi Cloud account](https://app.pulumi.com/signup), or review the [new plans and pricing](/pricing/).


### PR DESCRIPTION
## Summary

- Introduce the V6 Free, Essentials, Pro, and Enterprise plan ladder.
- Explain unlimited users on paid plans and self-service credit top-ups for Essentials and Pro.
- Explain the staged treatment for existing self-service and contracted customers.
- Use the site’s generic blog artwork until Marketing supplies an approved feature image.

Depends on #21444. The pricing facts come from `data/pulumi_pricing.yaml` in that pull request and the pricing rollout execution plan.

## Testing

- Ran the Markdown linter on the new post.
- Ran `git diff --check`.
- Verified the pricing, signup, and sales-contact links resolve.