### PR TITLE
Content review: stop re-selecting a page the day after its review

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -103,7 +103,8 @@ Read `.content-review-queue.json` from the repo root (written by
   `resolved_claims`. A marker you do not resolve is carried onto the next
   review with `unresolved_reviews` incremented, and after two such rounds it
   is escalated for a human — so silently skipping one does not make it go
-  away, it just delays it.
+  away, it just delays it. (That next review is not tomorrow's: the boost
+  sits out a five-day cooldown after any completed review of the page.)
 - `no_retire` — when true, retirement must never be proposed for this page.
   This is the **hard veto** on retirement — honor it regardless of evidence.
 - `reader_signals` / `signals` — Search Console and feedback-widget figures
@@ -715,7 +716,9 @@ The nightly `claims-reverify.yml` workflow re-checks volatile entities
 contradicted, every page asserting it gets a `stale_claims` marker in its
 ledger entry, and `select-articles.py` boosts those pages to the front of the
 next sweep — that is how a page can arrive in your queue the day after a
-release changed a fact it states.
+release changed a fact it states. The boost never fires within five days of
+the page's last completed review, so a marker one review leaves unresolved
+comes back after the cooldown rather than the next morning.
 
 None of this is yours to write: this worker's whole-page runs are the index's
 **only** writer, and the workflow runs `record-claims.py` itself after your

--- a/scripts/content-review/record-page-findings.py
+++ b/scripts/content-review/record-page-findings.py
@@ -36,7 +36,7 @@ Output (uploaded to the ledger bucket's `findings/` prefix, beside `ledger/`
 and `claims/`):
 
     {"schema_version": 2, "slug": ..., "path": ..., "reviewed_at": ...,
-     "commit": ..., "verdict": "fixed|clean|skipped|glowup",
+     "commit": ..., "verdict": "fixed|clean|glowup",
      "counts": {"total": N, "applied": N, "deferred": N, "superseded": N},
      "findings": [{"id": "f3", "label": ..., "source": ..., "detail": ...,
                    "category": ..., "line_range": ..., "fix_candidate": bool,
@@ -457,6 +457,16 @@ def build(queue: dict, verdict: dict | None, artifacts: dict,
         warn("queue has no article; nothing to record")
         return None
     art = articles[0]
+    if (verdict or {}).get("verdict") == "skipped":
+        # The workflow's open-PR pre-check: a previous run owns this page's
+        # PR, nothing was reviewed, no artifacts were computed, and the record
+        # built from that is an empty stub. One replaced elb.md's 12 KB
+        # fix-lane record on 2026-09-08 when the glow-up lane lost a same-day
+        # race to the fix lane. The previous record stands, as it does for an
+        # unknown glow-up disposition below.
+        log("verdict is skipped (a previous run owns this page's PR); leaving "
+            "the previous findings record standing")
+        return None
     cpb = _compose()
     findings, _errors = cpb.collect(
         artifacts.get("verified"), artifacts.get("vale"),
@@ -619,6 +629,12 @@ def self_test() -> int:
     # function stopped making. Writing the all-False record that falls out of
     # that would re-bank the work the glow-up just did, so it takes the same
     # exit as a sentinel carrying no lists at all.
+    # The open-PR pre-check skip computes no artifacts; a record built from it
+    # is an empty stub that replaced elb.md's fix-lane record on 2026-09-08.
+    check("a skipped verdict writes nothing (the previous record stands)",
+          build({"articles": [{"slug": "docs-x", "path": "content/docs/x.md"}]},
+                {"verdict": "skipped", "reason": "open PR already exists"},
+                {}, Path(".")) is None)
     check("a missing backlog skips the write rather than guessing by position",
           mark_from_backlog(F, {"verdict": "glowup",
                                 "executed_ids": ["findings-f2"]}, None) is None)

--- a/scripts/content-review/record-review.py
+++ b/scripts/content-review/record-review.py
@@ -4,8 +4,8 @@
 This is the single source of truth for the ledger record shape and its upload.
 The per-article worker (`.github/workflows/content-review-article.yml`) runs it
 once after the review model finishes, with `if: always()`, so every dispatched
-article lands exactly one canonical ledger object — even when the model exits
-without producing any output.
+article that was actually reviewed lands exactly one canonical ledger object —
+even when the model exits without producing any output.
 
 The model's only structured output is a tiny verdict sentinel
 (`.content-review-verdict.json`); everything authoritative about the PR
@@ -21,6 +21,17 @@ Outcome derivation:
   * verdict "fixed"  + no PR on the canonical branch     -> status "incomplete"
   * sentinel absent, run succeeded, no branch pushed     -> status "clean"
   * sentinel absent, run failed OR a branch exists       -> status "incomplete"
+
+A "skipped" outcome is built and written locally but never uploaded. It is
+the workflow's open-PR pre-check saying a previous run still owns this page's
+PR: nothing was reviewed, so the page's ledger record must go on describing
+its last real review. Until 2026-09-09 the skip was uploaded like any other
+outcome, and on the two days the glow-up lane picked a page the fix lane had
+dispatched minutes earlier (providers/_index.md 2026-08-28, elb.md
+2026-09-08) the skip rebuilt the record from the dispatch-time queue: status
+`skipped`, banked count 0, PR pointer null, and the stale-claim markers the
+fix review had just resolved put back with `unresolved_reviews` incremented —
+which re-boosted the page into the next sweep (#21266, #21495).
 
 The last two cases extend the file's "derive facts from observable state, not
 self-report" principle to the verdict itself: a model that completes its turn
@@ -552,6 +563,18 @@ def build_record(article: dict, verdict: dict | None, pr: dict | None,
 # ---- output -----------------------------------------------------------------
 
 
+def touches_ledger(record: dict) -> bool:
+    """False for the one outcome that must leave the S3 record alone.
+
+    A `skipped` status is the workflow's open-PR pre-check: a previous run
+    still owns this page's PR, nothing was reviewed, and the page's record
+    must keep describing its last real review (the module docstring has what
+    uploading it did instead). Every other status — `incomplete` included,
+    which is how a retry gets counted toward the attempt cap — is written.
+    """
+    return record.get("status") != "skipped"
+
+
 def upload(record: dict, slug: str, uri: str) -> None:
     """Upload the record to <uri>/<slug>.json via the aws CLI (stdin)."""
     key = f"{uri.rstrip('/')}/{slug}.json"
@@ -625,7 +648,10 @@ def run(args) -> int:
     out_path.write_text(json.dumps(record, indent=2) + "\n")
     log(f"status={record['status']} slug={slug} -> {out_path}")
 
-    if uri:
+    if not touches_ledger(record):
+        log(f"status={record['status']}: nothing was reviewed; the ledger record "
+            f"for {slug} is left as it was")
+    elif uri:
         upload(record, slug, uri)
     else:
         warn("CONTENT_REVIEW_LEDGER_URI unset; ledger record written locally only")
@@ -878,6 +904,13 @@ def self_test() -> int:
         r = build_record(article, {"verdict": "skipped", "reason": "draft"},
                          None, article["slug"], prior=prior_reviewed)
         check("a skipped review keeps the pointer", r["last_pr_number"] == 19885)
+        # ...and, being no review at all, never reaches S3: uploading it
+        # overwrote the fix review that had just opened the PR the skip is
+        # about (elb.md, 2026-09-08).
+        check("a skipped outcome never touches the ledger", touches_ledger(r) is False)
+        check("every other outcome does, incomplete included",
+              all(touches_ledger({"status": s})
+                  for s in ("reviewed", "clean", "reported", "glowup", "incomplete")))
         r = build_record(article, None, None, article["slug"],
                          claude_succeeded=False, prior=prior_reviewed)
         check("an incomplete review keeps the pointer", r["last_pr_number"] == 19885)

--- a/scripts/content-review/select-articles.py
+++ b/scripts/content-review/select-articles.py
@@ -68,7 +68,9 @@ Selection algorithm (weighted fair queuing by staleness):
                 resolves it (record-review.py `resolved_claims`), and one
                 unresolved through MARKER_ESCALATION_CAP reviews stops
                 boosting (escalated — a human's turn), so the boost is
-                bounded either way.
+                bounded either way. No marker boosts inside
+                STALE_BOOST_COOLDOWN_DAYS of the page's last completed
+                review, whichever side of that review it was written on.
 
    Ties break on path ascending, so runs are reproducible.
 
@@ -226,21 +228,34 @@ STALE_CLAIM_BOOST = 400.0
 MARKER_ESCALATION_CAP = 2
 
 # A stale-claim marker does not boost while the page's last COMPLETED review is
-# newer than this. The claims index snapshots the PRE-fix page on purpose (the
-# model must not launder its own edits into the index), so the night after a
-# fix merges the marker is still there describing a value the merged PR already
-# corrected — and a +400 boost would drag the just-fixed page straight back to
-# the front of the queue. That echo bought one redundant full review per fix,
-# observed twice in the 2026-08-18 queue alone.
+# newer than this, whichever side of that review the marker was written on.
 #
+# Marker written AFTER the review (an echo): the claims index snapshots the
+# PRE-fix page on purpose (the model must not launder its own edits into the
+# index), so the night after a fix merges the marker is still there describing
+# a value the merged PR already corrected — and a +400 boost would drag the
+# just-fixed page straight back to the front of the queue. That echo bought one
+# redundant full review per fix, observed twice in the 2026-08-18 queue alone.
 # reverify-claims.superseded_by_review() is the primary guard and stops the
 # re-check upstream of the marker; this is the second, independent one, on the
-# consumer side, for a marker that is already on the entry when a fix lands.
-# Both were specified in #20970; only the reverify half shipped.
+# consumer side, for a marker already on the entry when a fix lands.
 #
-# An INCOMPLETE review never suppresses — it did not fix anything, so the
-# marker is still live. A marker surviving past the cooldown is real drift and
-# boosts exactly as before.
+# Marker written BEFORE the review (seen and left): the review was handed the
+# marker in full (`stale_claim_markers`) and did not name it in
+# `resolved_claims`. Until 2026-09-09 that case kept boosting, on the argument
+# that unresolved drift must not be muted — and what it bought was an
+# identical pass the next working day, same marker, same page, before anything
+# about either had changed. elb.md was reviewed on 2026-09-08 (#21457, one of
+# three markers left unresolved), scored 400.4 the next morning, and was
+# reviewed again (#21495); providers/_index.md went from 2026-08-28 (#21220)
+# to 2026-08-31 (#21266) the same way. MARKER_ESCALATION_CAP already says a
+# repeat pass is not the remedy for a marker a review declined; the cooldown
+# says it is not the remedy the next morning either. Nothing is muted: the
+# marker stays on the entry, still rides the queue item, and boosts again once
+# the cooldown lapses — where a second miss escalates it exactly as before.
+#
+# An INCOMPLETE review never suppresses — it did not look at the page, so the
+# marker is still live.
 STALE_BOOST_COOLDOWN_DAYS = 5
 
 
@@ -265,37 +280,24 @@ def _day(value) -> date | None:
         return None
 
 
-def boost_suppressed_by_recent_fix(entry: dict | None, today: date) -> bool:
-    """True when this page's markers are an ECHO of a fix that already landed.
+def boost_suppressed_by_recent_review(entry: dict | None, today: date) -> bool:
+    """True when this page's last COMPLETED review is inside the cooldown.
 
-    See STALE_BOOST_COOLDOWN_DAYS. Three conditions, all required:
-
-    1. The last review COMPLETED (record-review.py's vocabulary: any status
-       but "incomplete"). An incomplete review fixed nothing.
-    2. It is inside the cooldown window.
-    3. EVERY marker on the entry was checked AFTER that review.
-
-    (3) is the one that makes this precise rather than a blunt mute. A marker
-    written after a completed review is the echo #20970 describes: the claims
-    index still holds the PRE-fix snapshot, so that night's re-check re-flags
-    a value the merged PR already corrected. A marker written BEFORE the
-    review is the opposite situation — the review saw it and left it — and
-    that is real, unresolved drift which must keep boosting (and escalates on
-    its own via MARKER_ESCALATION_CAP). Suppressing those would mute the
-    finding the whole mechanism exists to carry.
+    See STALE_BOOST_COOLDOWN_DAYS. "Completed" is record-review.py's
+    vocabulary: any status but "incomplete" — an incomplete review looked at
+    nothing, so it never suppresses. Marker timing is deliberately not
+    consulted: a marker written after the review is an echo of its fix, and a
+    marker written before it was handed to that review and left, and neither
+    earns the page another full pass tomorrow. An unparseable review date
+    fails open (keeps the boost) rather than suppressing silently.
     """
     entry = entry or {}
-    if entry.get("status") == "incomplete":
+    if entry.get("status") == INCOMPLETE_STATUS:
         return False
     reviewed = _day(entry.get("reviewed_at"))
-    if reviewed is None or not (0 <= (today - reviewed).days < STALE_BOOST_COOLDOWN_DAYS):
+    if reviewed is None:
         return False
-    markers = all_markers(entry)
-    if not markers:
-        return False
-    # An undated marker is not provably an echo, so it keeps its boost.
-    checked = [_day(m.get("checked_at")) for m in markers]
-    return all(c is not None and c > reviewed for c in checked)
+    return 0 <= (today - reviewed).days < STALE_BOOST_COOLDOWN_DAYS
 
 
 def active_markers(entry: dict | None) -> list[dict]:
@@ -943,7 +945,7 @@ def main() -> int:
                 today,
                 have_traffic,
                 stale_claims=(bool(active_markers(ledger.get(path)))
-                              and not boost_suppressed_by_recent_fix(
+                              and not boost_suppressed_by_recent_review(
                                   ledger.get(path), today)),
                 gsc_m=gsc_m,
                 feedback_m=fb_m,

--- a/scripts/content-review/select-glowup.py
+++ b/scripts/content-review/select-glowup.py
@@ -35,8 +35,11 @@ glow-up executes nothing — 43% of the eligible pool when measured against the
 live ledger on 2026-08-25. Those pages are excluded from `articles` and the
 highest-scoring one rides the queue's `repairs` array instead: the dispatcher
 sends it to the FIX lane, whose review needs no ledger and writes the findings
-record that makes a real glow-up possible next time. `--exclude-paths` keeps a
-repair off a page the fix lane already queued this run.
+record that makes a real glow-up possible next time. `--exclude-paths` keeps
+both the glow-up pick and the repair off a page the fix lane already queued
+this run: two workers on one page the same day race for its branch, the
+loser's open-PR pre-check throws its dispatch away, and until 2026-09-09 its
+`skipped` outcome also overwrote the winner's ledger and findings records.
 
 Backlog cap: when >= GLOWUP_MAX_OPEN_PRS open `content-review/glowup-*`
 branches exist, emit an empty queue with `"halted": "max_open_glowup_prs"` —
@@ -268,8 +271,8 @@ def main() -> int:
                    help="Comma-separated open content-review branch names (testing)")
     p.add_argument("--exclude-paths", default="",
                    help="Comma-separated content paths the fix lane already "
-                        "queued this run; they are never chosen for a repair, "
-                        "so one page is not reviewed twice in a day")
+                        "queued this run; they are never chosen for a glow-up "
+                        "or a repair, so one page is not reviewed twice in a day")
     p.add_argument("--dry-run", action="store_true", help="Print queue, write nothing")
     args = p.parse_args()
 
@@ -355,6 +358,15 @@ def main() -> int:
             continue
         if _select.slugify(path) in open_slugs:
             continue
+        # The fix lane queued this page this run (--exclude-paths). Until
+        # 2026-09-09 only the repair path honored the list; the glow-up pick
+        # did not, so on 2026-09-08 both lanes dispatched elb.md within a
+        # minute of each other. The glow-up worker lost the race to the fix
+        # PR, hit the open-PR pre-check, and its `skipped` record overwrote
+        # the fix review's ledger entry (putting back two stale-claim markers
+        # that review had just resolved) and its findings record.
+        if path in exclude_paths:
+            continue
         if _select.is_draft(repo / path):
             continue
         if _select.is_redirect_stub(repo / path):
@@ -390,8 +402,6 @@ def main() -> int:
     for score, path, entry, reason in stranded:
         if len(queue["repairs"]) >= GLOWUP_REPAIRS_PER_RUN:
             break
-        if path in exclude_paths:
-            continue
         queue["repairs"].append({
             "path": path,
             "url": _select.url_for(path),

--- a/scripts/content-review/test_select_articles.py
+++ b/scripts/content-review/test_select_articles.py
@@ -549,15 +549,21 @@ def main() -> int:
 
         marker = {"entity_key": "version/pulumi-package", "verdict": "contradicted",
                   "evidence": "CHANGELOG says 3.163.0", "source": "gh release view",
-                  # Before TODAY's review: the review saw this marker and left it
-                  # unresolved, so it is real drift and must keep boosting. (A
-                  # marker dated AFTER the last completed review is the #20970
-                  # echo instead — see boost_suppressed_by_recent_fix.)
-                  "checked_at": "2026-06-10"}
+                  # Before the page's last review: that review saw this marker
+                  # and left it unresolved. Once the boost cooldown after that
+                  # review lapses (REVIEWED_OLD is past it) this is real drift
+                  # and boosts until it escalates. (A marker dated AFTER the
+                  # last completed review is the #20970 echo instead — see
+                  # boost_suppressed_by_recent_review; inside the cooldown
+                  # neither kind boosts.)
+                  "checked_at": "2026-06-01"}
+        # Past STALE_BOOST_COOLDOWN_DAYS before TODAY (2026-06-12), and recent
+        # enough that on staleness alone the page never reaches the queue.
+        REVIEWED_OLD = "2026-06-05"
 
         led = tmp / "ledger-markers"
-        # STACKS is freshly reviewed, so absent a marker it never reaches the queue.
-        write_ledger(led, STACKS, TODAY, stale_claims=[marker])
+        # STACKS is recently reviewed, so absent a marker it never reaches the queue.
+        write_ledger(led, STACKS, REVIEWED_OLD, stale_claims=[marker])
         q = run_select(repo, tiers, led)
         entry = next((a for a in q["articles"] if a["path"] == STACKS), None)
         check(entry is not None, "marked page is boosted into the queue")
@@ -573,7 +579,7 @@ def main() -> int:
         # so a marker withheld here is a marker deleted from the ledger the
         # next time this page is reviewed for any reason.
         led_mixed = tmp / "ledger-mixed"
-        write_ledger(led_mixed, STACKS, TODAY, stale_claims=[
+        write_ledger(led_mixed, STACKS, REVIEWED_OLD, stale_claims=[
             marker,
             {**marker, "entity_key": "version/old-miss",
              "unresolved_reviews": 2, "escalated": True},
@@ -589,7 +595,7 @@ def main() -> int:
                   "stale_claims count matches the marker list it describes")
 
         led_esc = tmp / "ledger-escalated"
-        write_ledger(led_esc, STACKS, TODAY,
+        write_ledger(led_esc, STACKS, REVIEWED_OLD,
                      stale_claims=[{**marker, "unresolved_reviews": 2, "escalated": True}])
         q_esc = run_select(repo, tiers, led_esc)
         esc = next((a for a in q_esc["articles"] if a["path"] == STACKS), None)
@@ -667,7 +673,7 @@ def main() -> int:
         check(all("reserved" not in a for a in qrep["articles"]),
               "the report lane reserves nothing — its whole job is the cold half")
 
-        print("stale-claim boost cooldown (#20970's missing half)")
+        print("stale-claim boost cooldown (#20970's missing half, widened 2026-09-09)")
         import importlib.util
         from datetime import date as _date
         _spec = importlib.util.spec_from_file_location("select_articles", SCRIPT)
@@ -679,29 +685,51 @@ def main() -> int:
             if checked is not None:
                 e["stale_claims"] = [{"entity_key": "version/x", "checked_at": checked}]
             return e
-        check(sa.boost_suppressed_by_recent_fix(_e("2026-08-18", "2026-08-19"), _t) is True,
+        check(sa.boost_suppressed_by_recent_review(_e("2026-08-18", "2026-08-19"), _t) is True,
               "marker written AFTER a just-completed review is an echo: suppressed")
-        check(sa.boost_suppressed_by_recent_fix(_e("2026-08-18", "2026-08-17"), _t) is False,
-              "marker the review SAW and left unresolved is real drift: still boosts")
-        check(sa.boost_suppressed_by_recent_fix(_e("2026-08-01", "2026-08-02"), _t) is False,
-              "past the cooldown, an echo has had time to be real: still boosts")
-        check(sa.boost_suppressed_by_recent_fix(
+        # The 2026-09-09 change. This case used to keep boosting as "real,
+        # unresolved drift", and what that bought was an identical review the
+        # next working day (elb.md #21457 -> #21495, providers #21220 -> #21266).
+        check(sa.boost_suppressed_by_recent_review(_e("2026-08-18", "2026-08-17"), _t) is True,
+              "marker the review SAW and left unresolved sits out the cooldown too")
+        check(sa.boost_suppressed_by_recent_review(_e("2026-08-01", "2026-08-02"), _t) is False,
+              "past the cooldown, an echo has had time to be real: boosts")
+        check(sa.boost_suppressed_by_recent_review(_e("2026-08-01", "2026-07-31"), _t) is False,
+              "past the cooldown, a seen-and-left marker boosts again (then escalates)")
+        check(sa.boost_suppressed_by_recent_review(
                   _e("2026-08-18", "2026-08-19", status="incomplete"), _t) is False,
-              "an incomplete review fixed nothing, so it never suppresses")
-        check(sa.boost_suppressed_by_recent_fix(_e("2026-08-18", None), _t) is False,
-              "no markers, nothing to suppress")
-        check(sa.boost_suppressed_by_recent_fix(_e("2026-08-18", "garbage"), _t) is False,
-              "an undated marker is not provably an echo, so it keeps its boost")
-        check(sa.boost_suppressed_by_recent_fix(_e("garbage", "2026-08-19"), _t) is False,
+              "an incomplete review looked at nothing, so it never suppresses")
+        check(sa.boost_suppressed_by_recent_review(_e("2026-08-18", "garbage"), _t) is True,
+              "marker dating is irrelevant: the review date alone decides")
+        check(sa.boost_suppressed_by_recent_review(_e("garbage", "2026-08-19"), _t) is False,
               "an unparseable review date fails open (boosts), never suppresses silently")
+        check(sa.boost_suppressed_by_recent_review({}, _t) is False,
+              "a never-reviewed page has no cooldown")
         _edge = str(_date.fromordinal(_t.toordinal() - sa.STALE_BOOST_COOLDOWN_DAYS))
-        check(sa.boost_suppressed_by_recent_fix(_e(_edge, "2026-08-19"), _t) is False,
+        check(sa.boost_suppressed_by_recent_review(_e(_edge, "2026-08-19"), _t) is False,
               "exactly COOLDOWN days old is outside the window")
-        check(sa.boost_suppressed_by_recent_fix(
-                  {"status": "reviewed", "reviewed_at": "2026-08-18",
-                   "stale_claims": [{"entity_key": "a", "checked_at": "2026-08-19"},
-                                    {"entity_key": "b", "checked_at": "2026-08-17"}]}, _t) is False,
-              "one pre-review marker is enough to keep the boost")
+
+        # End to end: the elb.md shape. Reviewed yesterday with a marker from
+        # before that review left unresolved (unresolved_reviews 1, not yet
+        # escalated) -> no boost; the same marker on a page reviewed before
+        # the cooldown -> boosted.
+        _yday = str(_date.fromordinal(_date.fromisoformat(TODAY).toordinal() - 1))
+        _old = str(_date.fromordinal(
+            _date.fromisoformat(TODAY).toordinal() - sa.STALE_BOOST_COOLDOWN_DAYS - 1))
+        _seen = {"entity_key": "numerical/timeout", "verdict": "contradicted",
+                 "checked_at": "2026-06-01", "unresolved_reviews": 1, "escalated": False}
+        led_cd = tmp / "ledger-cooldown"
+        write_ledger(led_cd, STACKS, _yday, stale_claims=[_seen])
+        write_ledger(led_cd, ONE, _old, stale_claims=[_seen])
+        q_cd = run_select(repo, tiers, led_cd, "--count", "10")
+        s_cd = scores(q_cd)
+        check(STACKS in s_cd and s_cd[STACKS] < sa.STALE_CLAIM_BOOST,
+              f"reviewed yesterday, marker left: no boost (got {s_cd.get(STACKS)})")
+        check(s_cd.get(ONE, 0) >= sa.STALE_CLAIM_BOOST,
+              f"same marker past the cooldown: boosted (got {s_cd.get(ONE)})")
+        cd_item = next(a for a in q_cd["articles"] if a["path"] == STACKS)
+        check(cd_item["stale_claims"] == 1 and cd_item["stale_claim_markers"] == [_seen],
+              "the suppressed marker still rides the queue item, unchanged")
 
     print(f"\n{_passes} passed, {len(_failures)} failed")
     return 1 if _failures else 0

--- a/scripts/content-review/test_select_glowup.py
+++ b/scripts/content-review/test_select_glowup.py
@@ -300,6 +300,16 @@ def main() -> int:
                        "--exclude-paths", f"{A},{B},{C}")
         check(q["repairs"] == [], "all excluded means no repair, not a fallback pick")
 
+        print("--exclude-paths keeps the glow-up pick itself off a fix-lane page")
+        # Until 2026-09-09 only the repair path honored the list: on 2026-09-08
+        # the fix lane and this lane both dispatched elb.md, and the glow-up
+        # worker's open-PR skip overwrote the fix review's ledger and findings
+        # records.
+        q = run_select(repo, tiers, led_rec, "--count", "10", "--exclude-paths", B)
+        check([a["path"] for a in q["articles"]] == [A, C],
+              f"the fix lane's page is skipped, not glowed up (got {[a['path'] for a in q['articles']]})")
+        check(q["repairs"] == [], "and is not routed to a repair either")
+
         print("an existing-but-EMPTY findings dir skips the check, same as an absent one")
         # The production shape, and the one the guard exists for: the
         # dispatcher runs `mkdir -p .findings-cache` before the sync that fills


### PR DESCRIPTION
The existing-content review lane re-selected `content/docs/iac/guides/clouds/aws/elb.md` on 2026-09-09 (#21495), the morning after it had been reviewed and merged (#21457), and did the same to `content/docs/iac/concepts/providers/_index.md` on 2026-08-31 (#21266, three days after #21220). Neither repeat was a ledger-write failure. Both were the `stale_claims` boost firing on a page the lane had just reviewed, and both were made worse by the glow-up lane picking the same page the fix lane had dispatched minutes earlier.

## Timeline

Reconstructed from the S3 ledger bucket's object versions (`ledger/<slug>.json`, `findings/<slug>.json`) and the PR list. Times are UTC.

### `content/docs/iac/guides/clouds/aws/elb.md`

| When | Event |
| --- | --- |
| 09-02 14:32 | Fix-lane review, PR #21328 (10 fixes, 16 banked). Ledger `reviewed`, score 29.9, no markers. Merged 09-03 23:26. |
| 09-03 to 09-05 07:2x | Nightly `reverify-claims` writes three `stale_claims` markers (health-check `timeout`, `unhealthyThreshold`, `healthyThreshold` defaults). Inside the five-day boost cooldown, so no boost yet. |
| 09-07 | Labor Day; no dispatch. |
| 09-08 14:07 | Dispatcher. Cooldown lapsed; elb scores **402.6** (2.6 + 400 boost) and is dispatched to the fix lane. The glow-up selector, run from the same ledger cache with `--exclude-paths` naming elb, picks elb anyway: the flag only guarded the repairs list. |
| 09-08 14:26 | Fix-lane worker opens #21457 (1 fix, 18 banked), resolves two of the three markers, carries `timeout` with `unresolved_reviews: 1`. Ledger and findings records written. |
| 09-08 14:30 | Glow-up worker hits the open-PR pre-check and records `skipped`. That record **overwrites** the fix lane's: status `skipped`, `pr: null`, banked 0, and all three markers restored from the dispatch-time queue at `unresolved_reviews: 1`. Its findings record (346 bytes, zero findings) replaces the 12.7 KB fix-lane record. |
| 09-08 20:58 | #21457 merges. |
| 09-09 14:07 | Dispatcher. `reviewed_at` 09-08 is inside the cooldown, but every marker predates the review, so `boost_suppressed_by_recent_fix` returns False by design ("the review saw it and left it: real drift"). elb scores **400.4** and is dispatched again. |
| 09-09 14:25 | #21495 opens (2 fixes, 33 banked). Two markers escalate. |

The Linear issue IT-1227 filed at 14:22 that day is a different failure: two **glow-up** workers (`docs/install`, `docs/iac/get-started/terraform`) failed at "Create branch and PR" and were recorded `incomplete` (attempt 1 of 3). It did not touch elb.

### `content/docs/iac/concepts/providers/_index.md`

| When | Event |
| --- | --- |
| 08-15 07:17 | Marker `version/pulumi-package` written. |
| 08-17 / 08-18 | #20927 then #20953: the incident that produced `carry_markers` (the 08-17 run's ledger write never landed). Already fixed. |
| 08-28 10:39 | Marker `version/pulumi-package` written again (the pin had drifted). |
| 08-28 18:16 | Fix-lane review, #21220 (boosted, score 408.3), marker resolved. |
| 08-28 18:33 | Glow-up worker, same page, same run: `skipped` on the open-PR pre-check. Overwrites the record, restoring the marker at `unresolved_reviews: 1`, banked 11 becomes 0. |
| 08-31 14:24 | Dispatcher: inside the cooldown, marker predates the review, so it boosts. #21266 (score 402.5). Merged that evening. |
| 09-01 | Glow-up #21293 (24 fixes), the expected follow-up. |

### `content/docs/iac/concepts/config.md`

Glow-up #21143 (08-26) executed nothing (`glowup_degraded`), the selector routed it to a fix-lane repair #21222 (08-28), and glow-up #21373 (09-03) then executed the rebuilt backlog. That is the repair path #21192 designed, not a repeat.

## Hypotheses

1. **Failed publish leaves the ledger unchanged.** Refuted for these pages: every run wrote its record within a minute of opening its PR.
2. **Merge path never records the review.** Refuted: `reviewed_at` advances at record time, right after the PR opens.
3. **Nightly re-verify re-stamps the page.** Half right. The re-stamp itself was suppressed by the existing echo cooldown; what fired was the deliberate carve-out for markers the review had already seen and left.
4. **Lanes use different slugs.** Refuted; they share `slugify`. The cross-lane problem is the opposite one: the same slug, and the later writer wins.

## Fix

- `select-articles.py`: a stale-claim marker never boosts inside `STALE_BOOST_COOLDOWN_DAYS` of the page's last completed review, whichever side of that review it was written on. `boost_suppressed_by_recent_fix` becomes `boost_suppressed_by_recent_review`. The marker still rides the queue, stays on the ledger, and boosts again once the cooldown lapses, where a second miss escalates it as before.
- `select-glowup.py`: `--exclude-paths` now applies to the glow-up pick, not only to repairs, so the two lanes never dispatch the same page in one run.
- `record-review.py`: a `skipped` outcome (the open-PR pre-check) is written locally and never uploaded. Nothing was reviewed, so the page's record keeps describing its last real review.
- `record-page-findings.py`: same guard, so the pre-check cannot replace a findings record with an empty stub.
- Tests in `test_select_articles.py`, `test_select_glowup.py`, and the two recorders' `--self-test`. `make test-review-pipeline` passes.
- Two sentences in the review-existing-content skill so the worker's description of marker handling matches.

Not changed: no GitHub-side "recently merged PR" cooldown. It would also have prevented these two, but it blocks the marker-driven reviews that are the boost's whole purpose (elb's 09-08 review resolved two real markers), and every link in the confirmed chain is now closed on the ledger side.

## Impact on the Aug 9 to Sep 9 window

Of the 76 pulumi-bot PRs in the window (70 content-review lane, 6 link-fix; 75 merged, 1 open), 11 pages appeared more than once. Seven of those are a fix review followed by its glow-up, which is the designed hand-off. Of the five fix-review-after-fix-review repeats:

- **2 prevented by this change**: #21266 (providers, 08-31) and #21495 (elb, 09-09).
- 1 was the #20927 ledger-write miss, already fixed.
- 2 were marker-driven reviews after the cooldown by design (#21265 ecr 08-31, #21457 elb 09-08); the latter fixed a real drift.

The one glow-up-after-glow-up pair (stash, 08-24 and 08-25) was the degraded-retry loop that #21192 retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYUD8vgjtWRNGT58X2gwSz
