### PR TITLE
Add Dev Center results to docs search as a tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ What that means when you work here:
 - **Don't add tutorial or template content to this repo.** A new tutorial, a new template page, or a glossary term goes to pulumi/marketing-web. (The `glossary` shortcode and `data/glossary.toml` are a *different*, docs-only glossary rendered at `/docs/glossary/` — that one stays.)
 - **Link to `/dev/tutorials/<slug>/`, `/dev/templates/<group>/[<cloud>/]`, and `/dev/glossary/<term>/`.** Never `/tutorials/` or `/templates/`; those only redirect.
 - **`data/footer.yml` and `data/header_nav.yaml` are synced downstream.** marketing-web's `scripts/sync-content.mjs` reads both, so a nav or footer edit here also changes the Dev Center's chrome. Both carry one Dev Center entry pointing at `/dev/`; the Tutorials, Templates, and Pulumi guides entries collapsed into it.
-- **Search does not cover the Dev Center.** Docs search indexes this repo and the Registry only; `/dev` has its own search at `/dev/browse`. `scripts/search/update-search-index.js` deliberately doesn't fetch `/dev/search-index.json`, and there is no Dev Center facet in the docs search UI.
+- **Docs search includes the Dev Center as a facet.** Docs search indexes this repo, the Registry, and the Dev Center; `/dev` also keeps its own search at `/dev/browse`. `scripts/search/update-search-index.js` fetches `/dev/search-index.json` (published by pulumi/marketing-web), normalizes each record onto our schema with `section: "Dev Center"` (dropping its non-searchable `content` field), and merges it into the Algolia index. The "Dev Center" tab is wired via `data-facets` on the `#search` element in `layouts/partials/docs/menu.html`. A Dev Center fetch failure is non-fatal — the publish continues without those records.
 
 ---
 

--- a/layouts/partials/blog/search.html
+++ b/layouts/partials/blog/search.html
@@ -1,3 +1,3 @@
 <div>
-    <div id="search" data-app-id="{{ getenv "ALGOLIA_APP_ID" }}" data-search-key="{{ getenv "ALGOLIA_APP_SEARCH_KEY" }}" data-facets="Blog" data-index="production"></div>
+    <div id="search" data-app-id="{{ getenv "ALGOLIA_APP_ID" }}" data-search-key="{{ getenv "ALGOLIA_APP_SEARCH_KEY" }}" data-facets="Blog" data-index="production" data-sprite-url="{{ (partialCached "icon-context.html" "icon-context").spriteUrl }}"></div>
 </div>

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -70,7 +70,7 @@
                 id="search"
                 data-app-id="{{ getenv "ALGOLIA_APP_ID" }}"
                 data-search-key="{{ getenv "ALGOLIA_APP_SEARCH_KEY" }}"
-                data-facets="Docs,Registry,Blog"
+                data-facets="Docs,Registry,Dev Center,Blog"
                 data-index="production"
             ></div>
         {{ else }}

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -72,6 +72,7 @@
                 data-search-key="{{ getenv "ALGOLIA_APP_SEARCH_KEY" }}"
                 data-facets="Docs,Registry,Dev Center,Blog"
                 data-index="production"
+                data-sprite-url="{{ (partialCached "icon-context.html" "icon-context").spriteUrl }}"
             ></div>
         {{ else }}
             <!-- Visual placeholder styled like real search input -->

--- a/scripts/search/update-search-index.js
+++ b/scripts/search/update-search-index.js
@@ -6,6 +6,36 @@ const { algoliasearch } = require("algoliasearch");
 const registrySearchIndexUrl = "https://www.pulumi.com/registry/search-index.json";
 const docsSearchIndexUrl = "https://www.pulumi.com/search-index.json";
 
+// The Dev Center (tutorials, templates, community examples, glossary) ships from
+// pulumi/marketing-web and publishes its own search index. Its records use a
+// different shape than ours, so we normalize them before merging (see
+// normalizeDevRecords). A fetch failure here is non-fatal: we log and continue
+// with an empty set so a Dev Center outage never blocks the docs/registry index.
+const devSearchIndexUrl = "https://www.pulumi.com/dev/search-index.json";
+
+// Maps a Dev Center search record onto the docs/registry record shape. The Dev
+// Center index carries a large `content` field, but `content` isn't a searchable
+// attribute in our index (see settings.js), so we drop it here — that also keeps
+// each record under Algolia's per-record size limit. Dev Center results match on
+// title, blurb, and tags, like our blog and heading-level records.
+function normalizeDevRecords(devIndex) {
+    return devIndex
+        .filter(o => o.objectID && o.href && o.title)
+        .map(o => ({
+            objectID: o.objectID,
+            section: "Dev Center",
+            title: o.title,
+            h1: o.title,
+            description: o.blurb || "",
+            href: o.href,
+            rank: o.featured ? 150 : 100,
+            boosted: false,
+            keywords: [].concat(o.tagLabels || [], o.languageLabels || []),
+            tags: [].concat(o.tags || [], o.languages || [], o.clouds || []),
+            ancestors: ["Dev Center", o.typeLabel].filter(Boolean),
+        }));
+}
+
 // Configuration values required for updating the Algolia index.
 const config = {
     appID: process.env.ALGOLIA_APP_ID,
@@ -25,13 +55,14 @@ async function publishIndex() {
 
     let registryIndex = [];
     let docsIndex = [];
+    let devIndex = [];
 
     async function fetchIndexFiles() {
         return Promise.all([
             axios.get(registrySearchIndexUrl)
                 .then((response) => {
                     registryIndex = response.data;
-                }),    
+                }),
             axios.get(docsSearchIndexUrl)
                 .then((response) => {
                     docsIndex = response.data;
@@ -44,13 +75,25 @@ async function publishIndex() {
         process.exit(1);
     });
 
+    // Fetch the Dev Center index separately so a failure degrades gracefully
+    // (empty results) rather than failing the whole publish.
+    await axios.get(devSearchIndexUrl)
+        .then((response) => {
+            devIndex = normalizeDevRecords(response.data);
+            console.log(`Fetched ${devIndex.length} Dev Center records.`);
+        })
+        .catch((error) => {
+            console.error("error retrieving Dev Center index file (continuing without it):", error.message);
+        });
+
     // De-dupe any registry objects that also may exist in the docs index.
     const filteredDocsObjects = docsIndex.filter(o => registryIndex.find(ro => ro.href === o.href) === undefined);
 
-    // Combine search index objects from both docs and registry.
+    // Combine search index objects from docs, registry, and the Dev Center.
     let allObjects = [
         ...filteredDocsObjects,
         ...registryIndex,
+        ...devIndex,
     ];
 
     // Temporary hack: Remove any references to `azure-native-v1`. This line can be

--- a/scripts/search/update-search-index.js
+++ b/scripts/search/update-search-index.js
@@ -27,13 +27,20 @@ function normalizeDevRecords(devIndex) {
             title: o.title,
             h1: o.title,
             description: o.blurb || "",
-            href: o.href,
+            // Some Dev Center records carry absolute www.pulumi.com URLs (e.g. blog
+            // series). Strip the origin so same-site links are relative like the rest
+            // of the index and stay on-domain in every environment; genuinely off-site
+            // links (e.g. academy.pulumi.com) are left absolute.
+            href: o.href.replace(/^https:\/\/www\.pulumi\.com/, ""),
             rank: o.featured ? 150 : 100,
             boosted: false,
             keywords: [].concat(o.tagLabels || [], o.languageLabels || []),
             tags: [].concat(o.tags || [], o.languages || [], o.clouds || []),
             ancestors: ["Dev Center", o.typeLabel].filter(Boolean),
-        }));
+        }))
+        // Drop Dev Center blog posts and series: those live in /blog/ and are
+        // already surfaced in the Blog tab, so keeping them here would duplicate.
+        .filter(o => !o.href.startsWith("/blog/"));
 }
 
 // Configuration values required for updating the Algolia index.

--- a/theme/src/scss/_algolia.scss
+++ b/theme/src/scss/_algolia.scss
@@ -70,9 +70,14 @@
             button {
                 @apply px-3 py-2 flex items-center whitespace-nowrap;
 
-                // The tab icon.
-                img {
-                    @apply mr-1.5 opacity-70;
+                // The tab icon (inline sprite SVG, tinted via currentColor).
+                .tab-icon {
+                    @apply mr-1.5 inline-flex items-center opacity-70;
+
+                    .ph-icon {
+                        width: 1rem;
+                        height: 1rem;
+                    }
                 }
 
                 // The tab label (e.g., "All results").
@@ -105,7 +110,7 @@
                 @apply text-gray-900 border-violet-600;
 
                 button {
-                    img {
+                    .tab-icon {
                         @apply opacity-100;
                     }
 
@@ -152,7 +157,7 @@
                         @apply border-orange-300;
                     }
 
-                    &.packages {
+                    &.registry {
                         @apply border-yellow-300;
                     }
                 }

--- a/theme/src/ts/algolia/autocomplete.ts
+++ b/theme/src/ts/algolia/autocomplete.ts
@@ -1,6 +1,6 @@
 import { liteClient as algoliasearch, SearchClient } from "algoliasearch/lite";
 import { autocomplete, getAlgoliaResults, getAlgoliaFacets } from "@algolia/autocomplete-js";
-import { getTags, getTagsPlugin, setTags, Tag, iconForTag, labelForTag, mapTagsToFilters, groupBy, formatCount, debounce, listenForEvents } from "./utils";
+import { getTags, getTagsPlugin, setTags, Tag, symbolForTag, labelForTag, mapTagsToFilters, groupBy, formatCount, debounce, listenForEvents } from "./utils";
 
 interface SearchResultHit {
     objectID: string;
@@ -20,6 +20,16 @@ const autocompleteContainer = "#search";
 let appID: string;
 let searchKey: string;
 let indexName: string;
+
+// URL of the icon sprite (a fingerprinted asset), used to render tab icons from the
+// same Phosphor set as the main site nav. Set via data-sprite-url on the container.
+let spriteUrl: string;
+
+// Returns the inline SVG markup for a tab icon, referencing the shared sprite so the
+// icon inherits the tab's text color (and thus dark mode) via `currentColor`.
+function tabIcon(label: string): string {
+    return `<svg class="ph-icon ph-icon--regular" fill="currentColor" aria-hidden="true" focusable="false"><use href="${spriteUrl}#${symbolForTag(label)}"></use></svg>`;
+}
 
 // The autocomplete search client.
 let searchClient: SearchClient;
@@ -132,6 +142,7 @@ function initAutocomplete(el: HTMLElement) {
     appID = el.getAttribute("data-app-id");
     searchKey = el.getAttribute("data-search-key");
     indexName = el.getAttribute("data-index");
+    spriteUrl = el.getAttribute("data-sprite-url") || "";
     baseTags = el.getAttribute("data-facets").split(",").map(f => ({ label: f, facet: "section" }));
 
     if (!appID || !searchKey ||!indexName ||!baseTags) {
@@ -245,7 +256,9 @@ function initAutocomplete(el: HTMLElement) {
             // Tells the autocomplete control which URL to use for navigation (specifically keyboard navigation).
             // https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/sources/#param-getitemurl
             getItemUrl: ({ item }) => {
-                const url = new URL([document.location.origin, item.href].join(""));
+                // Resolve against the origin so relative hrefs work; an already-absolute
+                // href (e.g. an off-site Dev Center link) is returned unchanged.
+                const url = new URL(item.href, document.location.origin);
                 return url.toString();
             },
 
@@ -263,8 +276,8 @@ function initAutocomplete(el: HTMLElement) {
                             <ul class="header">
                                 <li class="${ getTags(state).length === baseTags.length ? "active" : "" }">
                                     <button>
-                                        <img src="${ iconForTag("all") }" />
-                                        <span class="label">All results</span>
+                                        <span class="tab-icon" dangerouslySetInnerHTML=${{ __html: tabIcon("all") }}></span>
+                                        <span class="label">All</span>
                                         <span class="count count-${allCount}">
                                             ${ formatCount(allCount) }
                                         </span>
@@ -286,8 +299,8 @@ function initAutocomplete(el: HTMLElement) {
                                         setTags(state, baseTags);
                                         refresh();
                                     }}">
-                                    <img src="${ iconForTag("all") }" />
-                                    <span class="label">All results</span>
+                                    <span class="tab-icon" dangerouslySetInnerHTML=${{ __html: tabIcon("all") }}></span>
+                                    <span class="label">All</span>
                                     <span class="count count-${allCount}">
                                         ${ formatCount(allCount) }
                                     </span>
@@ -312,7 +325,7 @@ function initAutocomplete(el: HTMLElement) {
                                                 setTags(state, [ { label: tag.label, facet: "section" } ]);
                                                 refresh();
                                             }}">
-                                            <img src="${ iconForTag(tag.label) }"/>
+                                            <span class="tab-icon" dangerouslySetInnerHTML=${{ __html: tabIcon(tag.label) }}></span>
                                             <span class="label">${ labelForTag(tag.label) }</span>
                                             <span class="count count-${ facetCount }">${ formatCount(facetCount) }</span>
                                         </button>

--- a/theme/src/ts/algolia/utils.ts
+++ b/theme/src/ts/algolia/utils.ts
@@ -150,21 +150,20 @@ export function formatCount(count: number) {
     return count > 1000 ? `${Math.ceil(count / 1000)}K` : count.toString();
 }
 
-// Returns the label to use for a given tag.
+// Returns the label to use for a given tag. Facet values are shown verbatim.
 export function labelForTag(facet) {
-    if (facet === "Registry") {
-        return "Packages";
-    }
     return facet;
 }
 
-// Returns the icon to use for a given tag.
-export function iconForTag(label: string) {
-    switch (label) {
-        case "Docs":
-            return "/icons/docs.svg";
-        case "Registry":
-            return "/icons/registry.svg";
-    }
-    return "/icons/list.svg";
+// Returns the sprite symbol id for a given tab, reusing the same Phosphor icons
+// (regular weight) as the main site nav. Unknown tabs fall back to a list icon.
+export function symbolForTag(label: string) {
+    const name = {
+        "all": "list",
+        "Docs": "book-open",
+        "Registry": "package",
+        "Dev Center": "compass",
+        "Blog": "newspaper",
+    }[label] || "list";
+    return `p-${name}-regular`;
 }


### PR DESCRIPTION
Adds a Dev Center tab to docs search, alongside Docs, Registry, and Blog. The hourly `update-search-index` cron now fetches `/dev/search-index.json` (published by pulumi/marketing-web), normalizes each record onto our Algolia schema with `section: "Dev Center"` (dropping the non-searchable `content` field), and merges it into the `production` index. Because the cron uses `replaceAllObjects`, Dev Center removals drop out on the next run automatically, and a Dev Center fetch failure is non-fatal so it never blocks the docs/registry publish.

Dev Center blog posts and series are filtered out, since those are already surfaced in the Blog tab. Same-site Dev Center hrefs are normalized to relative paths, and `getItemUrl` now tolerates already-absolute (off-site) hrefs. The search tabs now render from the shared icon sprite (the same Phosphor set as the main nav), and the "All results" tab is relabeled "All".

Verified against a scratch Algolia index built from the live indexes:

<img width="714" height="588" alt="image" src="https://github.com/user-attachments/assets/2c79a429-f1da-43c1-9eb7-ec2b99b45598" />

Closes [MA-757](https://linear.app/pulumi/issue/MA-757/surface-dev-center-in-docs-search-results).
