### PR TITLE
fix(review): key the glow-up body gate on table rows, drop the declined placeholder, alert on publish refusals

### DIFF
--- a/.claude/commands/review-existing-content/SKILL.md
+++ b/.claude/commands/review-existing-content/SKILL.md
@@ -560,7 +560,9 @@ Each banked item is split in two, and the split is the point:
 1. **Work the backlog first.** Execute every banked finding, or explicitly
    decline it with one line of reasoning. Every item lands in exactly one of
    the PR body's two tables — **Backlog executed** (pre-stubbed, one row per
-   item; fill "What changed") or **Backlog declined**. No silent drops.
+   item; fill "What changed") or **Backlog declined** (move the whole row,
+   keeping its id cell, and fill "Why not executed"). No silent drops, and
+   no row in both tables.
 1. **Then the secondary sweep**: apply the improvement taxonomy from
    `.claude/commands/glow-up.md` §5 — style, structural fixes, code
    formatting, terminology, links, image/diagram flags (flag-only, as ever),
@@ -584,6 +586,19 @@ Each banked item is split in two, and the split is the point:
    check is a `::warning::`, not a violation, but every warning must be
    acknowledged in the PR body under "Secondary sweep → Content
    enhancements": name the verdict that supports the wording, or remove it.
+   Then self-check the PR body the way the publish gate will:
+
+   ```bash
+   python3 scripts/content-review/compose-pr-body.py --check-accounting \
+       --body-file .pr-body-draft.md --backlog .glowup-backlog.json
+   ```
+
+   Exit 0 is required. It lists every stubbed id that is not a row in
+   exactly one of the two Backlog tables and any `<TODO` either table still
+   carries; fix the body and re-run until it is clean. Membership is by
+   row (the backticked id that opens a row's first cell), so a reason cell
+   may cross-reference another row ("see `findings-f17`") freely — that is
+   not a second row.
 1. **Verdict sentinel**: `{"verdict": "glowup", "fixes": <executed count>,
    "skipped_findings": <declined count>, "clarity_flag": <bool>,
    "executed_ids": [...], "declined_ids": [...], "retirement": false}` — no

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -983,8 +983,12 @@ jobs:
           # For a glow-up the gate also reads the body against the reconciled
           # backlog snapshot: every composer-stubbed row must sit in Backlog
           # executed or Backlog declined, or nothing is pushed.
-          # stderr is teed to a file so the failure alert below can quote
-          # the gate's ::error:: lines instead of just pointing at the run.
+          # Both streams go to a file first (fail() prints its ::error::
+          # lines on stdout) and are replayed into the log, so the failure
+          # alert below can quote the gate's own lines and the file is
+          # complete before a non-zero status ends the step — a tee'd
+          # process substitution can lose its tail on exactly that path.
+          rc=0
           python3 scripts/content-review/publish-gate.py \
             --queue .content-review-queue.json \
             --verdict .content-review-verdict.json \
@@ -992,7 +996,9 @@ jobs:
             --paths-from .applied.paths \
             --body-file .pr-body-draft.md \
             --backlog .review-snapshot/.glowup-backlog.json \
-            2> >(tee .publish-gate.err >&2)
+            > .publish-gate.err 2>&1 || rc=$?
+          cat .publish-gate.err
+          [ "$rc" -eq 0 ] || exit "$rc"
           TITLE="Content review: $ARTICLE_PATH"
           if [ "${{ steps.gate.outputs.retirement }}" = "true" ]; then
             TITLE="Content review (retirement): $ARTICLE_PATH"

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -724,6 +724,15 @@ jobs:
               but you must acknowledge every one in the PR body: under
               "Secondary sweep → Content enhancements", name the artifact
               verdict that supports the wording, or remove the wording.
+              Then self-check the PR body with the publish gate's own
+              accounting check: `python3
+              scripts/content-review/compose-pr-body.py --check-accounting
+              --body-file .pr-body-draft.md --backlog .glowup-backlog.json`.
+              Exit 0 is required: every stubbed id must be a ROW in exactly
+              one of the Backlog executed / Backlog declined tables (move
+              the whole row, keeping its id cell) and neither table may
+              still carry a `<TODO`. A reason cell may cross-reference
+              another row by id; that is not a second row.
             - Verdict sentinel: `{"verdict": "glowup", "fixes": <executed
               count>, "skipped_findings": <declined count>, "clarity_flag":
               <bool>, "executed_ids": [...], "declined_ids": [...],
@@ -908,6 +917,7 @@ jobs:
       # pushed, and the ledger step still records the page incomplete
       # (if: always()) so it is retried under the attempt cap.
       - name: Enforce guardrail gates
+        id: guardrails
         if: steps.gate.outputs.publish == 'true'
         env:
           ARTICLE_PATH: ${{ github.event.inputs.path }}
@@ -973,13 +983,16 @@ jobs:
           # For a glow-up the gate also reads the body against the reconciled
           # backlog snapshot: every composer-stubbed row must sit in Backlog
           # executed or Backlog declined, or nothing is pushed.
+          # stderr is teed to a file so the failure alert below can quote
+          # the gate's ::error:: lines instead of just pointing at the run.
           python3 scripts/content-review/publish-gate.py \
             --queue .content-review-queue.json \
             --verdict .content-review-verdict.json \
             --patch .review-changes.patch \
             --paths-from .applied.paths \
             --body-file .pr-body-draft.md \
-            --backlog .review-snapshot/.glowup-backlog.json
+            --backlog .review-snapshot/.glowup-backlog.json \
+            2> >(tee .publish-gate.err >&2)
           TITLE="Content review: $ARTICLE_PATH"
           if [ "${{ steps.gate.outputs.retirement }}" = "true" ]; then
             TITLE="Content review (retirement): $ARTICLE_PATH"
@@ -1100,6 +1113,44 @@ jobs:
             } > .lint-comment.md
             gh pr comment "$BRANCH" --body-file .lint-comment.md || true
           fi
+
+      # A worker that refuses its own output is a silent failure otherwise:
+      # the run goes red in the Actions tab, the ledger records the page
+      # incomplete, and nobody is told. Three glow-ups failed the publish
+      # gate on 2026-09-09/10 and were found by hand a day later. One line
+      # to #docs-ops per refusal, quoting the gate's own ::error:: lines.
+      # Fail-open: a Slack outage never fails the job.
+      - name: Post publish failure to Slack
+        if: >-
+          always() && github.event.inputs.mode != 'report' &&
+          (steps.gate.outcome == 'failure' || steps.guardrails.outcome == 'failure' ||
+           steps.publish.outcome == 'failure')
+        continue-on-error: true
+        env:
+          SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
+          ARTICLE_PATH: ${{ github.event.inputs.path }}
+          MODE: ${{ github.event.inputs.mode || 'fix' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          GUARDRAILS_OUTCOME: ${{ steps.guardrails.outcome }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+        run: |
+          STEP="publish"
+          [ "$GUARDRAILS_OUTCOME" = "failure" ] && STEP="guardrail gates"
+          [ "$GATE_OUTCOME" = "failure" ] && STEP="publish gate"
+          DETAIL=$(grep -h '::error::' .publish-gate.err 2>/dev/null | sed 's/^::error:://' | head -5 || true)
+          {
+            echo ":no_entry: content-review worker refused to publish \`${ARTICLE_PATH}\` (mode: ${MODE}) at the ${STEP} step — no PR opened; the page stays due."
+            [ -n "$DETAIL" ] && printf '%s\n' "$DETAIL" | sed 's/^/> /'
+            echo "<${RUN_URL}|Run log>"
+          } > .publish-failure-slack.txt
+          cat .publish-failure-slack.txt
+          [ -n "$SLACK_ACCESS_TOKEN" ] || { echo "::warning::SLACK_ACCESS_TOKEN unavailable; not posting"; exit 0; }
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_ACCESS_TOKEN}" \
+            -H "Content-type: application/json; charset=utf-8" \
+            --data "$(jq -n --arg ch "#docs-ops" --rawfile txt .publish-failure-slack.txt \
+              '{channel: $ch, text: $txt, unfurl_links: false}')"
 
       # AWS creds so the ledger-write step below can push this article's
       # review record to S3. Degrades gracefully (continue-on-error): if the

--- a/.github/workflows/content-review-article.yml
+++ b/.github/workflows/content-review-article.yml
@@ -881,10 +881,16 @@ jobs:
       - name: Publish gate
         id: gate
         run: |
+          # Same capture-and-replay as the publish step's gate call, so a
+          # refusal here quotes its ::error:: lines in the Slack alert too.
+          rc=0
           python3 scripts/content-review/publish-gate.py \
             --queue .content-review-queue.json \
             --verdict .content-review-verdict.json \
-            --patch .review-changes.patch
+            --patch .review-changes.patch \
+            > .publish-gate.err 2>&1 || rc=$?
+          cat .publish-gate.err
+          [ "$rc" -eq 0 ] || exit "$rc"
 
       # Always downloaded (not just when publishing): the guardrail gates
       # below need it for a publishable verdict, and later ledger-side steps

--- a/scripts/content-review/compose-pr-body.py
+++ b/scripts/content-review/compose-pr-body.py
@@ -771,7 +771,8 @@ def compose_glowup(queue: dict, backlog: dict | None, verified, vale,
     declined = ["## Backlog declined\n"]
     declined.append(
         "<!-- One row per banked finding you decided against, one line of "
-        "reasoning each. Rows marked \"pre-declined by the composer\" were "
+        "reasoning each: move the row here from Backlog executed, keeping its "
+        "id cell. Rows marked \"pre-declined by the composer\" were "
         "superseded by this run's artifacts: leave them as they are and list "
         "their ids in the sentinel's declined_ids. -->\n")
     declined.append("| Banked finding | Source PR | Why not executed |")
@@ -779,8 +780,11 @@ def compose_glowup(queue: dict, backlog: dict | None, verified, vale,
     for b in pre_declined:
         declined.append(f"| {_finding_cell(b)} | {_src(b)} | "
                         f"{_cell(b['pre_declined'])}. _Pre-declined by the composer._ |")
-    declined.append("| <TODO: any further banked finding you decided against, one row "
-                    "each, or delete this row> | | |")
+    # No placeholder row. The composer used to stub "<TODO: any further banked
+    # finding ... or delete this row>" here, and the publish gate then refused
+    # the body whenever the model left it in — a row whose only correct
+    # disposition is deletion is a trap, not a prompt (2026-09-09, terraform
+    # get-started). The HTML comment above carries the instruction instead.
 
     sweep = ["## Secondary sweep\n"]
     sweep.append("<!-- The /glow-up taxonomy, applied after the backlog. Note what "
@@ -809,12 +813,31 @@ def compose_glowup(queue: dict, backlog: dict | None, verified, vale,
     ])
 
 
+def _table_row_ids(section: str) -> list[str]:
+    """The ids of a Backlog table's rows: the backticked id that opens each
+    row's first cell (`| \`id\` — **finding** ... |`). This is the same
+    parse record-page-findings.py's declined_reasons() uses, so what the
+    gate accepts is what the findings record can read back."""
+    out = []
+    for line in section.splitlines():
+        m = re.match(r"^\|\s*`([^`]+)`", line.strip())
+        if m:
+            out.append(m.group(1))
+    return out
+
+
 def glowup_body_accounting(body: str, backlog: dict | None) -> list[str]:
-    """Every id the composer stubbed must appear in exactly one of the body's
-    Backlog executed / Backlog declined tables, and neither table may still
-    carry a `<TODO`. Returns the violations (empty = clean). The publish gate
-    calls this so a glow-up body that leaves a row unaccounted never ships —
-    the glow-up analogue of the fix lane's per-hunk scope gate."""
+    """Every id the composer stubbed must appear as a ROW in exactly one of
+    the body's Backlog executed / Backlog declined tables, and neither table
+    may still carry a `<TODO`. Returns the violations (empty = clean). The
+    publish gate calls this so a glow-up body that leaves a row unaccounted
+    never ships — the glow-up analogue of the fix lane's per-hunk scope gate.
+
+    Membership is by row id (the first cell), never by substring: a reason
+    cell that cross-references another row ("see `findings-f17`", "executed
+    under `pr21457-findings-12`") is good reviewing, and the substring check
+    this replaced read every such mention as a second row and refused three
+    consecutive glow-ups for it (2026-09-09/10)."""
     ids = [str(b.get("id")) for b in ((backlog or {}).get("banked") or []) if isinstance(b, dict)]
     ids += [str(st.get("id")) for st in (((backlog or {}).get("reconciled") or {}).get("fresh_stubs") or [])]
     text = body or ""
@@ -828,9 +851,9 @@ def glowup_body_accounting(body: str, backlog: dict | None) -> list[str]:
     if not exe.strip() or not dec.strip():
         out.append("body is missing the Backlog executed and/or Backlog declined section")
         return out
+    exe_ids, dec_ids = set(_table_row_ids(exe)), set(_table_row_ids(dec))
     for bid in ids:
-        tok = f"`{bid}`"
-        in_exe, in_dec = tok in exe, tok in dec
+        in_exe, in_dec = bid in exe_ids, bid in dec_ids
         if in_exe and in_dec:
             out.append(f"{bid} appears in both Backlog executed and Backlog declined")
         elif not (in_exe or in_dec):
@@ -839,6 +862,27 @@ def glowup_body_accounting(body: str, backlog: dict | None) -> list[str]:
         if "<TODO" in sec:
             out.append(f"{name} still carries a <TODO> marker")
     return out
+
+
+def check_accounting(body_file: Path, backlog_file: Path) -> int:
+    """`--check-accounting`: run the publish gate's body check on a draft, the
+    way the model self-checks its diff with verify-glowup-scope.py. Prints one
+    line per violation; exit 2 on any, 0 when clean."""
+    try:
+        body = body_file.read_text()
+        backlog = json.loads(backlog_file.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"compose-pr-body: check-accounting: input unreadable ({e})", file=sys.stderr)
+        return 2
+    problems = glowup_body_accounting(body, backlog)
+    for pr in problems:
+        print(f"compose-pr-body: check-accounting: {pr}", file=sys.stderr)
+    if problems:
+        print(f"compose-pr-body: check-accounting: {len(problems)} violation(s) — "
+              "the publish gate will refuse this body", file=sys.stderr)
+        return 2
+    print("compose-pr-body: check-accounting: clean", file=sys.stderr)
+    return 0
 
 
 def replace_notice(body_file: Path, kind: str) -> int:
@@ -878,8 +922,13 @@ def main() -> int:
     p.add_argument("--replace-notice", choices=["judgment"],
                    help="swap the composed auto-merge notice in --body-file for "
                         "this class's notice, then exit (publish-job mode)")
+    p.add_argument("--check-accounting", action="store_true",
+                   help="glowup mode self-check: run the publish gate's Backlog "
+                        "executed/declined accounting over --body-file against "
+                        "--backlog and exit 2 on any violation")
     p.add_argument("--body-file",
-                   help="the PR body draft to edit in place (with --replace-notice)")
+                   help="the PR body draft to edit in place (with --replace-notice) "
+                        "or to check (with --check-accounting)")
     p.add_argument("--mode", choices=["fix", "glowup"], default="fix",
                    help="body template: the fix lane's (default) or the glow-up lane's")
     p.add_argument("--backlog", default=".glowup-backlog.json",
@@ -894,8 +943,12 @@ def main() -> int:
         if not args.body_file:
             p.error("--replace-notice requires --body-file")
         return replace_notice(Path(args.body_file), args.replace_notice)
+    if args.check_accounting:
+        if not args.body_file:
+            p.error("--check-accounting requires --body-file")
+        return check_accounting(Path(args.body_file), Path(args.repo_root) / args.backlog)
     if not args.queue:
-        p.error("--queue is required (unless --replace-notice)")
+        p.error("--queue is required (unless --replace-notice / --check-accounting)")
 
     root = Path(args.repo_root)
     queue = json.loads(Path(args.queue).read_text())

--- a/scripts/content-review/test_compose_pr_body.py
+++ b/scripts/content-review/test_compose_pr_body.py
@@ -371,8 +371,9 @@ labels = {f["label"] for f in c.collect(_load(RUN_A, ".verified-claims.json"), N
 check("#21291: fresh stub text starts with collect()'s label for the same verdict",
       all(any(st["text"].startswith(lab) for lab in labels) for st in backlog_a["reconciled"]["fresh_stubs"]))
 check("#21291: every stubbed id is accounted for by the accounting check on the draft",
-      c.glowup_body_accounting(body_a, backlog_a) == ["Backlog executed still carries a <TODO> marker",
-                                                     "Backlog declined still carries a <TODO> marker"])
+      c.glowup_body_accounting(body_a, backlog_a) == ["Backlog executed still carries a <TODO> marker"])
+check("composed Backlog declined carries no placeholder row for the model to forget",
+      "<TODO" not in _section(body_a, "Backlog declined"))
 
 # Case 2 — PR #21293 (run 33518035360, providers/_index.md): `pr20503-findings-5`
 # is a July readthrough "self-redundancy" finding the July agent declined as
@@ -460,6 +461,21 @@ check("accounting: a leftover <TODO> in either table is a violation",
       any("<TODO>" in v for v in c.glowup_body_accounting(good.replace("| done |", "| <TODO> |"), acct_backlog)))
 check("accounting: a body without the two sections is a violation",
       c.glowup_body_accounting("## Why this page\n", acct_backlog))
+# Membership is by row, not substring: a reason cell that cross-references
+# another row is not that row appearing twice (2026-09-09/10 false positives).
+xref = good.replace("| `pr1-findings-2` | #1 | no |",
+                    "| `pr1-findings-2` | #1 | same sentence as `pr1-findings-1`, executed there; see also `fresh-c7` |")
+check("accounting: a cross-reference in a reason cell is not a second row",
+      c.glowup_body_accounting(xref, acct_backlog) == [])
+xref2 = good.replace("| `pr1-findings-1` | #1 | done |",
+                     "| `pr1-findings-1` | #1 | done — the `pr1-findings-2` decline below explains the rest |")
+check("accounting: a cross-reference from executed to declined is not a duplicate either",
+      c.glowup_body_accounting(xref2, acct_backlog) == [])
+prose = good.replace("## Secondary sweep", "Also relevant: `fresh-c7` was the trigger.\n\n## Secondary sweep")
+check("accounting: an id mentioned in prose under a table is not a row",
+      c.glowup_body_accounting(prose, acct_backlog) == [])
+check("accounting: _table_row_ids reads the first cell only",
+      c._table_row_ids("| `a-1` — x, see `b-2` | #1 | y `c-3` |\n| --- |\ntext `d-4`\n| `e-5` | | |") == ["a-1", "e-5"])
 
 if failures:
     print(f"\n{len(failures)} failure(s)", file=sys.stderr)


### PR DESCRIPTION
### Proposed changes

Three glow-up workers in a row passed the scope gate and were then refused by `publish-gate.py`'s Backlog accounting, so no glow-up PR opened on 2026-09-09 or 2026-09-10 and nobody was told: [install/_index.md](https://github.com/pulumi/docs/actions/runs/34361912504), [get-started/terraform/_index.md](https://github.com/pulumi/docs/actions/runs/34361915729), [guides/clouds/aws/elb.md](https://github.com/pulumi/docs/actions/runs/34487248304).

Two of the three refusals were gate false positives, the third was a composer trap. This PR fixes both, gives the model the gate as a self-check, and makes the next refusal loud.

**Gate keyed on rows, not substrings.** `glowup_body_accounting()` decided whether an id was "in" a Backlog table with `"`id`" in section`, so a reason cell that cross-referenced another row ("see `findings-f17`", "executed under `pr21457-findings-12`") counted as that id appearing in both tables. The elb body did that six times and was refused six times. Membership is now the backticked id that opens a row's first cell -- the same parse `record-page-findings.py`'s `declined_reasons()` already uses, so what the gate accepts is what the findings record reads back. Re-running the new check over the three refused bodies (downloaded from the handoff/snapshot artifacts): elb and install come back clean.

**No more placeholder row in Backlog declined.** The composer ended that table with `<TODO: any further banked finding ... or delete this row>`, whose only correct disposition was deletion, and the gate refused the body whenever the model left it in. That was the terraform failure. The row is gone; the HTML comment above the table carries the instruction. The terraform body fails the new check on that placeholder alone.

**Self-check.** `compose-pr-body.py --check-accounting --body-file .pr-body-draft.md --backlog .glowup-backlog.json` runs the publish gate's accounting over the draft and exits 2 on any violation, the way the skill already has the model self-check its diff with `verify-glowup-scope.py`. The skill's glow-up Validate step and the worker prompt now require it.

**Slack on refusal.** The publish job posts one line to #docs-ops when the publish gate, the guardrail gates, or the publish step fails, quoting the gate's `::error::` lines (stderr is teed to `.publish-gate.err`). Fail-open, skipped for the report lane.

Tests: `make test-review-pipeline` passes; `test_compose_pr_body.py` gains cross-reference and placeholder cases.

Follow-up once merged: re-dispatch the three refused glow-ups on master.

### Unreleased product version (optional)

n/a

### Related issues (optional)

Follows #21469 (fix-mode Vale + fixpoint loop), which is what made glow-up bodies large enough to trip the substring check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1jQUJLbDHt895GQEwMUoW

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1jQUJLbDHt895GQEwMUoW)_