### PR TITLE
docs: document no-subcommand exit code in the exit-codes page

### DIFF
--- a/content/docs/iac/cli/exit-codes.md
+++ b/content/docs/iac/cli/exit-codes.md
@@ -39,4 +39,4 @@ The exact non-zero value of a failing exit code gives us some information about 
 
 ## Running the CLI with no subcommand
 
-Running `pulumi` with no subcommand prints the CLI help and then exits with a non-zero exit code. This behavior changed in Pulumi CLI v3.254.0; earlier versions exited with code 0. If your automation runs a bare `pulumi` command to check that the binary is installed and working, use `pulumi version` or `pulumi --help` instead, both of which exit with code 0.
+Running `pulumi` with no subcommand prints the CLI help and exits with code 1, the generic error code. This behavior changed in Pulumi CLI v3.254.0; earlier versions exited with code 0. If your automation runs a bare `pulumi` command to check that the binary is installed and working, use [`pulumi version`](/docs/iac/cli/commands/pulumi_version/) or `pulumi --help` instead, both of which exit with code 0.

--- a/content/docs/iac/cli/exit-codes.md
+++ b/content/docs/iac/cli/exit-codes.md
@@ -36,3 +36,7 @@ The exact non-zero value of a failing exit code gives us some information about 
 | Canceled run                      | 8         | The operation is canceled before completion, for example due to `pulumi cancel`, a user interrupt (such as Ctrl+C), or cancellation initiated through the Automation API. |
 | Timeout                           | 9         | The operation fails because it does not complete within an expected time window. |
 | Internal CLI error                | 255       | An unexpected internal condition occurs inside the Pulumi CLI itself that does not fit another category. |
+
+## Running the CLI with no subcommand
+
+Running `pulumi` with no subcommand prints the CLI help and then exits with a non-zero exit code. This behavior changed in Pulumi CLI v3.254.0; earlier versions exited with code 0. If your automation runs a bare `pulumi` command to check that the binary is installed and working, use `pulumi version` or `pulumi --help` instead, both of which exit with code 0.


### PR DESCRIPTION
The CLI Exit Codes page does not mention what happens when `pulumi` is run with no subcommand. Since v3.254.0 a bare `pulumi` invocation prints help and exits with a non-zero code (previously it exited 0), which silently broke downstream health checks that used this pattern.

This adds a short note documenting the behavior and pointing to `pulumi version` (or `pulumi --help`) as the reliable way to check that the binary is installed and working.

Refs pulumi/pulumi#24301.
