### PR TITLE
Tag the DNS post as cloudflare

### DIFF
--- a/content/blog/manage-my-dns/index.md
+++ b/content/blog/manage-my-dns/index.md
@@ -5,7 +5,7 @@ updated: 2025-03-05
 draft: false
 meta_desc: In this article, Rawkode shows how he uses Pulumi to manage the DNS records for his many domains.
 authors: ["david-flanagan"]
-tags: [domains, dns]
+tags: [domains, dns, cloudflare]
 category: tutorials
 aliases:
   - /blog/2022-03-22-my-pulumi-managing-my-dns


### PR DESCRIPTION
Adds the `cloudflare` tag to the "Managing my DNS with Pulumi" post, which provisions Cloudflare zones and records but was tagged only `domains`/`dns`. Brings it in line with the other Cloudflare tutorials so it surfaces under the Cloudflare taxonomy in the [Dev Center](https://pulumi.com/dev).