### PR TITLE
Validator: give Step B a token so diff-based exemptions actually run

### DIFF
--- a/.claude/commands/docs-review/scripts/test_validator_step_token.py
+++ b/.claude/commands/docs-review/scripts/test_validator_step_token.py
@@ -16,7 +16,8 @@ import pytest
 import yaml
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
-WORKFLOWS = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+_WF_DIR = REPO_ROOT / ".github" / "workflows"
+WORKFLOWS = sorted([*_WF_DIR.glob("*.yml"), *_WF_DIR.glob("*.yaml")])
 
 
 def _validator_steps():

--- a/.claude/commands/docs-review/scripts/test_validator_step_token.py
+++ b/.claude/commands/docs-review/scripts/test_validator_step_token.py
@@ -1,0 +1,43 @@
+"""Every workflow step that runs `validate-pinned.py check --pr` must carry a
+GitHub token in its env.
+
+The validator fetches the PR diff with `gh pr diff` for the rules that exempt
+content the review merely echoes (`internal-link-existence` and friends). A
+step without `GH_TOKEN`/`GITHUB_TOKEN` makes that fetch fail silently, the
+exemptions go dead, and on the v3 surface (no splicer, no model fallback) the
+first review that quotes a dead link from the PR errors out -- #21560.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+WORKFLOWS = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+
+
+def _validator_steps():
+    for wf in WORKFLOWS:
+        data = yaml.safe_load(wf.read_text())
+        for job_name, job in (data.get("jobs") or {}).items():
+            for step in job.get("steps") or []:
+                run = step.get("run") or ""
+                if "validate-pinned.py check" in run and "--pr" in run:
+                    yield wf.name, job_name, step
+
+
+def test_validator_steps_exist():
+    assert list(_validator_steps()), "no workflow step invokes validate-pinned.py check --pr"
+
+
+@pytest.mark.parametrize("wf, job, step", list(_validator_steps()), ids=lambda v: v if isinstance(v, str) else v.get("name", "?"))
+def test_validator_step_has_a_token(wf, job, step):
+    env = step.get("env") or {}
+    assert "GH_TOKEN" in env or "GITHUB_TOKEN" in env, (
+        f"{wf} job {job!r} step {step.get('name')!r} runs validate-pinned.py check --pr "
+        "without GH_TOKEN/GITHUB_TOKEN; `gh pr diff` inside the validator fails silently "
+        "and every diff-based exemption goes dead"
+    )

--- a/.claude/commands/docs-review/scripts/validate-pinned.py
+++ b/.claude/commands/docs-review/scripts/validate-pinned.py
@@ -3367,13 +3367,31 @@ def gh_pr_diff_added_files(repo: str | None, pr: int) -> set[str]:
 
 
 def gh_pr_diff_text(repo: str | None, pr: int) -> str:
+    """The PR diff, or "" when `gh pr diff` fails.
+
+    Several rules (`internal-link-existence`, the temporal-trigger sweep,
+    pass-3 evidence) use the diff to tell "the review echoes the PR's
+    content" from "the review invented something". An empty diff silently
+    disables those exemptions, so a failed fetch is reported as a workflow
+    warning rather than swallowed -- an unrun check must not look like a
+    clean one.
+    """
     cmd = ["gh", "pr", "diff", str(pr)]
     if repo:
         cmd += ["--repo", repo]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
         return result.stdout
-    except (subprocess.SubprocessError, OSError):
+    except (subprocess.SubprocessError, OSError) as exc:
+        detail = ""
+        if isinstance(exc, subprocess.CalledProcessError):
+            detail = (exc.stderr or "").strip().splitlines()[-1:] or [""]
+            detail = detail[0]
+        print(
+            f"::warning::validate-pinned: `gh pr diff {pr}` failed ({exc.__class__.__name__}"
+            f"{': ' + detail if detail else ''}); diff-dependent exemptions are disabled for this run",
+            file=sys.stderr,
+        )
         return ""
 
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1452,6 +1452,8 @@ jobs:
         if: steps.check-access.outputs.has_write_access == 'true' && steps.claude-review.outcome == 'success' && steps.pr-context.outputs.v3 != 'true'
         id: revalidate
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set +e
           rm -f /tmp/validate-pinned.fix-me.json /tmp/validate-pinned.fix-me.md

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1357,6 +1357,14 @@ jobs:
         id: validate-body
         continue-on-error: true
         env:
+          # The validator fetches the PR diff itself (`gh pr diff`) for the
+          # rules that exempt content the review merely echoes -- e.g.
+          # `internal-link-existence` skips a dead link that appears in the
+          # diff, because reporting it IS the finding. Without a token that
+          # fetch fails silently and the exemption is dead: on v2 the splicer
+          # and model fallback papered over it; on v3 (no soft floor) the
+          # first review that quoted a broken link errored (#21560).
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REVIEW_V3: ${{ steps.pr-context.outputs.v3 == 'true' && '1' || '' }}
         run: |
           set +e


### PR DESCRIPTION
The initial lane's validate step (Step B) ran `validate-pinned.py check --pr` without `GH_TOKEN`, so the validator's own `gh pr diff` failed silently and every diff-based exemption was dead. `internal-link-existence` then flagged a review for quoting the PR's own broken link. v2 hid this behind the splicer and model fallback; v3 has no soft floor, so the first v3 review that quoted a dead link errored (#21560).

- Step B gets `GH_TOKEN`.
- A failed `gh pr diff` inside the validator is now a `::warning::`, not a silent empty diff.
- New test: every workflow step invoking `validate-pinned.py check --pr` must carry a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLhMYkjKBgBXE8aWs2bv1V