### PR TITLE
fix(audit-log): categorize the org-downgraded-to-free event

### DIFF
--- a/data/audit_log_event_categories.yaml
+++ b/data/audit_log_event_categories.yaml
@@ -98,6 +98,12 @@
       - organization-
       - retrial-
       - service-
+    events:
+      # A subscription change, which sits with the other organization-level
+      # settings. Listed exactly rather than by prefix because it is the only
+      # event using the abbreviated `org-` spelling; every other organization
+      # event spells it out. Add an `org-` prefix here if more of them appear.
+      - org-downgraded-to-free
 
 - id: teams
   name: Teams


### PR DESCRIPTION
### Proposed changes

The nightly `Audit Logs - Update Events` workflow is failing again, starting with [this morning's 07:27 UTC run](https://github.com/pulumi/docs/actions/runs/34450004239):

```
error: 1 audit log event(s) match no category rule in data/audit_log_event_categories.yaml:
  org-downgraded-to-free
```

The Pulumi Cloud event catalog picked up a new event, and an unmapped event is a deliberate hard failure rather than an "Other" bucket, so the job stops. This adds the one rule it needs.

It matched nothing because it uses an abbreviated `org-` spelling -- the `organization` category carries an `organization-` prefix, and no other event in the catalog abbreviates it. I added it as an exact rule rather than introducing a new `org-` prefix, since it's currently the only one; the inline comment says to switch to a prefix if more show up. It lands in **Organization and members**, next to the other org-level settings and the trial events.

Verified by replaying the fetch script's matching logic against the committed catalog (the script itself needs a `PULUMI_ACCESS_TOKEN`, so it can't run here):

- `org-downgraded-to-free` resolves to `organization`
- all 165 events already in `data/audit_log_events.json` keep the category they have today -- no drift, nothing newly unmapped

`make lint` reports 1779 files parsed, 0 errors, Prettier clean. (Ran `scripts/lint.sh` directly -- `make ensure` can't complete in this container because Hugo isn't installed, so the Node deps were installed with `yarn install` first.)

### One thing worth raising separately

The event is named `org-downgraded-to-free`, and its API-supplied `displayName` will render verbatim on `/docs/administration/reference/audit-log-events/`. Pulumi doesn't sell a "Free" edition -- the closed set in `data/pulumi_pricing.yaml` is Individual / Team / Enterprise / Business Critical, and "Free" is on the never-use list. Whoever owns the event catalog upstream should probably rename it before it's load-bearing. Nothing to do in this repo, and this PR shouldn't wait on it.

### Related issues (optional)

Same workflow as #21357, which pulumi-bot closed yesterday after #21429 fixed the Insights → Discovery renames. This is a different unmapped event that appeared roughly 24 hours later, not a regression of that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbL7DEZxgi4MRSXfNrwS5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbL7DEZxgi4MRSXfNrwS5N)_