### PR TITLE
Warm the shared build caches from master on downstream mirrors

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -127,13 +127,13 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          # Keyed on the Hugo resolved above, not a literal, so the four
+          # Keyed on the Hugo resolved above, not a literal, so the five
           # workflows that share this cache (pull-request.yml,
           # build-and-deploy.yml, testing-build-and-deploy.yml,
-          # pulumi-cli-docs.yml) stay in step through an upgrade without anyone
-          # remembering to bump them. Hugo does not put its version in its own
-          # cache entries, so without this an upgrade keeps serving images
-          # encoded by the previous version indefinitely.
+          # pulumi-cli-docs.yml, warm-build-cache.yml) stay in step through an
+          # upgrade without anyone remembering to bump them. Hugo does not put
+          # its version in its own cache entries, so without this an upgrade
+          # keeps serving images encoded by the previous version indefinitely.
           key: hugo-resources-${{ steps.hugo-version.outputs.version }}-${{ github.sha }}
           restore-keys: |
             hugo-resources-${{ steps.hugo-version.outputs.version }}-

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -113,13 +113,13 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          # Keyed on the Hugo resolved above, not a literal, so the four
+          # Keyed on the Hugo resolved above, not a literal, so the five
           # workflows that share this cache (pull-request.yml,
           # build-and-deploy.yml, testing-build-and-deploy.yml,
-          # pulumi-cli-docs.yml) stay in step through an upgrade without anyone
-          # remembering to bump them. Hugo does not put its version in its own
-          # cache entries, so without this an upgrade keeps serving images
-          # encoded by the previous version indefinitely.
+          # pulumi-cli-docs.yml, warm-build-cache.yml) stay in step through an
+          # upgrade without anyone remembering to bump them. Hugo does not put
+          # its version in its own cache entries, so without this an upgrade
+          # keeps serving images encoded by the previous version indefinitely.
           key: hugo-resources-${{ steps.hugo-version.outputs.version }}-${{ github.sha }}
           restore-keys: |
             hugo-resources-${{ steps.hugo-version.outputs.version }}-

--- a/.github/workflows/pulumi-cli-docs.yml
+++ b/.github/workflows/pulumi-cli-docs.yml
@@ -164,13 +164,13 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          # Keyed on the Hugo resolved above, not a literal, so the four
+          # Keyed on the Hugo resolved above, not a literal, so the five
           # workflows that share this cache (pull-request.yml,
           # build-and-deploy.yml, testing-build-and-deploy.yml,
-          # pulumi-cli-docs.yml) stay in step through an upgrade without anyone
-          # remembering to bump them. Hugo does not put its version in its own
-          # cache entries, so without this an upgrade keeps serving images
-          # encoded by the previous version indefinitely.
+          # pulumi-cli-docs.yml, warm-build-cache.yml) stay in step through an
+          # upgrade without anyone remembering to bump them. Hugo does not put
+          # its version in its own cache entries, so without this an upgrade
+          # keeps serving images encoded by the previous version indefinitely.
           key: hugo-resources-${{ steps.hugo-version.outputs.version }}-${{ github.sha }}
           restore-keys: |
             hugo-resources-${{ steps.hugo-version.outputs.version }}-

--- a/.github/workflows/testing-build-and-deploy.yml
+++ b/.github/workflows/testing-build-and-deploy.yml
@@ -104,13 +104,13 @@ jobs:
         uses: actions/cache@v6
         with:
           path: resources
-          # Keyed on the Hugo resolved above, not a literal, so the four
+          # Keyed on the Hugo resolved above, not a literal, so the five
           # workflows that share this cache (pull-request.yml,
           # build-and-deploy.yml, testing-build-and-deploy.yml,
-          # pulumi-cli-docs.yml) stay in step through an upgrade without anyone
-          # remembering to bump them. Hugo does not put its version in its own
-          # cache entries, so without this an upgrade keeps serving images
-          # encoded by the previous version indefinitely.
+          # pulumi-cli-docs.yml, warm-build-cache.yml) stay in step through an
+          # upgrade without anyone remembering to bump them. Hugo does not put
+          # its version in its own cache entries, so without this an upgrade
+          # keeps serving images encoded by the previous version indefinitely.
           key: hugo-resources-${{ steps.hugo-version.outputs.version }}-${{ github.sha }}
           restore-keys: |
             hugo-resources-${{ steps.hugo-version.outputs.version }}-

--- a/.github/workflows/warm-build-cache.yml
+++ b/.github/workflows/warm-build-cache.yml
@@ -1,0 +1,131 @@
+name: "Scheduled jobs: Warm build cache"
+
+# Downstream mirrors (pulumi/docs-private) have build-and-deploy.yml and
+# testing-build-and-deploy.yml disabled -- nothing there should deploy. That
+# leaves those repos with no job that ever runs on master, and GitHub scopes
+# actions/cache so a branch can restore only entries written by its own branch
+# or by the default branch. Every PR on a mirror is a fresh branch, so every PR
+# build there started cold: no meta-images-* or hugo-resources-* entry matched
+# even on the prefix restore key, Hugo re-encoded ~2,700 images (9 minutes),
+# generate-meta-images.mjs re-rendered every card (4 minutes), and the run took
+# 19-24 minutes against ~7 warm on pulumi/docs. The #21060 fixes were present
+# on the mirror the whole time; they just had no cache to keep.
+#
+# This job is the missing master-branch writer. It restores whatever is there,
+# runs the same `make ensure` + `make build` path pulumi-cli-docs.yml uses,
+# and lets actions/cache save the result under master's scope, where every PR
+# branch can restore it. It deploys nothing and needs no cloud credentials.
+#
+# pulumi/docs itself is excluded: its master deploys already write this cache
+# on every push, so a run here would only add compute. The gate mirrors the
+# one in scheduled-upstream-sync.yaml.
+on:
+  schedule:
+    # Every six hours, offset from the quarter-hour upstream sync. Hugo's
+    # resources cache is content-addressed and the meta-image generator skips
+    # unchanged pages, so a run on a warm cache only encodes what the last six
+    # hours of synced commits changed.
+    - cron: '23 */6 * * *'
+  workflow_dispatch: null
+
+# A second scheduled run overlapping the first would save a competing cache
+# entry for the same sha; queue it instead.
+concurrency:
+  group: warm-build-cache
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  warm:
+    # Only run this job on downstream mirrors. See the header comment.
+    if: github.repository != 'pulumi/docs'
+    name: Build site on master to populate the shared caches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: master
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24.x'
+          cache: 'yarn'
+          cache-dependency-path: |
+            yarn.lock
+            infrastructure/yarn.lock
+            theme/yarn.lock
+            theme/stencil/yarn.lock
+
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.157.0'
+          extended: true
+
+      - name: Install Vale (required by scripts/ensure.sh)
+        run: |
+          VALE_VERSION="3.14.1"
+          VALE_SHA256="ff2b49ffaa9dcd246fd5008f03ff67746d2790b75bf4d3657e2fb9530fb96db3"
+          curl -fsSL -o /tmp/vale.tar.gz "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin vale -f /tmp/vale.tar.gz
+          rm /tmp/vale.tar.gz
+
+      # Restore previously generated OpenGraph cards so the build-time generator
+      # only re-renders pages that changed (manifest content-hash skip). The
+      # cards are gitignored; this cache is their only persistence across runs.
+      - name: Cache generated meta images
+        uses: actions/cache@v6
+        with:
+          path: assets/images/generated
+          key: meta-images-${{ github.sha }}
+          restore-keys: |
+            meta-images-
+
+      # Derive the cache key from the Hugo installed above rather than a literal,
+      # so revving hugo-version updates the key on its own. Fails loudly on an
+      # unparseable version rather than silently collapsing every build into a
+      # single unversioned namespace, which is the bug this exists to prevent.
+      - name: Resolve Hugo version for the cache key
+        id: hugo-version
+        run: |
+          hv="$(hugo version)"
+          # -n/p so a non-match yields empty rather than echoing the input back,
+          # and check before appending -extended so the guard can't see a value
+          # that is only the suffix.
+          ver="$(printf '%s' "$hv" | sed -nE 's/^hugo v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')"
+          [ -n "$ver" ] || { echo "could not parse hugo version from: $hv" >&2; exit 1; }
+          case "$hv" in *+extended*) ver="$ver-extended" ;; esac
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      # Persist Hugo's processed-image cache (resources/_gen). This is the entry
+      # the mirror's PR builds restore from, so it has to be written from the
+      # default branch -- which is the whole reason this workflow exists.
+      - name: Cache Hugo processed images
+        uses: actions/cache@v6
+        with:
+          path: resources
+          # Keyed on the Hugo resolved above, not a literal, so the five
+          # workflows that share this cache (pull-request.yml,
+          # build-and-deploy.yml, testing-build-and-deploy.yml,
+          # pulumi-cli-docs.yml, warm-build-cache.yml) stay in step through an
+          # upgrade without anyone remembering to bump them. Hugo does not put
+          # its version in its own cache entries, so without this an upgrade
+          # keeps serving images encoded by the previous version indefinitely.
+          key: hugo-resources-${{ steps.hugo-version.outputs.version }}-${{ github.sha }}
+          restore-keys: |
+            hugo-resources-${{ steps.hugo-version.outputs.version }}-
+
+      - run: make ensure
+        env:
+          # fetch-github-stars.js runs unauthenticated without this and can hit
+          # the anonymous rate limit on a busy runner pool.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # A full non-preview build under CI, so build-site.sh runs Hugo with --gc
+      # and prunes cache entries the site no longer references -- the same
+      # bounded-growth behaviour the deploy workflows give pulumi/docs.
+      - run: make build
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -1412,6 +1412,24 @@ The repository uses 24 GitHub Actions workflows organized into categories. All w
 
 **Why It Matters:** Keeps private documentation fork synchronized with public repository.
 
+#### warm-build-cache.yml
+
+**Purpose:** Populate the shared Hugo image cache and meta-image cache from the default branch on downstream mirrors
+
+**Triggers:**
+
+- Every 6 hours
+- Manual: `workflow_dispatch`
+
+**Target:** Only runs on private fork repositories (not pulumi/docs)
+
+**Jobs:**
+
+- Check out `master`, restore the `meta-images-*` and `hugo-resources-*` caches, run `make ensure` + `make build`, and let `actions/cache` save the result
+- No deploy, no cloud credentials
+
+**Why It Matters:** GitHub scopes `actions/cache` so a branch can only restore entries written by itself or by the default branch. On the mirrors, `build-and-deploy.yml` and `testing-build-and-deploy.yml` are disabled, so nothing ever wrote a cache from `master` and every PR build there started cold (Hugo re-encoding ~2,700 images, ~19-24 minutes per run versus ~7 warm on pulumi/docs). This job is the missing default-branch writer. `pulumi/docs` doesn't need it because its master deploys already save the same caches on every push.
+
 ### Social Media Automation
 
 #### schedule-social.yml


### PR DESCRIPTION
### Proposed changes

pulumi/docs-private has carried every piece of #21060 since the 2026-09-04 upstream sync (clean.sh CI guard, GOMEMLIMIT, `--gc`, versioned `hugo-resources-*` key, concurrency group, duration alert -- all six touched files are byte-identical to docs master). Its PR builds still take 19-24 minutes, which is what the Sep 8 "Build and deploy took 21m" alerts in #docs-ops were.

The run log for one of them ([34272868254](https://github.com/pulumi/docs-private/actions/runs/34272868254)) shows why:

```
Cache not found for input keys: meta-images-0f695db7..., meta-images-
Cache not found for input keys: hugo-resources-0.157.0-extended-0f695db7..., hugo-resources-0.157.0-extended-
Generating meta images...          (3m54s)
Running Hugo...                    Total in 536871 ms
  5m52s cumulative  488ms avg  721 calls  _partials/blog/feature-image.html
```

Both caches miss on every PR, even on the prefix restore key. GitHub scopes `actions/cache` so a branch can restore only entries written by itself or by the default branch. On the mirror, `build-and-deploy.yml` and `testing-build-and-deploy.yml` are disabled (it must not deploy), so nothing ever runs on master and nothing ever writes a master-scoped cache. Every PR is a fresh branch, so every PR builds cold. The #21060 fixes were present the whole time; they just had nothing to keep.

This adds `warm-build-cache.yml`: a scheduled job (every 6h + `workflow_dispatch`), gated to downstream repos with the same `github.repository != 'pulumi/docs'` test `scheduled-upstream-sync.yaml` uses, that checks out master, restores both caches, runs `make ensure` + `make build`, and lets `actions/cache` save the result under master's scope. No deploy, no cloud credentials, no ESC. It's the same `ensure` + `build` path `pulumi-cli-docs.yml` already runs, so the build under CI gets `--gc` and prunes the cache the way the deploy workflows do on pulumi/docs.

Also:

- The "four workflows that share this cache" comment in the four existing cache steps now says five and names the new one, so the set that has to move together through a Hugo upgrade stays accurate.
- `BUILD-AND-DEPLOY.md` documents the workflow under Utility Workflows next to the upstream sync.

Expected effect on the mirror: first scheduled run is cold (~12 min); after that, PR builds should drop to roughly the ~7 min pulumi/docs sees. Nothing changes on pulumi/docs itself -- the job is skipped there.

### Unreleased product version (optional)

N/A

### Related issues (optional)

Follow-up to #21060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKnK93kpUip9hDd8w2cvWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKnK93kpUip9hDd8w2cvWY)_