### PR TITLE
Update lane: quoted protocol is not a request, explicit refresh wins the race, pointer goes to the author

### DIFF
--- a/.claude/commands/docs-review/scripts/mention-gate.py
+++ b/.claude/commands/docs-review/scripts/mention-gate.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Decide whether a comment really asks for a review refresh.
+
+The `@claude … #update-review` / `#new-review` workflows fire on a plain
+substring match in their `if:` expressions (GitHub expressions can't strip
+markdown). That is enough to make a comment that merely *quotes* the reply
+pattern — an explainer with `@claude F2: … #update-review` in backticks, a
+quote-reply of the card's own instructions — dispatch a full model run
+(#21535: two of four card versions were unrequested). This script is the
+second, precise check the workflows run before spending anything: it
+removes fenced code blocks, inline code spans, and blockquoted lines, then
+looks for the mention and the hashtag in what is left.
+
+Two entry points, both side-effect free:
+
+  check    — one body (from an env var, never argv): does it carry a live
+             `@claude` + `#<hashtag>` outside quoted material? Prints
+             `fire=<bool>` and `reason=<text>` in GITHUB_OUTPUT form.
+  pending  — given recent comments/reviews on a PR plus the in-flight
+             workflow runs, is an explicit refresh already on its way? Used
+             by the auto-refresh job so a push-then-comment sequence doesn't
+             cancel the human's request through the per-PR concurrency group.
+             Prints `yield=<bool>` and `reason=<text>`.
+
+Exit status is 0 for every decision; only a usage error is non-zero, so a
+workflow step can't be knocked over by the input it is judging.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+
+MENTION = "@claude"
+
+# Fenced blocks first (``` or ~~~, any info string, any length), then inline
+# spans — a run of N backticks closed by the same run, per CommonMark — then
+# whole blockquoted lines. Order matters: an inline-span regex run over a
+# fence would pair the wrong backticks.
+_FENCE_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})[^\n]*\n.*?^[ \t]{0,3}\1[ \t]*$", re.S | re.M)
+_UNCLOSED_FENCE_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})[^\n]*\n.*\Z", re.S | re.M)
+_INLINE_RE = re.compile(r"(`+)(?!`)(.+?)(?<!`)\1(?!`)", re.S)
+_QUOTE_LINE_RE = re.compile(r"^[ \t]{0,3}>.*$", re.M)
+
+
+def strip_quoted(text: str) -> str:
+    """Return `text` with code and blockquotes removed.
+
+    Anything a reader would understand as "showing" rather than "saying":
+    fenced blocks, inline spans, and `>`-prefixed lines. An unclosed fence
+    swallows the rest of the comment, matching how GitHub renders it.
+    """
+    text = _FENCE_RE.sub(" ", text)
+    text = _UNCLOSED_FENCE_RE.sub(" ", text)
+    text = _INLINE_RE.sub(" ", text)
+    text = _QUOTE_LINE_RE.sub(" ", text)
+    return text
+
+
+def decide(body: str, hashtag: str, exclude: str | None = None) -> tuple[bool, str]:
+    """Should a `#<hashtag>` workflow fire for `body`?
+
+    `exclude` is the more decisive hashtag that wins when both appear live
+    (`#new-review` beats `#update-review`). Quoted material never counts for
+    either: a quoted `#new-review` does not suppress a live `#update-review`.
+    """
+    live = strip_quoted(body or "")
+    tag = f"#{hashtag}"
+    if MENTION not in live or tag not in live:
+        raw = body or ""
+        if MENTION in raw and tag in raw:
+            return False, f"{MENTION} + {tag} appear only inside code or a blockquote"
+        return False, f"no live {MENTION} + {tag}"
+    if exclude and f"#{exclude}" in live:
+        return False, f"#{exclude} present — the more decisive command wins"
+    return True, f"live {MENTION} + {tag}"
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+EXPLICIT_EVENTS = {"issue_comment", "pull_request_review_comment", "pull_request_review"}
+IN_FLIGHT = {"queued", "in_progress", "waiting", "requested", "pending"}
+
+
+def pending_explicit(
+    items: list[dict],
+    runs: list[dict],
+    hashtag: str,
+    since: datetime,
+    exclude: str | None = None,
+) -> tuple[bool, str]:
+    """Is an explicit `#<hashtag>` request already being served?
+
+    `items` are issue comments, review comments, and reviews (any mix; each
+    needs `user.login`, a body, and `created_at` or `submitted_at`). `runs`
+    are workflow runs of the refresh workflow (`event`, `status`,
+    `created_at`). Yield when a live request newer than `since` exists AND a
+    run of an explicit event type is still in flight and was created after
+    that request — a request whose run already finished may have evaluated
+    an older head and must not suppress the refresh for the new push.
+    """
+    newest: datetime | None = None
+    newest_by = ""
+    for item in items:
+        login = ((item.get("user") or {}).get("login") or "")
+        if login.endswith("[bot]") and not login.startswith("workprentice"):
+            continue  # the pipeline's own progress notes quote the protocol too
+        ts = _parse_ts(item.get("created_at") or item.get("submitted_at"))
+        if ts is None or ts < since:
+            continue
+        fire, _ = decide(item.get("body") or "", hashtag, exclude)
+        if fire and (newest is None or ts > newest):
+            newest, newest_by = ts, login
+    if newest is None:
+        return False, f"no live #{hashtag} request since {since.isoformat()}"
+    for run in runs:
+        if run.get("event") not in EXPLICIT_EVENTS:
+            continue
+        if (run.get("status") or "") not in IN_FLIGHT:
+            continue
+        run_ts = _parse_ts(run.get("created_at") or run.get("createdAt"))
+        if run_ts is not None and run_ts >= newest - timedelta(seconds=5):
+            return True, f"explicit #{hashtag} by {newest_by} at {newest.isoformat()} has a run in flight"
+    return False, f"explicit #{hashtag} by {newest_by} at {newest.isoformat()} has no run in flight"
+
+
+def _emit(pairs: dict[str, object]) -> None:
+    for key, value in pairs.items():
+        text = str(value).lower() if isinstance(value, bool) else str(value)
+        print(f"{key}={text}")
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    body = os.environ.get(args.body_env, "")
+    title = os.environ.get(args.title_env, "") if args.title_env else ""
+    fire, reason = decide(f"{body}\n{title}" if title else body, args.hashtag, args.exclude)
+    if not fire:
+        print(f"::notice::mention gate: not firing — {reason}", file=sys.stderr)
+    _emit({"fire": fire, "reason": reason})
+    return 0
+
+
+def _load_json_list(path: str | None) -> list[dict]:
+    if not path:
+        return []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return []
+    if isinstance(data, dict):
+        data = data.get("workflow_runs") or data.get("items") or []
+    return [d for d in data if isinstance(d, dict)]
+
+
+def _cmd_pending(args: argparse.Namespace) -> int:
+    since = _parse_ts(args.since)
+    if since is None:
+        print("pending: --since must be an ISO-8601 timestamp", file=sys.stderr)
+        return 2
+    items: list[dict] = []
+    for path in args.comments:
+        items.extend(_load_json_list(path))
+    runs = _load_json_list(args.runs)
+    do_yield, reason = pending_explicit(items, runs, args.hashtag, since, args.exclude)
+    _emit({"yield": do_yield, "reason": reason})
+    return 0
+
+
+def _self_test() -> int:
+    failures = 0
+
+    def check(name: str, cond: bool) -> None:
+        nonlocal failures
+        print(f"  {'ok ' if cond else 'FAIL'} {name}")
+        if not cond:
+            failures += 1
+
+    # -- decide ------------------------------------------------------------
+    check("plain mention fires", decide("@claude F2: sourced it #update-review", "update-review", "new-review")[0])
+    check("inline-code quote does not fire",
+          not decide("Reply with `@claude F<n>: … #update-review` to answer.", "update-review", "new-review")[0])
+    check("fenced quote does not fire",
+          not decide("Use:\n```\n@claude F1: fixed #update-review\n```\nthanks", "update-review", "new-review")[0])
+    check("tilde fence does not fire",
+          not decide("~~~text\n@claude #update-review\n~~~", "update-review", "new-review")[0])
+    check("blockquote does not fire",
+          not decide("> @claude F2: … #update-review\n\nDone, thanks.", "update-review", "new-review")[0])
+    check("live mention beside a quoted one fires",
+          decide("Per the card (`@claude F2 #update-review`): @claude F2: the figure is from Q3 #update-review",
+                 "update-review", "new-review")[0])
+    check("double-backtick span stripped",
+          not decide("``@claude #update-review``", "update-review", "new-review")[0])
+    check("unclosed fence swallows the rest",
+          not decide("```\n@claude #update-review", "update-review", "new-review")[0])
+    check("live #new-review beats #update-review",
+          not decide("@claude #update-review #new-review", "update-review", "new-review")[0])
+    check("quoted #new-review does not suppress",
+          decide("@claude F1: fixed #update-review (not `#new-review`)", "update-review", "new-review")[0])
+    check("mention only, no hashtag", not decide("@claude what does F2 mean?", "update-review")[0])
+    check("hashtag only, no mention", not decide("#update-review please", "update-review")[0])
+    check("new-review mode fires", decide("@claude #new-review", "new-review")[0])
+    check("empty body", not decide("", "update-review")[0])
+    check("reason names the quote",
+          "inside code" in decide("`@claude #update-review`", "update-review")[1])
+
+    # -- pending -----------------------------------------------------------
+    since = datetime(2026, 9, 10, 20, 20, tzinfo=timezone.utc)
+    live = {"user": {"login": "workprentice[bot]"}, "body": "@claude I pushed a fix for F1 #update-review",
+            "created_at": "2026-09-10T20:35:02Z"}
+    quoted = {"user": {"login": "someone"}, "body": "the pattern is `@claude … #update-review`",
+              "created_at": "2026-09-10T20:36:00Z"}
+    bot_note = {"user": {"login": "github-actions[bot]"}, "body": "@claude #update-review", "created_at": "2026-09-10T20:37:00Z"}
+    old = {"user": {"login": "alice"}, "body": "@claude F3 #update-review", "created_at": "2026-09-10T19:00:00Z"}
+    inflight = {"event": "issue_comment", "status": "in_progress", "created_at": "2026-09-10T20:35:06Z"}
+    finished = {"event": "issue_comment", "status": "completed", "created_at": "2026-09-10T20:35:06Z"}
+    auto = {"event": "workflow_dispatch", "status": "in_progress", "created_at": "2026-09-10T20:35:14Z"}
+    earlier_run = {"event": "issue_comment", "status": "in_progress", "created_at": "2026-09-10T20:00:00Z"}
+
+    check("live request + in-flight run yields",
+          pending_explicit([live], [inflight], "update-review", since, "new-review")[0])
+    check("quoted request does not yield",
+          not pending_explicit([quoted], [inflight], "update-review", since, "new-review")[0])
+    check("pipeline progress note does not count",
+          not pending_explicit([bot_note], [inflight], "update-review", since, "new-review")[0])
+    check("request older than window does not yield",
+          not pending_explicit([old], [inflight], "update-review", since, "new-review")[0])
+    check("finished run does not yield",
+          not pending_explicit([live], [finished], "update-review", since, "new-review")[0])
+    check("auto dispatch run is not explicit",
+          not pending_explicit([live], [auto], "update-review", since, "new-review")[0])
+    check("run older than the request does not count",
+          not pending_explicit([live], [earlier_run], "update-review", since, "new-review")[0])
+    check("review with submitted_at counts",
+          pending_explicit([{"user": {"login": "bob"}, "body": "@claude F1 #update-review",
+                             "submitted_at": "2026-09-10T20:34:00Z"}],
+                           [{"event": "pull_request_review", "status": "queued", "created_at": "2026-09-10T20:34:03Z"}],
+                           "update-review", since, "new-review")[0])
+    check("no items", not pending_explicit([], [inflight], "update-review", since)[0])
+
+    print("mention-gate self-test:", "PASS" if failures == 0 else f"{failures} FAILED")
+    return 1 if failures else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--self-test", action="store_true")
+    sub = parser.add_subparsers(dest="cmd")
+
+    chk = sub.add_parser("check", help="judge one comment body")
+    chk.add_argument("--hashtag", required=True, help="e.g. update-review")
+    chk.add_argument("--exclude", default=None, help="hashtag that wins when both appear live")
+    chk.add_argument("--body-env", required=True, help="env var holding the body (never pass the body as an argument)")
+    chk.add_argument("--title-env", default=None, help="env var holding an issue title to consider alongside the body")
+
+    pen = sub.add_parser("pending", help="is an explicit request already in flight?")
+    pen.add_argument("--hashtag", required=True)
+    pen.add_argument("--exclude", default=None)
+    pen.add_argument("--since", required=True, help="ISO-8601; requests older than this are ignored")
+    pen.add_argument("--comments", action="append", default=[], help="JSON list of comments/reviews (repeatable)")
+    pen.add_argument("--runs", default=None, help="JSON list of workflow runs (gh run list --json or the REST shape)")
+
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return _self_test()
+    if args.cmd == "check":
+        return _cmd_check(args)
+    if args.cmd == "pending":
+        return _cmd_pending(args)
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/commands/docs-review/scripts/mention-gate.py
+++ b/.claude/commands/docs-review/scripts/mention-gate.py
@@ -41,9 +41,15 @@ MENTION = "@claude"
 # spans — a run of N backticks closed by the same run, per CommonMark — then
 # whole blockquoted lines. Order matters: an inline-span regex run over a
 # fence would pair the wrong backticks.
+#
+# The inline pattern deliberately stays on one line (no re.S): a code span
+# can't cross a paragraph break, so a stray unpaired backtick must not pair
+# with one paragraphs later and swallow a live request in between. Erring
+# this way costs at most a run on a quoted protocol split across lines;
+# erring the other way silently drops a real request.
 _FENCE_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})[^\n]*\n.*?^[ \t]{0,3}\1[ \t]*$", re.S | re.M)
 _UNCLOSED_FENCE_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})[^\n]*\n.*\Z", re.S | re.M)
-_INLINE_RE = re.compile(r"(`+)(?!`)(.+?)(?<!`)\1(?!`)", re.S)
+_INLINE_RE = re.compile(r"(`+)(?!`)([^\n]+?)(?<!`)\1(?!`)")
 _QUOTE_LINE_RE = re.compile(r"^[ \t]{0,3}>.*$", re.M)
 
 
@@ -204,6 +210,11 @@ def _self_test() -> int:
           not decide("``@claude #update-review``", "update-review", "new-review")[0])
     check("unclosed fence swallows the rest",
           not decide("```\n@claude #update-review", "update-review", "new-review")[0])
+    check("a stray backtick before a live request does not swallow it",
+          decide("One stray ` here.\n\n@claude F1: default is 5 per the AWS reference #update-review\n\nSee `verify.py`.",
+                 "update-review", "new-review")[0])
+    check("a span still can't hide a request on the same line",
+          not decide("try `@claude #update-review` first", "update-review", "new-review")[0])
     check("live #new-review beats #update-review",
           not decide("@claude #update-review #new-review", "update-review", "new-review")[0])
     check("quoted #new-review does not suppress",

--- a/.claude/commands/docs-review/scripts/mention-gate.py
+++ b/.claude/commands/docs-review/scripts/mention-gate.py
@@ -97,6 +97,11 @@ def _parse_ts(value: str | None) -> datetime | None:
 
 EXPLICIT_EVENTS = {"issue_comment", "pull_request_review_comment", "pull_request_review"}
 IN_FLIGHT = {"queued", "in_progress", "waiting", "requested", "pending"}
+# The same exclusion the workflows' own `if:` applies — exact logins, never
+# a prefix or a `[bot]` heuristic. `claude[bot]` is the review itself (its
+# footer quotes the protocol); any other commenter, human or bot, who writes
+# a live request gets a run and so must count as a request in flight.
+EXCLUDED_LOGINS = {"claude[bot]"}
 
 
 def pending_explicit(
@@ -120,8 +125,8 @@ def pending_explicit(
     newest_by = ""
     for item in items:
         login = ((item.get("user") or {}).get("login") or "")
-        if login.endswith("[bot]") and not login.startswith("workprentice"):
-            continue  # the pipeline's own progress notes quote the protocol too
+        if login in EXCLUDED_LOGINS:
+            continue  # the workflow trigger excludes this login; it never starts a run
         ts = _parse_ts(item.get("created_at") or item.get("submitted_at"))
         if ts is None or ts < since:
             continue
@@ -232,7 +237,10 @@ def _self_test() -> int:
             "created_at": "2026-09-10T20:35:02Z"}
     quoted = {"user": {"login": "someone"}, "body": "the pattern is `@claude … #update-review`",
               "created_at": "2026-09-10T20:36:00Z"}
-    bot_note = {"user": {"login": "github-actions[bot]"}, "body": "@claude #update-review", "created_at": "2026-09-10T20:37:00Z"}
+    bot_note = {"user": {"login": "claude[bot]"}, "body": "@claude #update-review", "created_at": "2026-09-10T20:37:00Z"}
+    other_bot = {"user": {"login": "eon-pulumi-agent[bot]"}, "body": "@claude F1: sourced #update-review",
+                 "created_at": "2026-09-10T20:36:30Z"}
+    human = {"user": {"login": "alice"}, "body": "@claude F2: fixed #update-review", "created_at": "2026-09-10T20:36:40Z"}
     old = {"user": {"login": "alice"}, "body": "@claude F3 #update-review", "created_at": "2026-09-10T19:00:00Z"}
     inflight = {"event": "issue_comment", "status": "in_progress", "created_at": "2026-09-10T20:35:06Z"}
     finished = {"event": "issue_comment", "status": "completed", "created_at": "2026-09-10T20:35:06Z"}
@@ -243,8 +251,16 @@ def _self_test() -> int:
           pending_explicit([live], [inflight], "update-review", since, "new-review")[0])
     check("quoted request does not yield",
           not pending_explicit([quoted], [inflight], "update-review", since, "new-review")[0])
-    check("pipeline progress note does not count",
+    check("claude[bot]'s own comment does not count",
           not pending_explicit([bot_note], [inflight], "update-review", since, "new-review")[0])
+    check("workprentice[bot] counts",
+          pending_explicit([live], [inflight], "update-review", since, "new-review")[0])
+    check("any other bot login counts",
+          pending_explicit([other_bot], [{"event": "issue_comment", "status": "queued", "created_at": "2026-09-10T20:36:33Z"}],
+                           "update-review", since, "new-review")[0])
+    check("a human counts",
+          pending_explicit([human], [{"event": "issue_comment", "status": "queued", "created_at": "2026-09-10T20:36:44Z"}],
+                           "update-review", since, "new-review")[0])
     check("request older than window does not yield",
           not pending_explicit([old], [inflight], "update-review", since, "new-review")[0])
     check("finished run does not yield",

--- a/.claude/commands/docs-review/scripts/test_mention_gate.py
+++ b/.claude/commands/docs-review/scripts/test_mention_gate.py
@@ -1,0 +1,108 @@
+"""pytest coverage for mention-gate.py (the --self-test is the broader table)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE / "mention-gate.py"
+
+spec = importlib.util.spec_from_file_location("mention_gate", SCRIPT)
+mg = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(mg)
+
+
+def test_quoted_protocol_in_backticks_does_not_fire():
+    body = "the pattern is `@claude F<n>: <reasoning> #update-review`; I'll use it once I've pushed."
+    fire, reason = mg.decide(body, "update-review", "new-review")
+    assert fire is False
+    assert "inside code" in reason
+
+
+def test_workprentice_explainer_from_21535_does_not_fire():
+    body = (
+        "Yes — the instructions are clear enough as they stand.\n\n"
+        "- The per-finding `F<n>` IDs plus the `@claude F<n>: ... #update-review` reply pattern are a stable contract.\n"
+        "- I'd act on `#update-review` only after pushing."
+    )
+    assert mg.decide(body, "update-review", "new-review")[0] is False
+
+
+def test_live_request_fires_even_next_to_a_quoted_one():
+    body = "Per the card's `@claude … #update-review` pattern: @claude F3: default is 5 per the AWS reference #update-review"
+    assert mg.decide(body, "update-review", "new-review")[0] is True
+
+
+def test_blockquoted_reply_does_not_fire():
+    body = "> @claude F2: accepting as-is #update-review\n\nDid this, thanks!"
+    assert mg.decide(body, "update-review", "new-review")[0] is False
+
+
+def test_new_review_wins_only_when_live():
+    assert mg.decide("@claude #update-review #new-review", "update-review", "new-review")[0] is False
+    assert mg.decide("@claude F1 fixed #update-review (not `#new-review`)", "update-review", "new-review")[0] is True
+
+
+def test_check_reads_body_from_env_never_argv():
+    env = dict(os.environ, BODY="`@claude #update-review` is the pattern")
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), "check", "--hashtag", "update-review", "--exclude", "new-review", "--body-env", "BODY"],
+        env=env, capture_output=True, text=True, check=True,
+    )
+    assert "fire=false" in out.stdout
+    assert "::notice::" in out.stderr
+
+
+def test_check_with_issue_title():
+    env = dict(os.environ, BODY="please refresh", TITLE="@claude #update-review")
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), "check", "--hashtag", "update-review", "--body-env", "BODY", "--title-env", "TITLE"],
+        env=env, capture_output=True, text=True, check=True,
+    )
+    assert "fire=true" in out.stdout
+
+
+def _since():
+    return datetime(2026, 9, 10, 20, 20, tzinfo=timezone.utc)
+
+
+def test_pending_yields_only_for_a_live_request_with_a_run_in_flight():
+    live = {"user": {"login": "workprentice[bot]"}, "body": "@claude I pushed a fix for F1 #update-review",
+            "created_at": "2026-09-10T20:35:02Z"}
+    inflight = {"event": "issue_comment", "status": "in_progress", "created_at": "2026-09-10T20:35:06Z"}
+    assert mg.pending_explicit([live], [inflight], "update-review", _since(), "new-review")[0] is True
+    finished = dict(inflight, status="completed")
+    assert mg.pending_explicit([live], [finished], "update-review", _since(), "new-review")[0] is False
+
+
+def test_pending_ignores_the_auto_dispatch_run_itself():
+    live = {"user": {"login": "alice"}, "body": "@claude F2 #update-review", "created_at": "2026-09-10T20:35:02Z"}
+    auto = {"event": "workflow_dispatch", "status": "in_progress", "created_at": "2026-09-10T20:35:14Z"}
+    assert mg.pending_explicit([live], [auto], "update-review", _since(), "new-review")[0] is False
+
+
+def test_pending_cli_reads_gh_json_shapes(tmp_path):
+    comments = tmp_path / "c.json"
+    comments.write_text('[{"user":{"login":"alice"},"body":"@claude F2 #update-review","created_at":"2026-09-10T20:35:02Z"}]')
+    runs = tmp_path / "r.json"
+    runs.write_text('[{"event":"issue_comment","status":"queued","createdAt":"2026-09-10T20:35:05Z"}]')
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), "pending", "--hashtag", "update-review", "--exclude", "new-review",
+         "--since", "2026-09-10T20:20:00Z", "--comments", str(comments), "--runs", str(runs)],
+        capture_output=True, text=True, check=True,
+    )
+    assert "yield=true" in out.stdout
+
+
+def test_pending_bad_since_is_a_usage_error():
+    rc = subprocess.run(
+        [sys.executable, str(SCRIPT), "pending", "--hashtag", "update-review", "--since", "yesterday"],
+        capture_output=True, text=True,
+    ).returncode
+    assert rc == 2

--- a/.claude/commands/docs-review/scripts/test_mention_gate.py
+++ b/.claude/commands/docs-review/scripts/test_mention_gate.py
@@ -39,6 +39,13 @@ def test_live_request_fires_even_next_to_a_quoted_one():
     assert mg.decide(body, "update-review", "new-review")[0] is True
 
 
+def test_stray_backtick_before_a_live_request_does_not_swallow_it():
+    # F1 on #21557: with re.S a lone backtick paired with one paragraphs later
+    # and blanked out a real request. Code spans never cross a paragraph break.
+    body = "One stray ` here.\n\n@claude F1: default is 5 per the AWS reference #update-review\n\nSee `verify.py`."
+    assert mg.decide(body, "update-review", "new-review")[0] is True
+
+
 def test_blockquoted_reply_does_not_fire():
     body = "> @claude F2: accepting as-is #update-review\n\nDid this, thanks!"
     assert mg.decide(body, "update-review", "new-review")[0] is False

--- a/.claude/commands/docs-review/scripts/test_mention_gate.py
+++ b/.claude/commands/docs-review/scripts/test_mention_gate.py
@@ -88,6 +88,16 @@ def test_pending_yields_only_for_a_live_request_with_a_run_in_flight():
     assert mg.pending_explicit([live], [finished], "update-review", _since(), "new-review")[0] is False
 
 
+def test_pending_excludes_only_the_logins_the_trigger_excludes():
+    run_after = lambda ts: [{"event": "issue_comment", "status": "queued", "created_at": ts}]
+    mk = lambda login: {"user": {"login": login}, "body": "@claude F1: fixed #update-review", "created_at": "2026-09-10T20:35:02Z"}
+    # claude[bot] is excluded by the workflow if:, so it never has a run
+    assert mg.pending_explicit([mk("claude[bot]")], run_after("2026-09-10T20:35:05Z"), "update-review", _since(), "new-review")[0] is False
+    # every other login that writes a live request does get a run
+    assert mg.pending_explicit([mk("workprentice[bot]")], run_after("2026-09-10T20:35:05Z"), "update-review", _since(), "new-review")[0] is True
+    assert mg.pending_explicit([mk("alice")], run_after("2026-09-10T20:35:05Z"), "update-review", _since(), "new-review")[0] is True
+
+
 def test_pending_ignores_the_auto_dispatch_run_itself():
     live = {"user": {"login": "alice"}, "body": "@claude F2 #update-review", "created_at": "2026-09-10T20:35:02Z"}
     auto = {"event": "workflow_dispatch", "status": "in_progress", "created_at": "2026-09-10T20:35:14Z"}

--- a/.claude/commands/pr-review/SKILL.md
+++ b/.claude/commands/pr-review/SKILL.md
@@ -70,6 +70,8 @@ gh pr diff "$PR_NUMBER"
 bash .claude/commands/docs-review/scripts/pinned-comment.sh fetch --pr "$PR_NUMBER"
 ```
 
+> **v3 surface guard (read before anything else in this step).** If the fetch output contains `<!-- CLAUDE_REVIEW_AUTHOR -->`, the PR is on the v3 surface and the rest of this skill's refresh machinery does not apply to it. The findings are the author card's blocking rows (🚨 / ❓, each with an `F<n>` id; dispositions live in its `REVIEW_STATE` block) plus the reviewer's guide's `### ⚠️ Check these before approving` rows — fetch the guide with `BRIEF_ID=$(bash .claude/commands/docs-review/scripts/pinned-comment.sh find --pr "$PR_NUMBER" --role brief)` and `gh api "repos/$REPO/issues/comments/$BRIEF_ID" --jq .body`. **Never run the local `docs-review:references:update` refresh or `pinned-comment.sh upsert` on a v3 PR** — they write a legacy monolith beside the cards. When a v3 review is `STALE`, comment `@claude #update-review` and wait for the card to re-render (the label returns to `review:outstanding-issues` / `review:no-blockers`), then continue from Step 4 with the card's rows as the findings. The Sentinel check on the PR is the merge gate; approve only when it is green or would be.
+
 Determine the pinned-review state from labels and fetch output. **Labels alone are not a sufficient freshness signal**: pushes made by the Copilot coding agent or with `GITHUB_TOKEN` never fire the `pull_request: synchronize` event, so the `mark-stale` job never runs for them and a PR can sit at `review:no-blockers` while the pinned review describes content a later commit replaced (PR #20556). Before accepting `CURRENT`, run the SHA freshness check:
 
 ```bash
@@ -86,7 +88,7 @@ If `REVIEWED_SHA` is non-empty and is not a prefix-match of `HEAD_SHA`, treat th
 | State | Detection | What Step 3 does |
 |---|---|---|
 | `CURRENT` | `review:outstanding-issues` or `review:no-blockers` set; `review:stale` / `review:in-progress` / `review:error` absent; fetch returns body; **SHA freshness check passes** | Nothing — proceed to Step 4 |
-| `STALE` | `review:stale` set | Refresh in place by invoking `docs-review:references:update` locally (re-runs claim verification against new commits, then writes via `pinned-comment.sh upsert`) |
+| `STALE` | `review:stale` set | Legacy monolith only: refresh in place by invoking `docs-review:references:update` locally (re-runs claim verification against new commits, then writes via `pinned-comment.sh upsert`). v3 PR: comment `@claude #update-review` (see the guard above) |
 | `IN_PROGRESS` | `review:in-progress` set | Wait briefly for the workflow to finish; re-check labels. If it stays >15 min, treat as `ERROR`. |
 | `ERROR` | `review:error` set (or `review:in-progress` stuck) | Investigate the Actions logs before proceeding |
 | `ABSENT` | Fetch returns no `<!-- CLAUDE_REVIEW -->` markers | Fall back: run a local review (see Step 3 §Absent path) |
@@ -103,7 +105,9 @@ Continue to Step 4.
 
 #### STALE
 
-Refresh the pinned comment in place by invoking `docs-review:references:update` locally with `PR_NUMBER` set. The update procedure re-reads the diff since the last reviewed SHA, classifies as Case 1/2/3, and writes the refreshed body via `pinned-comment.sh upsert`. When it completes, re-fetch the pinned comment and re-parse findings for Step 6.
+**v3 PR (author card present): do not refresh locally.** Comment `@claude #update-review`, wait for the card to re-render, then re-fetch and continue.
+
+Legacy monolith: refresh the pinned comment in place by invoking `docs-review:references:update` locally with `PR_NUMBER` set. The update procedure re-reads the diff since the last reviewed SHA, classifies as Case 1/2/3, and writes the refreshed body via `pinned-comment.sh upsert`. When it completes, re-fetch the pinned comment and re-parse findings for Step 6.
 
 #### ABSENT
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -127,6 +127,9 @@ jobs:
   # - Once per push comes free: one synchronize event per push, and
   #   claude-update.yml's per-PR concurrency group (cancel-in-progress)
   #   collapses stacked pushes onto the newest head.
+  # - An explicit `#update-review` already in flight wins: the yield step
+  #   skips the dispatch so the concurrency group can't cancel the
+  #   human's request (see that step's comment).
   auto-refresh:
     needs: mark-stale
     if: |
@@ -196,6 +199,45 @@ jobs:
           echo "fire=$FIRE" >> "$GITHUB_OUTPUT"
           echo "auto-refresh gate: fire=$FIRE — $REASON" | tee -a "$GITHUB_STEP_SUMMARY"
 
+      # Push-then-comment is the documented happy path, and it used to
+      # lose: the author pushes, then within seconds replies `@claude …
+      # #update-review` with their reasoning; the explicit run starts, the
+      # dispatch below lands a few seconds later and cancels it through
+      # claude-update.yml's per-PR concurrency group (#21535, 20:35 —
+      # runs 34527254288 → 34527268414). The scoped auto pass then marked
+      # the findings fixed on diff evidence alone and the reasoning was
+      # never adjudicated. So before dispatching, look for a live explicit
+      # request in the last 15 minutes that still has a run in flight; an
+      # explicit run reads the PR live, so it covers this head too. Yield
+      # to it. (A request whose run already finished may have evaluated
+      # an older head; mention-gate.py's `pending` only yields when the
+      # run is still in flight.) Fail open: if the lookup errors, dispatch.
+      - name: Yield to an explicit refresh already in flight
+        id: yield
+        if: steps.gate.outputs.fire == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          SCRIPTS=.claude/commands/docs-review/scripts
+          SINCE=$(date -u -d '15 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          gh api "repos/$REPO/issues/$PR/comments?since=$SINCE&per_page=100" > /tmp/recent-issue-comments.json || echo '[]' > /tmp/recent-issue-comments.json
+          gh api "repos/$REPO/pulls/$PR/comments?since=$SINCE&per_page=100" > /tmp/recent-review-comments.json || echo '[]' > /tmp/recent-review-comments.json
+          gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" > /tmp/recent-reviews.json || echo '[]' > /tmp/recent-reviews.json
+          gh run list --repo "$REPO" --workflow claude-update.yml --limit 30 \
+            --json event,status,createdAt > /tmp/update-runs.json || echo '[]' > /tmp/update-runs.json
+          python3 "$SCRIPTS/mention-gate.py" pending \
+            --hashtag update-review --exclude new-review --since "$SINCE" \
+            --comments /tmp/recent-issue-comments.json \
+            --comments /tmp/recent-review-comments.json \
+            --comments /tmp/recent-reviews.json \
+            --runs /tmp/update-runs.json | tee -a "$GITHUB_OUTPUT"
+          if grep -q '^yield=true' "$GITHUB_OUTPUT"; then
+            echo "auto-refresh: yielding to the explicit #update-review already in flight" | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
       # The instant signal (persona-pass round, 2026-09-01 / Cam): the
       # author learns "a re-review is happening" the moment the gate
       # decides — not minutes later when the dispatched workflow starts.
@@ -205,7 +247,7 @@ jobs:
       # path clears it explicitly so a failed refresh doesn't leave the
       # promise standing.
       - name: Signal re-review instantly (label + card banner)
-        if: steps.gate.outputs.fire == 'true'
+        if: steps.gate.outputs.fire == 'true' && steps.yield.outputs.yield != 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -225,7 +267,7 @@ jobs:
       # dispatch of this workflow. The dispatched run's actor becomes
       # github-actions[bot]; claude-update.yml opts in via allowed_bots.
       - name: Dispatch scoped update review
-        if: steps.gate.outputs.fire == 'true'
+        if: steps.gate.outputs.fire == 'true' && steps.yield.outputs.yield != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/claude-new.yml
+++ b/.github/workflows/claude-new.yml
@@ -42,6 +42,27 @@ jobs:
       id-token: write
       actions: write # Required to dispatch claude-code-review.yml.
     steps:
+      # The job-level `if:` is a substring match; a comment that quotes
+      # `@claude … #new-review` in backticks or a blockquote must not wipe
+      # the review and regenerate it. Same gate as claude-update.yml: the
+      # script comes from the default branch, the body from an env var.
+      - name: Checkout mention gate (default branch, sparse)
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          path: .mention-gate
+          sparse-checkout: .claude/commands/docs-review/scripts/mention-gate.py
+          sparse-checkout-cone-mode: false
+
+      - name: Mention gate (a quoted protocol is not a request)
+        id: mention
+        env:
+          BODY: ${{ github.event.comment.body || github.event.review.body }}
+        run: |
+          python3 .mention-gate/.claude/commands/docs-review/scripts/mention-gate.py check \
+            --hashtag new-review --body-env BODY | tee -a "$GITHUB_OUTPUT"
+
       # ESC runs before checkout so the bot token can authenticate the
       # checkout. claude-new.yml doesn't push today (it just clears the
       # pinned comment and dispatches claude-code-review.yml), but kept
@@ -49,9 +70,11 @@ jobs:
       # change adds a push path here.
       - name: Fetch secrets from ESC
         id: esc-secrets
+        if: steps.mention.outputs.fire == 'true'
         uses: pulumi/esc-action@v3
 
       - name: Checkout repository
+        if: steps.mention.outputs.fire == 'true'
         uses: actions/checkout@v7
         with:
           token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
@@ -59,6 +82,7 @@ jobs:
 
       - name: Check repository write access
         id: check-access
+        if: steps.mention.outputs.fire == 'true'
         run: |
           REPO_FULL="${{ github.repository }}"
 

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -77,6 +77,40 @@ jobs:
       id-token: write
       actions: write # read CI results on PRs; dispatch review-sentinel.yml after a v3 publish
     steps:
+      # The job-level `if:` above is a substring match, which is all a
+      # GitHub expression can do — it fires on a comment that merely
+      # *quotes* the reply pattern in backticks or a blockquote (#21535:
+      # two of four card versions were unrequested; each was a full Opus
+      # run). This pair of steps is the precise check: strip code and
+      # quotes, then require a live `@claude` + `#update-review`. The
+      # script comes from the default branch, never the PR head, and reads
+      # the body from an env var, never argv. Dispatched runs skip it —
+      # there is no comment to judge.
+      - name: Checkout mention gate (default branch, sparse)
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          path: .mention-gate
+          sparse-checkout: .claude/commands/docs-review/scripts/mention-gate.py
+          sparse-checkout-cone-mode: false
+
+      - name: Mention gate (a quoted protocol is not a request)
+        id: mention
+        env:
+          BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
+          TITLE: ${{ github.event_name == 'issues' && github.event.issue.title || '' }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "fire=true" >> "$GITHUB_OUTPUT"
+            echo "reason=workflow_dispatch" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 .mention-gate/.claude/commands/docs-review/scripts/mention-gate.py check \
+            --hashtag update-review --exclude new-review \
+            --body-env BODY --title-env TITLE | tee -a "$GITHUB_OUTPUT"
+
       # Resolve the PR head SHA before checkout so the working tree
       # reflects PR content, not the base branch. Without this, Vale
       # below runs against base prose and produces empty findings.
@@ -85,6 +119,7 @@ jobs:
       # gated on is_pr=true anyway, so it skips on issues).
       - name: Resolve PR head SHA
         id: head
+        if: steps.mention.outputs.fire == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -127,17 +162,19 @@ jobs:
       # then go out as pulumi-bot rather than github-actions[bot],
       # which is what lets downstream workflows (build-and-deploy, social
       # review, etc.) fire on those commits.
-      # The three setup steps below skip on superseded dispatched runs
+      # The setup steps below skip when the mention gate declined (a
+      # quoted protocol, nothing to do) and on superseded dispatched runs
       # (steps.head sets superseded=true when the PR head moved past the
-      # dispatcher's pinned SHA) — the run is a no-op, so don't pay for
-      # secrets, checkout, or toolchain install.
+      # dispatcher's pinned SHA) — either way the run is a no-op, so don't
+      # pay for secrets, checkout, or toolchain install. Every later step
+      # gates on check-access outputs, which stay empty when it skips.
       - name: Fetch secrets from ESC
         id: esc-secrets
-        if: steps.head.outputs.superseded != 'true'
+        if: steps.mention.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
         uses: pulumi/esc-action@v3
 
       - name: Checkout repository
-        if: steps.head.outputs.superseded != 'true'
+        if: steps.mention.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
         uses: actions/checkout@v7
         with:
           token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
@@ -147,14 +184,14 @@ jobs:
       # Install mise-managed tools (Vale, Node, etc.) so the prose-lint
       # step below has the pinned vale binary on PATH.
       - name: Install mise-managed tools
-        if: steps.head.outputs.superseded != 'true'
+        if: steps.mention.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
         uses: jdx/mise-action@v4
         with:
           cache: true
 
       - name: Check repository write access
         id: check-access
-        if: steps.head.outputs.superseded != 'true'
+        if: steps.mention.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
         run: |
           # workflow_dispatch runs skip the collaborator-permission lookup:
           # triggering a dispatch already requires write access (humans via

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The repository runs a tiered review pipeline on every PR. AI-assisted contributo
 
 ### The v3 review surface (staged rollout)
 
-The review is moving from one monolithic pinned comment to the **v3 surface**, enabled per-repo by the `REVIEW_V3_COMMENTS` variable, or per-PR by the `surface:v3` label (add it to a draft, mark ready — or add it and comment `@claude #new-review`; remove it and `#new-review` again to go back to the monolith). Everything below this section describes the v2 monolith and stays accurate for PRs reviewed before the flip and for repos where the flag is off. What changes under v3:
+The review has moved from one monolithic pinned comment to the **v3 surface**, enabled per-repo by the `REVIEW_V3_COMMENTS` variable (on for pulumi/docs), or per-PR by the `surface:v3` label. Every fresh review now renders the v3 cards; a PR reviewed before the flip keeps its legacy monolith until someone comments `@claude #new-review`, which regenerates it as cards. Where the sections below say "the pinned comment", read "the author card" on a v3 PR. What v3 changed:
 
 - **Two comments instead of one.** An **author card** ("Author action guide") lists only what you must act on — one-line `🚨 Fix or disagree` and `❓ Questions for you` rows (both block merge), each with a `#### F<n> · Do this` block underneath (the flagged line verbatim, why, and exactly one required fix — replacement text in a copyable fenced block), plus inline ✏️ style suggestions. A separate **reviewer's guide** tells your reviewer what the PR contains, what's still waiting on you, what to check, and what's machine-verified. The bulk — the verification trail, investigation log, review history — lives on a linked **evidence page**, not in the comments.
 - **Every finding has a stable ID** (`F1`, `F2`, …) and every blocking finding needs an answer before merge — fix, disagree, or accept. Fix it and push (the card shows a 🔄 banner within a minute when your push triggers the automatic re-review), or reply naming the ID:
@@ -42,7 +42,7 @@ The disposition vocabulary, the outcome table, and "work the review to zero" bel
 Transitioning to **Ready for review** triggers:
 
 1. A re-triage to refresh labels (domain, trivial / frontmatter-only short-circuits, prose-flagged signal if applicable).
-1. The full Claude review (currently `claude-opus-5`), composed per touched domain. Findings post to a single pinned comment at the top of the PR — overflow is appended as additional pinned comments tagged `<!-- CLAUDE_REVIEW N/M -->`.
+1. The full Claude review (currently `claude-opus-5`), composed per touched domain. Findings post as the two v3 cards — the author card (`<!-- CLAUDE_REVIEW_AUTHOR -->`) and the reviewer's guide (`<!-- CLAUDE_REVIEW_BRIEF -->`) — with the verification trail on the linked evidence page. A PR reviewed before the v3 flip still carries the legacy single pinned comment (overflow tagged `<!-- CLAUDE_REVIEW N/M -->`).
 
 Mark the PR ready when you're done iterating, not when you start. Each ready-transition produces one full review run; thrashing through draft → ready → draft burns review budget and produces stale pinned comments.
 
@@ -61,15 +61,15 @@ A pinned review goes **stale** when you push new commits after it ran. One case 
         - **Re-verify** (no specific request beyond the hashtag): re-checks outstanding findings only.
     - **`@claude` alone, no hashtag** — ad-hoc questions, code fixes, or one-off requests. Tag mode: the action handles it directly with its own animated tracking comment. Doesn't touch the pinned review. Use this when you want help, not a re-review.
 1. **Transition through draft and back to ready** — re-triggers the full initial review. Use this when the PR has changed substantially since the last review.
-1. **Wait for the human reviewer** — Cam's local `pr-review` skill reads the pinned comment as source of truth and refreshes it during adjudication if needed.
+1. **Wait for the human reviewer** — the reviewer's guide is their source of truth, and the Sentinel check tells them (and you) whether anything still blocks. A reviewer who wants a fresh look asks for one with `@claude #update-review`, same as you.
 
 #### Power-user escape hatch: `@claude #new-review`
 
-Rare. Use when the pinned-review state is corrupted (the 1/M comment was manually deleted, the comment sequence is malformed, the review is stuck in a wrong state that `#update-review` can't reconcile). Clears every existing `<!-- CLAUDE_REVIEW N/M -->` comment and dispatches a fresh initial review from scratch — same workflow that fires on ready-for-review, just bypassing the trivial / frontmatter-only / draft / bot-author skips. Don't use it for routine refreshes; `#update-review` is the right tool for those.
+Rare. Use when the pinned-review state is corrupted (the 1/M comment was manually deleted, the comment sequence is malformed, the review is stuck in a wrong state that `#update-review` can't reconcile). Clears every existing review comment (the v3 cards, or a legacy `<!-- CLAUDE_REVIEW N/M -->` sequence) and dispatches a fresh initial review from scratch — same workflow that fires on ready-for-review, just bypassing the trivial / frontmatter-only / draft / bot-author skips. Don't use it for routine refreshes; `#update-review` is the right tool for those.
 
 ### Working the review to zero
 
-A review is finished when every finding it raised has an outcome — not when the 🚨 count hits zero. The pinned comment carries three actionable buckets and they are all yours: **🚨 Outstanding** (must be resolved or refuted before merge), **⚠️ Low-confidence** (doesn't block, still needs a decision), and the **✏️ style suggestions** posted inline on the Files-changed tab. 💡 Pre-existing is the one optional bucket — that's not debt this PR created.
+A review is finished when every finding it raised has an outcome — not when the 🚨 count hits zero. On a v3 PR the author card carries **🚨 Fix or disagree** and **❓ Questions for you** (both block merge) plus the **✏️ style suggestions** posted inline on the Files-changed tab; the reviewer's guide carries **⚠️ Check these before approving** for your reviewer. On a legacy monolith the buckets are **🚨 Outstanding** (must be resolved or refuted before merge), **⚠️ Low-confidence** (doesn't block, still needs a decision), and the same ✏️ suggestions. 💡 Pre-existing is the one optional bucket — that's not debt this PR created.
 
 Five outcomes count as done, and no others:
 
@@ -90,13 +90,13 @@ python3 .claude/commands/docs-review/scripts/review-worklist.py --pr <N> \
   --state .review-worklist-<N>.json --require-clean
 ```
 
-### Don't fight the pinned comment
+### Don't fight the review comments
 
-The `<!-- CLAUDE_REVIEW N/M -->` comments are managed by the pipeline. Don't delete them — the re-entrant skill expects to find and edit them in place. If you accidentally delete the 1/M summary, the next run posts fresh at the bottom of the timeline; recoverable but ugly.
+The review comments are managed by the pipeline: on a v3 PR the author card and the reviewer's guide (`<!-- CLAUDE_REVIEW_AUTHOR -->` / `<!-- CLAUDE_REVIEW_BRIEF -->`), on an older PR the `<!-- CLAUDE_REVIEW N/M -->` sequence. Don't delete them — the re-entrant lanes expect to find and edit them in place, and the author card's `REVIEW_STATE` block is where your answers are recorded. If one goes missing, `@claude #new-review` regenerates from scratch; recoverable but ugly.
 
-**Don't hide them either.** Marking the pinned comment resolved (**Hide** → *Resolved*) collapses it but leaves it in place, so a later `#update-review` edits a comment nobody can see: the job runs green, posts its "🤖 Review updated" progress note, and the refreshed review never appears. The publish path now unhides the comment before patching, but the mutation can be refused by the token's scopes — if a refresh looks like a no-op, check whether the pinned comment is collapsed and unhide it. Use the ✅ Resolved section inside the review to track what you've addressed; that's what it's for.
+**Don't hide them either.** Marking a card resolved (**Hide** → *Resolved*) collapses it but leaves it in place, so a later `#update-review` edits a comment nobody can see: the job runs green, posts its "🤖 Review updated" progress note, and the refreshed review never appears. The publish path now unhides the comment before patching, but the mutation can be refused by the token's scopes — if a refresh looks like a no-op, check whether the card is collapsed and unhide it. Use the ✅ Resolved section inside the card to track what you've addressed; that's what it's for.
 
-The pinned comment is also the pipeline's outcome ledger: after a PR closes, a weekly scrape derives what happened to each finding (fixed, conceded, disputed, or merged over) and aggregates it into the Monday `#docs-ops` digest, which is how the review's severity rules get tuned over time.
+The author card is also the pipeline's outcome ledger (the S3 evidence record mirrors it): after a PR closes, a weekly scrape derives what happened to each finding (fixed, conceded, disputed, or merged over) and aggregates it into the Monday `#docs-ops` digest, which is how the review's severity rules get tuned over time.
 
 ### Trivial, frontmatter-only, and oversized short-circuits
 

--- a/scripts/review-v3/README.md
+++ b/scripts/review-v3/README.md
@@ -76,8 +76,8 @@ Lives as an HTML comment in the bot-owned author comment:
 - Writers: the update lane (`apply-update.py`) and the `/resolve` workflow —
   both merge per finding-id, latest `updated_at` wins, never whole-block
   overwrite. `bulk: true` marks `/resolve all …` answers (telemetry).
-- Readers: Sentinel gate 2 (uncredentialed, fork-safe), `review-worklist.py
-  --state-from-body`, the record job's mirror into `latest.json`.
+- Readers: Sentinel gate 2 (uncredentialed, fork-safe), `review-worklist.py`
+  (`--body-file` / `--brief-file`), the record job's mirror into `latest.json`.
 - Sentinel accepts the block only from the bot-authored comment.
 
 ## The Sentinel

--- a/scripts/review-v3/resolve-handler.py
+++ b/scripts/review-v3/resolve-handler.py
@@ -272,6 +272,13 @@ def handle(pr: int, comment_id, actor: str, body: str, gh: Gh) -> HandleResult:
         if not prose_hits:
             return HandleResult(0, "no-op")
 
+        # Only the PR author owes an answer, so only the author gets the
+        # nudge. A maintainer's status note ("F2 is recorded as accepted —
+        # please proceed") mentions ids too; on #21395 it earned the
+        # maintainer a pointer telling them how to answer their own PR.
+        if actor != gh.get_pr_author():
+            return HandleResult(0, "prose-not-author")
+
         pointer_marker = POINTER_MARKER_TMPL.format(actor=actor)
         if find_marker_comment(comments, pointer_marker) is not None:
             return HandleResult(0, "pointer-already-sent")
@@ -533,25 +540,24 @@ def _self_test() -> int:
     check("state untouched by out-of-range id", gh.comments[author_id]["body"] == original_body)
     check("no reaction on full rejection", gh.reactions == [])
 
-    # -- prose answer -> pointer once; second prose by same actor -> no repeat
+    # -- prose answer by the author -> pointer once; second -> no repeat -----
     gh = StubGh(pr_author="alice")
     gh.seed_comment(_author_body(3))
-    r1 = handle(42, 9005, "bob", "I think F2 is wrong because the docs say otherwise", gh)
-    check("first prose hit posts a pointer", r1.outcome == "pointer-sent")
-    pointer_marker = POINTER_MARKER_TMPL.format(actor="bob")
+    r1 = handle(42, 9005, "alice", "I think F2 is wrong because the docs say otherwise", gh)
+    check("first prose hit by the author posts a pointer", r1.outcome == "pointer-sent")
+    pointer_marker = POINTER_MARKER_TMPL.format(actor="alice")
     first_count = sum(1 for c in gh.list_issue_comments() if pointer_marker in c["body"])
     check("exactly one pointer posted", first_count == 1)
-    r2 = handle(42, 9006, "bob", "actually F2 is still wrong, see above", gh)
-    check("second prose by same actor is a no-op", r2.outcome == "pointer-already-sent")
+    r2 = handle(42, 9006, "alice", "actually F2 is still wrong, see above", gh)
+    check("second prose by the author is a no-op", r2.outcome == "pointer-already-sent")
     second_count = sum(1 for c in gh.list_issue_comments() if pointer_marker in c["body"])
-    check("still exactly one pointer for bob", second_count == 1)
+    check("still exactly one pointer for alice", second_count == 1)
 
-    # -- different actor gets their own pointer -------------------------------
-    r3 = handle(42, 9007, "carol", "F2 looks wrong to me too", gh)
-    check("a different actor gets their own pointer", r3.outcome == "pointer-sent")
+    # -- anyone else mentioning an id gets nothing -----------------------------
+    r3 = handle(42, 9007, "carol", "F2 is recorded as accepted — please proceed", gh)
+    check("a non-author's prose gets no pointer", r3.outcome == "prose-not-author")
     carol_marker = POINTER_MARKER_TMPL.format(actor="carol")
-    check("carol's pointer exists", find_marker_comment(gh.list_issue_comments(), carol_marker) is not None)
-    check("bob's pointer count unaffected", sum(1 for c in gh.list_issue_comments() if pointer_marker in c["body"]) == 1)
+    check("no pointer posted for carol", find_marker_comment(gh.list_issue_comments(), carol_marker) is None)
 
     # -- non-author without write -> refused, state untouched -----------------
     gh = StubGh(pr_author="alice", permissions={"mallory": "read"})

--- a/scripts/review-v3/test_resolve_handler.py
+++ b/scripts/review-v3/test_resolve_handler.py
@@ -111,44 +111,52 @@ def test_errors_reply_is_updated_in_place_not_duplicated():
 # ---- prose detection --------------------------------------------------------
 
 
-def test_prose_answer_gets_one_pointer_reply():
+def test_prose_answer_by_the_author_gets_one_pointer_reply():
     gh = StubGh(pr_author="alice")
     gh.seed_comment(_author_body(3))
 
-    r = handle(42, 9005, "bob", "I think F2 is wrong because the docs say otherwise", gh)
+    r = handle(42, 9005, "alice", "I think F2 is wrong because the docs say otherwise", gh)
 
     assert r.outcome == "pointer-sent"
-    marker = POINTER_MARKER_TMPL.format(actor="bob")
+    marker = POINTER_MARKER_TMPL.format(actor="alice")
     matches = [c for c in gh.list_issue_comments() if marker in c["body"]]
     assert len(matches) == 1
     assert "F2" in matches[0]["body"]
 
 
-def test_second_prose_comment_by_same_actor_gets_no_second_pointer():
+def test_second_prose_comment_by_the_author_gets_no_second_pointer():
     gh = StubGh(pr_author="alice")
     gh.seed_comment(_author_body(3))
 
-    handle(42, 9005, "bob", "I think F2 is wrong", gh)
-    r2 = handle(42, 9006, "bob", "still think F2 is wrong, see above", gh)
+    handle(42, 9005, "alice", "I think F2 is wrong", gh)
+    r2 = handle(42, 9006, "alice", "still think F2 is wrong, see above", gh)
 
     assert r2.outcome == "pointer-already-sent"
-    marker = POINTER_MARKER_TMPL.format(actor="bob")
+    marker = POINTER_MARKER_TMPL.format(actor="alice")
     matches = [c for c in gh.list_issue_comments() if marker in c["body"]]
     assert len(matches) == 1
 
 
-def test_different_actor_gets_their_own_pointer():
+def test_a_maintainers_status_note_gets_no_pointer():
+    # #21395: "F2 is recorded as accepted as-is … please proceed" earned the
+    # maintainer a pointer explaining how to answer the author's own PR.
+    gh = StubGh(pr_author="alice", permissions={"cam": "admin"})
+    gh.seed_comment(_author_body(3))
+
+    r = handle(42, 9007, "cam", "F2 is recorded as accepted as-is on the brief — please proceed", gh)
+
+    assert r.outcome == "prose-not-author"
+    assert not [c for c in gh.list_issue_comments() if "RESOLVE_POINTER" in c["body"]]
+
+
+def test_a_bystander_gets_no_pointer_either():
     gh = StubGh(pr_author="alice")
     gh.seed_comment(_author_body(3))
 
-    handle(42, 9005, "bob", "I think F2 is wrong", gh)
-    r2 = handle(42, 9007, "carol", "F2 looks wrong to me too", gh)
+    r = handle(42, 9008, "carol", "F2 looks wrong to me too", gh)
 
-    assert r2.outcome == "pointer-sent"
-    bob_marker = POINTER_MARKER_TMPL.format(actor="bob")
-    carol_marker = POINTER_MARKER_TMPL.format(actor="carol")
-    assert len([c for c in gh.list_issue_comments() if bob_marker in c["body"]]) == 1
-    assert len([c for c in gh.list_issue_comments() if carol_marker in c["body"]]) == 1
+    assert r.outcome == "prose-not-author"
+    assert not [c for c in gh.list_issue_comments() if "RESOLVE_POINTER" in c["body"]]
 
 
 def test_prose_with_no_known_id_and_no_command_is_a_silent_no_op():


### PR DESCRIPTION
Three things one week of v3 traffic showed, plus the doc drift the `REVIEW_V3_COMMENTS=1` flip would otherwise leave behind.

- **A quoted protocol is not a request.** `claude-update.yml` / `claude-new.yml` match `@claude` + the hashtag as substrings, so an explainer that quoted `@claude F<n>: … #update-review` in backticks (#21535) dispatched two full Opus runs. New `mention-gate.py` strips fenced blocks, inline spans, and blockquoted lines first; both workflows run it as step one (default-branch sparse checkout, body via env) and every later step gates on its verdict. `workflow_dispatch` runs are untouched.
- **An explicit `#update-review` wins the race.** Push-then-comment used to lose: the auto-refresh dispatch cancelled the author's run through the per-PR concurrency group and their reasoning was never adjudicated (#21535, 20:35). The auto-refresh job now yields when a live explicit request in the last 15 minutes still has a run in flight. Fails open.
- **The prose pointer goes to the author only.** It nudged a maintainer for a status note that mentioned F2 (#21395).
- Docs: CONTRIBUTING describes the two cards as the default and the monolith as legacy; `scripts/review-v3/README.md` names the real `review-worklist.py` flags; the `pr-review` skill refuses to write a legacy monolith on a v3 PR.

Tests: `mention-gate.py --self-test` + `test_mention_gate.py` (wired into `make test-review-pipeline`), resolve-handler pytest + self-test updated. Machinery only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLhMYkjKBgBXE8aWs2bv1V
