### PR TITLE
docs: note that passkeys are revoked for organization-managed users

### DIFF
--- a/content/docs/administration/concepts/accounts.md
+++ b/content/docs/administration/concepts/accounts.md
@@ -187,6 +187,8 @@ To use one, select the passkey option on the sign-in page. If your browser suppo
 
 Registering a passkey does not disable any other way of signing in. Your password, if you have one, keeps working, so losing every registered passkey does not lock you out of your account.
 
+An [organization-managed account](/docs/administration/concepts/org-managed-users/) can't register a passkey, because single sign-on through its managing organization is its only login method. Migrating an account to organization-managed revokes every passkey registered on it, and a passkey registered before the migration can no longer sign you in.
+
 {{% notes type="info" %}}
 A passkey sign-in does not prompt for a one-time password, even when you have [MFA](#setting-up-mfa) enrolled. Pulumi Cloud requires user verification, a biometric or a PIN, on every passkey ceremony, so the passkey already proves both possession of the device and the factor that unlocks it. Signing in with your password still prompts for your second factor.
 {{% /notes %}}

--- a/content/docs/administration/concepts/accounts.md
+++ b/content/docs/administration/concepts/accounts.md
@@ -187,7 +187,7 @@ To use one, select the passkey option on the sign-in page. If your browser suppo
 
 Registering a passkey does not disable any other way of signing in. Your password, if you have one, keeps working, so losing every registered passkey does not lock you out of your account.
 
-An [organization-managed account](/docs/administration/concepts/org-managed-users/) can't register a passkey, because single sign-on through its managing organization is its only login method. Migrating an account to organization-managed revokes every passkey registered on it, and a passkey registered before the migration can no longer sign you in.
+An [organization-managed user](/docs/administration/concepts/org-managed-users/) can't register a passkey, because single sign-on through the managing organization is the account's only authentication method. Migrating an account to organization-managed revokes every passkey registered on it, and a passkey registered before the migration can no longer sign you in. The organization's [SAML admin](/docs/administration/guides/saml/saml-admin/) is the exception: they keep an alternative authentication method while they hold the role, so they can register a new passkey after the migration.
 
 {{% notes type="info" %}}
 A passkey sign-in does not prompt for a one-time password, even when you have [MFA](#setting-up-mfa) enrolled. Pulumi Cloud requires user verification, a biometric or a PIN, on every passkey ceremony, so the passkey already proves both possession of the device and the factor that unlocks it. Signing in with your password still prompts for your second factor.

--- a/content/docs/administration/concepts/org-managed-users.md
+++ b/content/docs/administration/concepts/org-managed-users.md
@@ -38,18 +38,19 @@ An organization that uses SCIM is the exception. SCIM can convert an account tha
 
 ## Restrictions
 
-An organization-managed user is subject to three restrictions that an ordinary Pulumi account isn't:
+An organization-managed user is subject to four restrictions that an ordinary Pulumi account isn't:
 
 - **Organization membership.** The account can belong only to the organization that manages it. Invitations to any other organization are rejected. A user who needs access to an unrelated Pulumi organization has to create a separate Pulumi account that isn't organization-managed.
 - **Additional identities.** The account can't connect the identity providers described in [Adding new identities](/docs/administration/concepts/accounts/#adding-new-identities). GitHub, GitLab, Atlassian, and Google identities are unavailable.
 - **Creating organizations.** The account can't [create an organization](/docs/administration/concepts/organizations/#creating-an-organization).
+- **Passkeys.** The account can't register a [passkey](/docs/administration/concepts/accounts/#signing-in-with-a-passkey), and any passkey it had is revoked when it becomes organization-managed. Signing in with a passkey that predates that change is refused. The [SAML admin](/docs/administration/guides/saml/saml-admin/) is the exception here, as they are for [every other login method](#migrating-an-existing-account).
 
 ## Migrating an existing account
 
 Migrating an ordinary account to an organization-managed one is permanent and destructive, and it takes effect as soon as you confirm it.
 
 {{% notes type="warning" %}}
-Migrating an account deletes your personal organization, removes you from every organization other than the one taking it over, and deletes every linked identity except the managing organization's SAML identity. Any authentication method that depended on a deleted identity, such as GitHub or Google, stops working. Single sign-on through the managing organization becomes the account's only authentication method.
+Migrating an account deletes your personal organization, removes you from every organization other than the one taking it over, deletes every linked identity except the managing organization's SAML identity, and revokes every passkey registered on the account. Any authentication method that depended on a deleted identity, such as GitHub or Google, stops working. Single sign-on through the managing organization becomes the account's only authentication method.
 {{% /notes %}}
 
 Pulumi rejects the migration unless all the following are true:
@@ -65,7 +66,7 @@ To migrate the account:
 1. Under your email address, select **Migrate to Org-Managed Account**.
 1. Review the changes in the confirmation dialog, then select **Migrate**.
 
-The [SAML admin](/docs/administration/guides/saml/saml-admin/) role is the exception to the single-authentication-method rule. It exists so that at least one person can still sign in if the SAML configuration breaks, so a SAML admin keeps an alternative login method for as long as they hold the role, and loses it when the role passes to someone else.
+The [SAML admin](/docs/administration/guides/saml/saml-admin/) role is the exception to the single-authentication-method rule. It exists so that at least one person can still sign in if the SAML configuration breaks, so a SAML admin keeps an alternative login method for as long as they hold the role, and loses it when the role passes to someone else. Migration revokes the passkeys of a SAML admin along with everyone else's, but a SAML admin can register a new one afterward, the same way they can reset their password.
 
 ## Learn more
 

--- a/content/docs/administration/concepts/org-managed-users.md
+++ b/content/docs/administration/concepts/org-managed-users.md
@@ -43,7 +43,7 @@ An organization-managed user is subject to four restrictions that an ordinary Pu
 - **Organization membership.** The account can belong only to the organization that manages it. Invitations to any other organization are rejected. A user who needs access to an unrelated Pulumi organization has to create a separate Pulumi account that isn't organization-managed.
 - **Additional identities.** The account can't connect the identity providers described in [Adding new identities](/docs/administration/concepts/accounts/#adding-new-identities). GitHub, GitLab, Atlassian, and Google identities are unavailable.
 - **Creating organizations.** The account can't [create an organization](/docs/administration/concepts/organizations/#creating-an-organization).
-- **Passkeys.** The account can't register a [passkey](/docs/administration/concepts/accounts/#signing-in-with-a-passkey), and any passkey it had is revoked when it becomes organization-managed. Signing in with a passkey that predates that change is refused. The [SAML admin](/docs/administration/guides/saml/saml-admin/) is the exception here, as they are for [every other login method](#migrating-an-existing-account).
+- **Passkeys.** The account can't register a [passkey](/docs/administration/concepts/accounts/#signing-in-with-a-passkey), and any passkey it had is revoked when it becomes organization-managed. Signing in with a passkey that predates that change is refused. The [SAML admin](/docs/administration/guides/saml/saml-admin/) is the exception here, as they are for [every other authentication method](#migrating-an-existing-account).
 
 ## Migrating an existing account
 


### PR DESCRIPTION
pulumi/pulumi-service#48984 (merged) closed the gap where a passkey survived org-managed migration and let a user bypass their managing organization's SSO. Migration now revokes every passkey, registration is blocked for org-managed accounts, and a pre-migration passkey no longer signs anyone in. The SAML admin keeps their break-glass exception and can re-register.

## Changes

- `org-managed-users.md`: fourth **Restrictions** bullet for passkeys; the destructive-migration warning now says passkeys are revoked; the SAML admin paragraph notes they can register a new one afterward.
- `accounts.md`: the passkey section states that an organization-managed account can't register one.

Fixes #21533

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J786VY678r8PahPXEVv8Vg