### PR TITLE
fix(audit-logs): map renamed Discovery event ids to the discovery category

### DIFF
--- a/data/audit_log_event_categories.yaml
+++ b/data/audit_log_event_categories.yaml
@@ -154,6 +154,13 @@
   description: Cloud accounts connected for resource discovery, and the scans run against them.
   match:
     prefixes:
+      # The Insights -> Discovery rename landed in the API as new event ids:
+      # `insights-account-*` became `cloud-account-*` and
+      # `insights-trial-billing-*` became `discovery-trial-billing-*`. The
+      # `insights-` prefix is kept so a catalog that still carries the old ids
+      # does not fail the nightly job; drop it once the API stops emitting them.
+      - cloud-account-
+      - discovery-
       - insights-
 
 - id: neo


### PR DESCRIPTION
### Proposed changes

The nightly [Audit Logs - Update Events](https://github.com/pulumi/docs/actions/runs/34199346948/job/101974311476) job has been failing. `scripts/fetch-audit-log-events.sh` exits non-zero when an event from the Pulumi Cloud catalog matches no rule in `data/audit_log_event_categories.yaml`, and ten did:

```
cloud-account-created                    discovery-trial-billing-accepted
cloud-account-deleted                    discovery-trial-billing-denied
cloud-account-scan-canceled
cloud-account-scan-started
cloud-account-scheduled-scans-paused
cloud-account-scheduled-scans-resumed
cloud-account-tags-updated
cloud-account-updated
```

These aren't new events -- the Insights → Discovery rename reached the audit log event ids. They map one-for-one onto the ten `insights-*` events already in `data/audit_log_events.json`: the eight `insights-account-*` became `cloud-account-*`, and `insights-trial-billing-{accepted,denied}` became `discovery-trial-billing-{accepted,denied}`. The total stays at 153, which is what you'd expect from a rename rather than an addition.

The `discovery` category matched on exactly one prefix, `insights-`, so when the ids changed underneath it every one of them fell through. This adds `cloud-account-` and `discovery-` alongside it.

`insights-` is kept for now, in case the catalog still carries the old ids -- dropping it while the API still emits them would just re-break the job. The inline comment says it can go once that's confirmed.

**Verification:** replayed the script's `categorize()` logic against the current committed catalog with the renamed ids substituted in -- 0 unmapped, all ten land in `discovery`, and no category drift on the other 143 events. (The script itself needs a `PULUMI_ACCESS_TOKEN` to run end to end, so it can't be exercised fully here.)

The failed run bailed before the commit step, so nothing was written and no automated PR was opened. Once this merges, the next nightly run regenerates `data/audit_log_events.json` with the new ids and descriptions on its own.

### Unreleased product version (optional)

N/A

### Related issues (optional)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQgZFv1WzHJWF67EVQQZRK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQgZFv1WzHJWF67EVQQZRK)_