### PR TITLE
Author card: the Line / Why / Fix detail block is a bulleted list

### DIFF
--- a/.claude/commands/docs-review/references/output-format.md
+++ b/.claude/commands/docs-review/references/output-format.md
@@ -461,9 +461,9 @@ _<one sentence: what the PR is and what the review checked>_
 |---|---|---|
 | **F1** | [`file.md` L12-14](…R12) · [✏️ edit](…/edit/<branch>/file.md) | <ONE-line finding: claim quote ref + verdict> |
 #### F1 · Do this                         ← one detail block per 🚨/❓ finding, directly under its table
-**Line (verbatim):** "<the flagged line, quoted exactly — the ONLY quote of it on this card>"
-**Why:** <1-2 sentences>
-**Fix:** <exactly ONE required action; replacement text in a fenced block>
+- **Line (verbatim):** "<the flagged line, quoted exactly — the ONLY quote of it on this card>"
+- **Why:** <1-2 sentences>
+- **Fix:** <exactly ONE required action; replacement text in a fenced block at column 0 after the list>
 ### ❓ Questions for you
 | ID | Where | Finding |                  ← same row + block shape
 #### F3 · Do this
@@ -554,11 +554,13 @@ these rules:
    build-evidence files those on the evidence page and drops them from the
    published card. A finding that simply vanishes is a violation.
 1. **Fill every `#### F<n> · Do this` block** (they are scaffolded per
-   blocking finding): `**Line (verbatim):**` quotes the flagged file line
+   blocking finding). The block is a three-bullet list — keep the `- `
+   markers: `- **Line (verbatim):**` quotes the flagged file line
    exactly ONCE on the whole card — a paraphrase never appears inside
-   quotation marks; `**Why:**` is 1-2 sentences; `**Fix:**` states exactly
+   quotation marks; `- **Why:**` is 1-2 sentences; `- **Fix:**` states exactly
    ONE required action, first. Replacement text goes in a fenced block
-   (GitHub gives it a copy button). If deletion is the better fix, LEAD
+   at column 0 after the list (GitHub gives it a copy button); an
+   alternative is a fourth bullet, `- **If you'd rather keep it:**`. If deletion is the better fix, LEAD
    with deletion — a reword is offered only under a
    `**If you'd rather keep it:**` label, never as a competing imperative.
    A structural observation shared by several findings ("both new sentences

--- a/.claude/commands/docs-review/scripts/apply-update.py
+++ b/.claude/commands/docs-review/scripts/apply-update.py
@@ -340,16 +340,23 @@ def _rebuild_detail_block(fid: str, old: list[str], detail: dict) -> list[str]:
     """A retext with `detail` refreshes the finding's Do-this block: the
     verbatim line is kept (the flagged text didn't change), Why/Fix/keep are
     replaced — same shape as the composer scaffold."""
-    verbatim = next((ln for ln in old if ln.startswith("**Line (verbatim):**")), None)
+    # Accept both the bulleted form and the pre-2026-09-11 paragraph form
+    # (cards rendered before the change stay live); always emit bullets.
+    verbatim = next((ln for ln in old if _unbullet(ln).startswith("**Line (verbatim):**")), None)
     out = [f"#### {fid} · Do this", ""]
     if verbatim:
-        out.append(verbatim)
-    out.append(f"**Why:** {str(detail['why']).strip()}")
-    out.append(f"**Fix:** {str(detail['fix']).strip()}")
+        out.append(f"- {_unbullet(verbatim)}")
+    out.append(f"- **Why:** {str(detail['why']).strip()}")
+    out.append(f"- **Fix:** {str(detail['fix']).strip()}")
     keep = str(detail.get("keep", "")).strip()
     if keep:
-        out += ["", f"**If you'd rather keep it:** {keep}"]
+        out.append(f"- **If you'd rather keep it:** {keep}")
     return out
+
+
+def _unbullet(line: str) -> str:
+    """`- **Why:** …` → `**Why:** …`; a non-bulleted line is returned as-is."""
+    return line[2:] if line.startswith("- ") else line
 
 
 def apply(

--- a/.claude/commands/docs-review/scripts/compose-review.py
+++ b/.claude/commands/docs-review/scripts/compose-review.py
@@ -1892,16 +1892,21 @@ def render_detail_scaffold(fid: str) -> list[str]:
     the flagged line quoted verbatim exactly once, replacement text in a
     fenced block (GitHub gives it a copy button). Model-added `F?` rows get
     NO block (ids are not assigned yet); their cell stays terse instead.
+
+    The three labelled lines are a bulleted list (2026-09-11: the paragraph
+    form read as a wall of text). Readers that key on the labels accept
+    both the bulleted and the older unbulleted form, because cards
+    rendered before this change stay live until their PR closes.
     """
     return [
         f"#### {fid} · Do this",
         "",
-        "**Line (verbatim):** <TODO: the flagged line, quoted exactly as it "
+        "- **Line (verbatim):** <TODO: the flagged line, quoted exactly as it "
         "appears in the file — the only quote of it on this card; never a paraphrase>",
-        "**Why:** <TODO: 1-2 sentences — what is wrong (🚨) or what only the author can settle (❓)>",
-        "**Fix:** <TODO: exactly ONE required action, stated first; put any "
-        "replacement text in a fenced block; label an alternative "
-        "\"**If you'd rather keep it:**\" — never two competing imperatives>",
+        "- **Why:** <TODO: 1-2 sentences — what is wrong (🚨) or what only the author can settle (❓)>",
+        "- **Fix:** <TODO: exactly ONE required action, stated first; put any "
+        "replacement text in a fenced block at column 0 after this list; label an alternative "
+        "\"- **If you'd rather keep it:**\" as a fourth bullet — never two competing imperatives>",
     ]
 
 

--- a/.claude/commands/docs-review/scripts/test_apply_update.py
+++ b/.claude/commands/docs-review/scripts/test_apply_update.py
@@ -136,8 +136,8 @@ def test_retext_detail_rebuilds_block_keeping_verbatim_line():
     a_out, _, _, _ = au.apply(AUTHOR, BRIEF, up, head_sha=SHA, actor="cam", auto=False)
     _spans, texts = au.be.collect_detail_blocks(a_out)
     block = texts["F1"]
-    assert block.startswith("**Line (verbatim):**")
-    assert "**Why:** new why" in block and "**Fix:** Attribute it inline." in block
+    assert block.startswith("- **Line (verbatim):**")
+    assert "- **Why:** new why" in block and "- **Fix:** Attribute it inline." in block
     assert "**If you'd rather keep it:** cite the study" in block
     assert block.count("**Fix:**") == 1
 
@@ -324,7 +324,7 @@ def test_retext_on_a_resolved_finding_reopens_with_a_fresh_detail_block():
                    "detail": {"why": "the revert restored it", "fix": "apply the earlier fix"}}], case="re-verify")
     a2, _, state2, report = au.apply(a1, b1, up, head_sha="2" * 40, actor="update-lane", auto=False)
     assert report["reopened"] == ["F1"] and "F1" in _open_author_ids(a2)
-    assert "#### F1 · Do this" in a2 and "**Fix:** apply the earlier fix" in a2
+    assert "#### F1 · Do this" in a2 and "- **Fix:** apply the earlier fix" in a2
     assert "F1" not in state2["findings"]
 
 
@@ -364,3 +364,22 @@ def test_resolve_and_concede_on_a_resolved_finding_are_rejected():
         assert "reason" in str(exc)
     else:
         raise AssertionError("reopen without a reason must be rejected")
+
+
+def test_rebuild_detail_block_accepts_the_legacy_paragraph_form_and_emits_bullets():
+    legacy = [
+        "#### F2 · Do this", "",
+        '**Line (verbatim):** "old line"',
+        "**Why:** old why",
+        "**Fix:** old fix",
+    ]
+    out = au._rebuild_detail_block("F2", legacy, {"why": "new why", "fix": "new fix", "keep": "keep it"})
+    assert out == [
+        "#### F2 · Do this", "",
+        '- **Line (verbatim):** "old line"',
+        "- **Why:** new why",
+        "- **Fix:** new fix",
+        "- **If you'd rather keep it:** keep it",
+    ]
+    bulleted = ["#### F2 · Do this", "", '- **Line (verbatim):** "b"', "- **Why:** w", "- **Fix:** f"]
+    assert au._rebuild_detail_block("F2", bulleted, {"why": "w2", "fix": "f2"})[2] == '- **Line (verbatim):** "b"'

--- a/.claude/commands/docs-review/scripts/test_compose_v3.py
+++ b/.claude/commands/docs-review/scripts/test_compose_v3.py
@@ -393,3 +393,10 @@ def test_empty_checks_sentinel_acknowledges_stances(v3_with_stances, tmp_path):
     nxt = next(i for i in range(h4 + 1, len(furniture)) if furniture[i].startswith("### "))
     without = "\n".join(furniture[:h4] + furniture[nxt:])
     assert cr._V3_EMPTY_CHECKS in be._collapse_empty_tables(without, be.BRIEF_SECTIONS)
+
+
+def test_detail_scaffold_is_a_bulleted_list():
+    lines = cr.render_detail_scaffold("F7")
+    assert lines[0] == "#### F7 · Do this" and lines[1] == ""
+    assert [ln[:6] for ln in lines[2:5]] == ["- **Li", "- **Wh", "- **Fi"]
+    assert sum(ln.startswith("- **Fix:**") for ln in lines) == 1

--- a/.claude/commands/docs-review/scripts/testdata/v3-fixture-author.md.txt
+++ b/.claude/commands/docs-review/scripts/testdata/v3-fixture-author.md.txt
@@ -17,15 +17,15 @@ _<TODO: one sentence — what this PR is and what the review checked>_
 
 #### F1 · Do this
 
-**Line (verbatim):** <TODO: the flagged line, quoted exactly as it appears in the file — the only quote of it on this card; never a paraphrase>
-**Why:** <TODO: 1-2 sentences — what is wrong (🚨) or what only the author can settle (❓)>
-**Fix:** <TODO: exactly ONE required action, stated first; put any replacement text in a fenced block; label an alternative "**If you'd rather keep it:**" — never two competing imperatives>
+- **Line (verbatim):** <TODO: the flagged line, quoted exactly as it appears in the file — the only quote of it on this card; never a paraphrase>
+- **Why:** <TODO: 1-2 sentences — what is wrong (🚨) or what only the author can settle (❓)>
+- **Fix:** <TODO: exactly ONE required action, stated first; put any replacement text in a fenced block at column 0 after this list; label an alternative "- **If you'd rather keep it:**" as a fourth bullet — never two competing imperatives>
 
 #### F2 · Do this
 
-**Line (verbatim):** <TODO: the flagged line, quoted exactly as it appears in the file — the only quote of it on this card; never a paraphrase>
-**Why:** <TODO: 1-2 sentences — what is wrong (🚨) or what only the author can settle (❓)>
-**Fix:** <TODO: exactly ONE required action, stated first; put any replacement text in a fenced block; label an alternative "**If you'd rather keep it:**" — never two competing imperatives>
+- **Line (verbatim):** <TODO: the flagged line, quoted exactly as it appears in the file — the only quote of it on this card; never a paraphrase>
+- **Why:** <TODO: 1-2 sentences — what is wrong (🚨) or what only the author can settle (❓)>
+- **Fix:** <TODO: exactly ONE required action, stated first; put any replacement text in a fenced block at column 0 after this list; label an alternative "- **If you'd rather keep it:**" as a fourth bullet — never two competing imperatives>
 
 ### ❓ Questions for you
 
@@ -35,9 +35,9 @@ _<TODO: one sentence — what this PR is and what the review checked>_
 
 #### F3 · Do this
 
-**Line (verbatim):** <TODO: the flagged line, quoted exactly as it appears in the file — the only quote of it on this card; never a paraphrase>
-**Why:** <TODO: 1-2 sentences — what is wrong (🚨) or what only the author can settle (❓)>
-**Fix:** <TODO: exactly ONE required action, stated first; put any replacement text in a fenced block; label an alternative "**If you'd rather keep it:**" — never two competing imperatives>
+- **Line (verbatim):** <TODO: the flagged line, quoted exactly as it appears in the file — the only quote of it on this card; never a paraphrase>
+- **Why:** <TODO: 1-2 sentences — what is wrong (🚨) or what only the author can settle (❓)>
+- **Fix:** <TODO: exactly ONE required action, stated first; put any replacement text in a fenced block at column 0 after this list; label an alternative "- **If you'd rather keep it:**" as a fourth bullet — never two competing imperatives>
 
 _Editing in the browser? The ✏️ links open the file in GitHub's editor — Ctrl+F for the quoted line._
 

--- a/.claude/commands/docs-review/scripts/validate-pinned.py
+++ b/.claude/commands/docs-review/scripts/validate-pinned.py
@@ -2933,7 +2933,10 @@ def check_v3_detail_blocks(ctx: Context) -> list[Violation]:
                                "every detail block pairs with an open 🚨/❓ row",
                                f"block for {bid} has no open row",
                                "A block never outlives its finding — when a row resolves or is dispositioned, delete its block too."))
-        n_fix = sum(1 for line in body.splitlines() if line.startswith("**Fix:**"))
+        # The label lines are bullets since 2026-09-11 (`- **Fix:** …`); the
+        # unbulleted form is still accepted for cards rendered before that.
+        n_fix = sum(1 for line in body.splitlines()
+                    if line.startswith("**Fix:**") or line.startswith("- **Fix:**"))
         if n_fix != 1:
             v.append(Violation("v3-detail-blocks", f"<{bid}>",
                                "exactly one `**Fix:**` line per block (one required action)",
@@ -2946,7 +2949,7 @@ def check_v3_detail_blocks(ctx: Context) -> list[Violation]:
                 v.append(Violation("v3-detail-blocks", f"<{f['id']}>",
                                    "every open blocking finding keeps its `#### F<n> · Do this` block",
                                    "block missing",
-                                   "Fill the composed scaffold (Line (verbatim) / Why / Fix) — don't delete it."))
+                                   "Fill the composed scaffold (the Line (verbatim) / Why / Fix bullets) — don't delete it."))
     if ctx.brief and _v3_detail_blocks(ctx.brief):
         v.append(Violation("v3-detail-blocks", "<brief>",
                            "the reviewer brief carries no detail blocks",


### PR DESCRIPTION
The three labelled lines under each blocking finding on the v3 author card rendered as a wall of text. The composer scaffold now emits them as bullets. The update lane's block rebuild and the validator's one-`Fix`-per-block rule accept both the bulleted and the older paragraph form, since cards rendered before this change stay live until their PR closes. Contract doc and the v3 author golden updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLhMYkjKBgBXE8aWs2bv1V