### PR TITLE
Update lane: the mention gate step reused an existing step id

### DIFF
--- a/.claude/commands/docs-review/scripts/test_workflow_sanity.py
+++ b/.claude/commands/docs-review/scripts/test_workflow_sanity.py
@@ -1,0 +1,34 @@
+"""Structural sanity for every workflow file GitHub will try to parse.
+
+GitHub rejects a workflow whose job reuses a step `id`, and it does so at
+trigger time, not at merge time: the file merges fine, then every run of
+that workflow fails to start and every `gh workflow run` of it returns
+HTTP 422. #21557 shipped a second `id: mention` into claude-update.yml and
+took the update lane down until the rename landed. `yaml.safe_load` alone
+would not have caught it -- duplicate ids are valid YAML.
+"""
+
+from __future__ import annotations
+
+import collections
+import pathlib
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_WF_DIR = REPO_ROOT / ".github" / "workflows"
+WORKFLOWS = sorted([*_WF_DIR.glob("*.yml"), *_WF_DIR.glob("*.yaml")])
+
+
+@pytest.mark.parametrize("wf", WORKFLOWS, ids=lambda p: p.name)
+def test_workflow_parses_and_step_ids_are_unique_per_job(wf):
+    data = yaml.safe_load(wf.read_text())
+    assert isinstance(data, dict) and "jobs" in data, f"{wf.name}: no jobs block"
+    for job_name, job in (data["jobs"] or {}).items():
+        ids = [s.get("id") for s in (job.get("steps") or []) if isinstance(s, dict) and s.get("id")]
+        dupes = [k for k, n in collections.Counter(ids).items() if n > 1]
+        assert not dupes, (
+            f"{wf.name} job {job_name!r} reuses step id(s) {dupes}; GitHub refuses to run "
+            "the workflow (\"identifier may not be used more than once within the same scope\")"
+        )

--- a/.github/workflows/claude-new.yml
+++ b/.github/workflows/claude-new.yml
@@ -56,7 +56,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Mention gate (a quoted protocol is not a request)
-        id: mention
+        id: mention-gate
         env:
           BODY: ${{ github.event.comment.body || github.event.review.body }}
         run: |
@@ -70,11 +70,11 @@ jobs:
       # change adds a push path here.
       - name: Fetch secrets from ESC
         id: esc-secrets
-        if: steps.mention.outputs.fire == 'true'
+        if: steps.mention-gate.outputs.fire == 'true'
         uses: pulumi/esc-action@v3
 
       - name: Checkout repository
-        if: steps.mention.outputs.fire == 'true'
+        if: steps.mention-gate.outputs.fire == 'true'
         uses: actions/checkout@v7
         with:
           token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Check repository write access
         id: check-access
-        if: steps.mention.outputs.fire == 'true'
+        if: steps.mention-gate.outputs.fire == 'true'
         run: |
           REPO_FULL="${{ github.repository }}"
 

--- a/.github/workflows/claude-update.yml
+++ b/.github/workflows/claude-update.yml
@@ -97,7 +97,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Mention gate (a quoted protocol is not a request)
-        id: mention
+        id: mention-gate
         env:
           BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
           TITLE: ${{ github.event_name == 'issues' && github.event.issue.title || '' }}
@@ -119,7 +119,7 @@ jobs:
       # gated on is_pr=true anyway, so it skips on issues).
       - name: Resolve PR head SHA
         id: head
-        if: steps.mention.outputs.fire == 'true'
+        if: steps.mention-gate.outputs.fire == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -170,11 +170,11 @@ jobs:
       # gates on check-access outputs, which stay empty when it skips.
       - name: Fetch secrets from ESC
         id: esc-secrets
-        if: steps.mention.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
+        if: steps.mention-gate.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
         uses: pulumi/esc-action@v3
 
       - name: Checkout repository
-        if: steps.mention.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
+        if: steps.mention-gate.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
         uses: actions/checkout@v7
         with:
           token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
@@ -184,14 +184,14 @@ jobs:
       # Install mise-managed tools (Vale, Node, etc.) so the prose-lint
       # step below has the pinned vale binary on PATH.
       - name: Install mise-managed tools
-        if: steps.mention.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
+        if: steps.mention-gate.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
         uses: jdx/mise-action@v4
         with:
           cache: true
 
       - name: Check repository write access
         id: check-access
-        if: steps.mention.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
+        if: steps.mention-gate.outputs.fire == 'true' && steps.head.outputs.superseded != 'true'
         run: |
           # workflow_dispatch runs skip the collaborator-permission lookup:
           # triggering a dispatch already requires write access (humans via


### PR DESCRIPTION
#21557 added the mention-gate step with `id: mention`, which the "Save mention body" step in the same job already owns. GitHub refuses to parse a workflow with a duplicated step id, so since that merge every trigger of `claude-update.yml` failed to start and the auto-refresh dispatch returned HTTP 422. Renames the gate step to `mention-gate` (both lanes) and adds a test that every workflow parses with unique step ids per job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLhMYkjKBgBXE8aWs2bv1V